### PR TITLE
feat: add BaseProviderParams as base class for provider params

### DIFF
--- a/packages/lmux-anthropic/src/lmux_anthropic/params.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/params.py
@@ -2,10 +2,10 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from lmux.types import BaseProviderParams
 
 
-class AnthropicParams(BaseModel):
+class AnthropicParams(BaseProviderParams):
     """Anthropic-specific parameters passed via ``provider_params``."""
 
     thinking: dict[str, object] | None = None

--- a/packages/lmux-openai/src/lmux_openai/params.py
+++ b/packages/lmux-openai/src/lmux_openai/params.py
@@ -2,10 +2,10 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from lmux.types import BaseProviderParams
 
 
-class OpenAIParams(BaseModel):
+class OpenAIParams(BaseProviderParams):
     """Provider-specific parameters for OpenAI API calls."""
 
     service_tier: Literal["auto", "default", "flex"] | None = None

--- a/packages/lmux/src/lmux/__init__.py
+++ b/packages/lmux/src/lmux/__init__.py
@@ -22,6 +22,7 @@ from lmux.protocols import (
 from lmux.registry import Provider, Registry
 from lmux.types import (
     AssistantMessage,
+    BaseProviderParams,
     ChatChunk,
     ChatResponse,
     ContentPart,
@@ -56,6 +57,7 @@ __all__ = [
     "AssistantMessage",
     "AuthProvider",
     "AuthenticationError",
+    "BaseProviderParams",
     "ChatChunk",
     "ChatResponse",
     "CompletionProvider",

--- a/packages/lmux/src/lmux/registry.py
+++ b/packages/lmux/src/lmux/registry.py
@@ -5,11 +5,10 @@
 from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from typing import Any
 
-from pydantic import BaseModel
-
 from lmux.exceptions import InvalidRequestError, UnsupportedFeatureError
 from lmux.protocols import CompletionProvider, EmbeddingProvider, ResponsesProvider
 from lmux.types import (
+    BaseProviderParams,
     ChatChunk,
     ChatResponse,
     EmbeddingResponse,
@@ -37,7 +36,7 @@ class Registry:
         registry.register("anthropic", AnthropicProvider())
         response = registry.chat("openai/gpt-4o", messages=[...])
 
-    Provider-specific params can be passed per-call as a single ``BaseModel`` or as a
+    Provider-specific params can be passed per-call as a single ``BaseProviderParams`` or as a
     ``dict`` keyed by prefix for multi-provider loops::
 
         params = {
@@ -50,9 +49,9 @@ class Registry:
 
     def __init__(self) -> None:
         self._providers: dict[str, Provider] = {}
-        self._default_params: dict[str, BaseModel | None] = {}
+        self._default_params: dict[str, BaseProviderParams | None] = {}
 
-    def register[ParamsT: BaseModel | None](
+    def register[ParamsT: BaseProviderParams | None](
         self,
         prefix: str,
         provider: CompletionProvider[ParamsT] | EmbeddingProvider[ParamsT] | ResponsesProvider[ParamsT],
@@ -78,15 +77,15 @@ class Registry:
     def _resolve_params(
         self,
         prefix: str,
-        provider_params: BaseModel | Mapping[str, BaseModel] | None,
-    ) -> BaseModel | None:
-        """Resolve provider_params to a single BaseModel or None.
+        provider_params: BaseProviderParams | Mapping[str, BaseProviderParams] | None,
+    ) -> BaseProviderParams | None:
+        """Resolve provider_params to a single BaseProviderParams or None.
 
         Precedence: per-call params > default_params > None.
         """
         if isinstance(provider_params, Mapping):
             params = provider_params.get(prefix)
-        elif isinstance(provider_params, BaseModel):
+        elif isinstance(provider_params, BaseProviderParams):
             params = provider_params
         else:
             params = None
@@ -107,7 +106,7 @@ class Registry:
         stop: str | list[str] | None = None,
         tools: list[Tool] | None = None,
         response_format: ResponseFormat | None = None,
-        provider_params: BaseModel | Mapping[str, BaseModel] | None = None,
+        provider_params: BaseProviderParams | Mapping[str, BaseProviderParams] | None = None,
     ) -> ChatResponse:
         provider, prefix, bare_model = self._resolve(model)
         if not isinstance(provider, CompletionProvider):
@@ -136,7 +135,7 @@ class Registry:
         stop: str | list[str] | None = None,
         tools: list[Tool] | None = None,
         response_format: ResponseFormat | None = None,
-        provider_params: BaseModel | Mapping[str, BaseModel] | None = None,
+        provider_params: BaseProviderParams | Mapping[str, BaseProviderParams] | None = None,
     ) -> ChatResponse:
         provider, prefix, bare_model = self._resolve(model)
         if not isinstance(provider, CompletionProvider):
@@ -165,7 +164,7 @@ class Registry:
         stop: str | list[str] | None = None,
         tools: list[Tool] | None = None,
         response_format: ResponseFormat | None = None,
-        provider_params: BaseModel | Mapping[str, BaseModel] | None = None,
+        provider_params: BaseProviderParams | Mapping[str, BaseProviderParams] | None = None,
     ) -> Iterator[ChatChunk]:
         provider, prefix, bare_model = self._resolve(model)
         if not isinstance(provider, CompletionProvider):
@@ -194,7 +193,7 @@ class Registry:
         stop: str | list[str] | None = None,
         tools: list[Tool] | None = None,
         response_format: ResponseFormat | None = None,
-        provider_params: BaseModel | Mapping[str, BaseModel] | None = None,
+        provider_params: BaseProviderParams | Mapping[str, BaseProviderParams] | None = None,
     ) -> AsyncIterator[ChatChunk]:
         provider, prefix, bare_model = self._resolve(model)
         if not isinstance(provider, CompletionProvider):
@@ -220,7 +219,7 @@ class Registry:
         model: str,
         input: str | list[str],  # noqa: A002
         *,
-        provider_params: BaseModel | Mapping[str, BaseModel] | None = None,
+        provider_params: BaseProviderParams | Mapping[str, BaseProviderParams] | None = None,
     ) -> EmbeddingResponse:
         provider, prefix, bare_model = self._resolve(model)
         if not isinstance(provider, EmbeddingProvider):
@@ -233,7 +232,7 @@ class Registry:
         model: str,
         input: str | list[str],  # noqa: A002
         *,
-        provider_params: BaseModel | Mapping[str, BaseModel] | None = None,
+        provider_params: BaseProviderParams | Mapping[str, BaseProviderParams] | None = None,
     ) -> EmbeddingResponse:
         provider, prefix, bare_model = self._resolve(model)
         if not isinstance(provider, EmbeddingProvider):
@@ -248,7 +247,7 @@ class Registry:
         model: str,
         input: str | Sequence[ResponseInputItem],  # noqa: A002
         *,
-        provider_params: BaseModel | Mapping[str, BaseModel] | None = None,
+        provider_params: BaseProviderParams | Mapping[str, BaseProviderParams] | None = None,
     ) -> ResponseResponse:
         provider, prefix, bare_model = self._resolve(model)
         if not isinstance(provider, ResponsesProvider):
@@ -264,7 +263,7 @@ class Registry:
         model: str,
         input: str | Sequence[ResponseInputItem],  # noqa: A002
         *,
-        provider_params: BaseModel | Mapping[str, BaseModel] | None = None,
+        provider_params: BaseProviderParams | Mapping[str, BaseProviderParams] | None = None,
     ) -> ResponseResponse:
         provider, prefix, bare_model = self._resolve(model)
         if not isinstance(provider, ResponsesProvider):

--- a/packages/lmux/src/lmux/types.py
+++ b/packages/lmux/src/lmux/types.py
@@ -4,6 +4,13 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+# MARK: Provider Params
+
+
+class BaseProviderParams(BaseModel):
+    """Base class for provider-specific parameter types."""
+
+
 # MARK: Content Parts
 
 

--- a/packages/lmux/tests/test_registry.py
+++ b/packages/lmux/tests/test_registry.py
@@ -3,13 +3,13 @@
 from collections.abc import AsyncIterator, Iterator, Sequence
 
 import pytest
-from pydantic import BaseModel
 
 from lmux.exceptions import InvalidRequestError, UnsupportedFeatureError
 from lmux.mock import MockProvider
 from lmux.protocols import CompletionProvider, EmbeddingProvider
 from lmux.registry import Registry
 from lmux.types import (
+    BaseProviderParams,
     ChatChunk,
     ChatResponse,
     Cost,
@@ -327,14 +327,14 @@ class TestUnsupportedFeature:
 # MARK: Provider Params Resolution
 
 
-class FakeParams(BaseModel):
+class FakeParams(BaseProviderParams):
     tag: str = "default"
 
 
 class RecordingProvider(CompletionProvider[FakeParams]):
     """A provider that records the provider_params it receives."""
 
-    last_params: BaseModel | None = None
+    last_params: BaseProviderParams | None = None
 
     def chat(  # noqa: PLR0913
         self,
@@ -442,7 +442,7 @@ class TestProviderParamsResolution:
         prov = RecordingProvider()
         reg = Registry()
         reg.register("rec", prov, default_params=FakeParams(tag="fallback"))
-        params: dict[str, BaseModel] = {"other": FakeParams(tag="wrong")}
+        params: dict[str, BaseProviderParams] = {"other": FakeParams(tag="wrong")}
         reg.chat("rec/model", [UserMessage(content="Hi")], provider_params=params)
         assert isinstance(prov.last_params, FakeParams)
         assert prov.last_params.tag == "fallback"
@@ -460,7 +460,7 @@ class TestProviderParamsResolution:
         prov = RecordingProvider()
         reg = Registry()
         reg.register("rec", prov)
-        params: dict[str, BaseModel] = {"other": FakeParams(tag="wrong")}
+        params: dict[str, BaseProviderParams] = {"other": FakeParams(tag="wrong")}
         reg.chat("rec/model", [UserMessage(content="Hi")], provider_params=params)
         assert prov.last_params is None
 


### PR DESCRIPTION
Replace direct BaseModel usage with BaseProviderParams(BaseModel) as a semantic marker type for provider-specific parameter classes. OpenAIParams, AnthropicParams, and Registry all use BaseProviderParams instead of raw BaseModel.