### PR TITLE
style: migrate test fixtures from unittest.mock.patch to pytest-mock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ If any dependencies are not present in the local .venv, use `uv sync --all-packa
 ### General
 
 - All tests are mocked unit tests — **no network calls**
-- `unittest.mock`: `MagicMock`, `AsyncMock`, `patch`
+- `pytest-mock` for patching via `mocker: MockerFixture` fixture; `MagicMock`/`AsyncMock` from `unittest.mock` for type annotations and direct construction
 - `pytest-asyncio` with `asyncio_mode = "auto"` — async test methods just work
 - `--import-mode=importlib` to avoid namespace collisions between packages
 - **No `tests/__init__.py` files** (required for importlib mode)
@@ -186,7 +186,25 @@ Use **pytest fixtures** for all mocking and shared test data — not module-leve
 - Fake auth providers
 - Common test data (e.g., `api_error` factories)
 
-Mock fixtures that use `patch()` are **path-dependent** (e.g., `patch("lmux_openai.provider.create_sync_client")`) — keep these in the individual test file, not `conftest.py`. Only truly shared, non-path-dependent data (e.g., reusable model instances, constants) belongs in `conftest.py`.
+Mock fixtures that use `mocker.patch()` are **path-dependent** (e.g., `mocker.patch("lmux_openai.provider.create_sync_client")`) — keep these in the individual test file, not `conftest.py`. Only truly shared, non-path-dependent data (e.g., reusable model instances, constants) belongs in `conftest.py`.
+
+`mocker.patch()` must only appear inside `@pytest.fixture` functions — **never** directly in test methods. Tests receive already-patched mocks via fixture parameters:
+
+```python
+# Good — patching in a fixture, test receives the mock
+@pytest.fixture
+def mock_sync_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_openai.provider.create_sync_client", return_value=mock_sync_client)
+
+def test_client_created(self, mock_sync_create: MagicMock) -> None:
+    ...
+
+# Bad — patching directly in a test method
+def test_client_created(self, mocker: MockerFixture) -> None:
+    mocker.patch("lmux_openai.provider.create_sync_client", ...)
+```
+
+For non-mock value replacements (e.g., swapping module-level data), use `monkeypatch.setattr()` directly in test methods — `monkeypatch` is not subject to the fixtures-only rule.
 
 ### Mocking Principles
 

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -1,11 +1,11 @@
 """Tests for Anthropic provider."""
 
-from collections.abc import Iterator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import anthropic
 import pytest
+from pytest_mock import MockerFixture
 
 from lmux.cost import ModelPricing, PricingTier
 from lmux.exceptions import (
@@ -113,9 +113,8 @@ def mock_sync_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_sync_create(mock_sync_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_anthropic.provider.create_sync_client", return_value=mock_sync_client) as mock_create:
-        yield mock_create
+def mock_sync_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_anthropic.provider.create_sync_client", return_value=mock_sync_client)
 
 
 @pytest.fixture
@@ -131,9 +130,8 @@ def mock_async_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_async_create(mock_async_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_anthropic.provider.create_async_client", return_value=mock_async_client) as mock_create:
-        yield mock_create
+def mock_async_create(mock_async_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_anthropic.provider.create_async_client", return_value=mock_async_client)
 
 
 @pytest.fixture

--- a/packages/lmux-aws-bedrock/tests/test_auth.py
+++ b/packages/lmux-aws-bedrock/tests/test_auth.py
@@ -1,23 +1,26 @@
 """Tests for AWS Bedrock auth providers."""
 
-from collections.abc import Iterator
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from lmux_aws_bedrock.auth import BedrockEnvAuthProvider, BedrockSessionAuthProvider
 
 
 @pytest.fixture
-def mock_boto3_session_cls() -> Iterator[MagicMock]:
-    with patch("boto3.Session") as mock_cls:
-        yield mock_cls
+def mock_boto3_session_cls(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("boto3.Session")
 
 
 @pytest.fixture
-def mock_aioboto3_session_cls() -> Iterator[MagicMock]:
-    with patch("aioboto3.Session") as mock_cls:
-        yield mock_cls
+def mock_aioboto3_session_cls(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("aioboto3.Session")
+
+
+@pytest.fixture
+def mock_missing_aioboto3(mocker: MockerFixture) -> None:
+    mocker.patch.dict("sys.modules", {"aioboto3": None})
 
 
 class TestBedrockEnvAuthProvider:
@@ -35,13 +38,10 @@ class TestBedrockEnvAuthProvider:
         assert result is mock_aioboto3_session_cls.return_value
         mock_aioboto3_session_cls.assert_called_once_with()
 
-    async def test_aget_raises_import_error(self) -> None:
+    async def test_aget_raises_import_error(self, mock_missing_aioboto3: None) -> None:
         provider = BedrockEnvAuthProvider()
 
-        with (
-            patch.dict("sys.modules", {"aioboto3": None}),
-            pytest.raises(ImportError, match=r"\[async\] extra group is required for async operations.*"),
-        ):
+        with pytest.raises(ImportError, match=r"\[async\] extra group is required for async operations.*"):
             await provider.aget_credentials()
 
 
@@ -80,13 +80,10 @@ class TestBedrockSessionAuthProvider:
             aws_session_token=None,
         )
 
-    async def test_aget_raises_import_error(self) -> None:
+    async def test_aget_raises_import_error(self, mock_missing_aioboto3: None) -> None:
         provider = BedrockSessionAuthProvider()
 
-        with (
-            patch.dict("sys.modules", {"aioboto3": None}),
-            pytest.raises(ImportError, match=r"\[async\] extra group is required for async operations.*"),
-        ):
+        with pytest.raises(ImportError, match=r"\[async\] extra group is required for async operations.*"):
             await provider.aget_credentials()
 
     def test_default_kwargs_all_none(self, mock_boto3_session_cls: MagicMock) -> None:

--- a/packages/lmux-aws-bedrock/tests/test_cost.py
+++ b/packages/lmux-aws-bedrock/tests/test_cost.py
@@ -1,7 +1,5 @@
 """Tests for AWS Bedrock pricing and cost calculation."""
 
-from unittest.mock import patch
-
 import pytest
 
 from lmux.cost import ModelPricing, PricingTier, per_million_tokens
@@ -106,7 +104,7 @@ class TestCalculateBedrockCost:
         assert cost_default is not None
         assert cost.total_cost == pytest.approx(cost_default.total_cost)
 
-    def test_regional_pricing_exact_match(self) -> None:
+    def test_regional_pricing_exact_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Regional pricing returns different cost when region has overrides."""
         regional = {
             "eu-west-1": {
@@ -121,13 +119,13 @@ class TestCalculateBedrockCost:
             },
         }
         usage = Usage(input_tokens=1000, output_tokens=500)
-        with patch("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional):
-            cost = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1", usage, region="eu-west-1")
+        monkeypatch.setattr("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional)
+        cost = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1", usage, region="eu-west-1")
         assert cost is not None
         assert cost.input_cost == pytest.approx(1000 * 1.0 / 1_000_000)
         assert cost.output_cost == pytest.approx(500 * 1.0 / 1_000_000)
 
-    def test_regional_pricing_prefix_match(self) -> None:
+    def test_regional_pricing_prefix_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Regional pricing uses prefix matching for versioned model IDs."""
         regional = {
             "eu-west-1": {
@@ -142,13 +140,13 @@ class TestCalculateBedrockCost:
             },
         }
         usage = Usage(input_tokens=1000, output_tokens=500)
-        with patch("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional):
-            cost = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1:0", usage, region="eu-west-1")
+        monkeypatch.setattr("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional)
+        cost = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1:0", usage, region="eu-west-1")
         assert cost is not None
         assert cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
         assert cost.output_cost == pytest.approx(500 * 2.0 / 1_000_000)
 
-    def test_regional_pricing_falls_back_to_default_for_unlisted_model(self) -> None:
+    def test_regional_pricing_falls_back_to_default_for_unlisted_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A model not in regional overrides falls back to us-east-1 default."""
         regional = {
             "eu-west-1": {
@@ -163,8 +161,8 @@ class TestCalculateBedrockCost:
             },
         }
         usage = Usage(input_tokens=1000, output_tokens=500)
-        with patch("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional):
-            cost = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1", usage, region="eu-west-1")
+        monkeypatch.setattr("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional)
+        cost = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1", usage, region="eu-west-1")
         cost_default = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1", usage)
         assert cost is not None
         assert cost_default is not None

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -1,11 +1,11 @@
 """Tests for AWS Bedrock provider."""
 
 import json
-from collections.abc import Iterator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from lmux.cost import ModelPricing, PricingTier
 from lmux.exceptions import ProviderError, UnsupportedFeatureError
@@ -83,9 +83,8 @@ def mock_sync_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_sync_create(mock_sync_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_aws_bedrock.provider.create_sync_client", return_value=mock_sync_client) as mock_create:
-        yield mock_create
+def mock_sync_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_aws_bedrock.provider.create_sync_client", return_value=mock_sync_client)
 
 
 @pytest.fixture
@@ -773,9 +772,12 @@ class TestProviderParamsKwargs:
 
 
 class TestPreload:
+    @pytest.fixture
+    def mock_missing_aioboto3(self, mocker: MockerFixture) -> None:
+        mocker.patch.dict("sys.modules", {"aioboto3": None})
+
     def test_preload_imports_boto3_and_aioboto3(self) -> None:
         preload()  # should not raise; aioboto3 is installed in dev
 
-    def test_preload_without_aioboto3(self) -> None:
-        with patch.dict("sys.modules", {"aioboto3": None}):
-            preload()  # should not raise when aioboto3 is missing
+    def test_preload_without_aioboto3(self, mock_missing_aioboto3: None) -> None:
+        preload()  # should not raise when aioboto3 is missing

--- a/packages/lmux-azure-foundry/tests/test_auth.py
+++ b/packages/lmux-azure-foundry/tests/test_auth.py
@@ -1,9 +1,10 @@
 """Tests for Azure AI Foundry auth providers."""
 
-from collections.abc import Callable, Generator
-from unittest.mock import MagicMock, patch
+from collections.abc import Callable
+from unittest.mock import MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from lmux.exceptions import AuthenticationError
 from lmux_azure_foundry.auth import (
@@ -69,14 +70,12 @@ class TestAzureFoundryKeyAuthProvider:
 
 class TestAzureFoundryTokenAuthProvider:
     @pytest.fixture
-    def mock_credential_cls(self) -> Generator[MagicMock]:
-        with patch("azure.identity.DefaultAzureCredential") as mock:
-            yield mock
+    def mock_credential_cls(self, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch("azure.identity.DefaultAzureCredential")
 
     @pytest.fixture
-    def mock_get_provider(self) -> Generator[MagicMock]:
-        with patch("azure.identity.get_bearer_token_provider") as mock:
-            yield mock
+    def mock_get_provider(self, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch("azure.identity.get_bearer_token_provider")
 
     def test_get_credentials_returns_callable(
         self, mock_credential_cls: MagicMock, mock_get_provider: MagicMock

--- a/packages/lmux-azure-foundry/tests/test_provider.py
+++ b/packages/lmux-azure-foundry/tests/test_provider.py
@@ -1,8 +1,8 @@
 """Tests for Azure AI Foundry provider."""
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import openai
 import pytest
@@ -14,6 +14,7 @@ from openai.types.completion_usage import CompletionUsage
 from openai.types.create_embedding_response import CreateEmbeddingResponse
 from openai.types.create_embedding_response import Usage as EmbUsage
 from openai.types.embedding import Embedding
+from pytest_mock import MockerFixture
 
 from lmux.cost import ModelPricing, PricingTier
 from lmux.exceptions import AuthenticationError, InvalidRequestError, ProviderError
@@ -132,9 +133,8 @@ def mock_sync_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_sync_create(mock_sync_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_azure_foundry.provider.create_sync_client", return_value=mock_sync_client) as mock_create:
-        yield mock_create
+def mock_sync_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_azure_foundry.provider.create_sync_client", return_value=mock_sync_client)
 
 
 @pytest.fixture
@@ -151,9 +151,8 @@ def mock_async_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_async_create(mock_async_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_azure_foundry.provider.create_async_client", return_value=mock_async_client) as mock_create:
-        yield mock_create
+def mock_async_create(mock_async_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_azure_foundry.provider.create_async_client", return_value=mock_async_client)
 
 
 @pytest.fixture
@@ -186,39 +185,33 @@ def server_error() -> openai.InternalServerError:
 
 
 @pytest.fixture
-def failing_sync_create(auth_error: openai.AuthenticationError) -> Iterator[MagicMock]:
-    with patch("lmux_azure_foundry.provider.create_sync_client", side_effect=auth_error) as mock_create:
-        yield mock_create
+def failing_sync_create(auth_error: openai.AuthenticationError, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_azure_foundry.provider.create_sync_client", side_effect=auth_error)
 
 
 @pytest.fixture
-def failing_async_create(auth_error: openai.AuthenticationError) -> Iterator[MagicMock]:
-    with patch("lmux_azure_foundry.provider.create_async_client", side_effect=auth_error) as mock_create:
-        yield mock_create
+def failing_async_create(auth_error: openai.AuthenticationError, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_azure_foundry.provider.create_async_client", side_effect=auth_error)
 
 
 @pytest.fixture
-def failing_sync_create_server(server_error: openai.InternalServerError) -> Iterator[MagicMock]:
-    with patch("lmux_azure_foundry.provider.create_sync_client", side_effect=server_error) as mock_create:
-        yield mock_create
+def failing_sync_create_server(server_error: openai.InternalServerError, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_azure_foundry.provider.create_sync_client", side_effect=server_error)
 
 
 @pytest.fixture
-def failing_async_create_server(server_error: openai.InternalServerError) -> Iterator[MagicMock]:
-    with patch("lmux_azure_foundry.provider.create_async_client", side_effect=server_error) as mock_create:
-        yield mock_create
+def failing_async_create_server(server_error: openai.InternalServerError, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_azure_foundry.provider.create_async_client", side_effect=server_error)
 
 
 @pytest.fixture
-def failing_sync_create_bad_request(bad_request_error: openai.BadRequestError) -> Iterator[MagicMock]:
-    with patch("lmux_azure_foundry.provider.create_sync_client", side_effect=bad_request_error) as mock_create:
-        yield mock_create
+def failing_sync_create_bad_request(bad_request_error: openai.BadRequestError, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_azure_foundry.provider.create_sync_client", side_effect=bad_request_error)
 
 
 @pytest.fixture
-def failing_async_create_bad_request(bad_request_error: openai.BadRequestError) -> Iterator[MagicMock]:
-    with patch("lmux_azure_foundry.provider.create_async_client", side_effect=bad_request_error) as mock_create:
-        yield mock_create
+def failing_async_create_bad_request(bad_request_error: openai.BadRequestError, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_azure_foundry.provider.create_async_client", side_effect=bad_request_error)
 
 
 # MARK: Chat

--- a/packages/lmux-gcp-vertex/tests/test_auth.py
+++ b/packages/lmux-gcp-vertex/tests/test_auth.py
@@ -1,8 +1,9 @@
 """Tests for GCP Vertex AI auth providers."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from lmux.exceptions import AuthenticationError
 from lmux_gcp_vertex.auth import (
@@ -13,67 +14,65 @@ from lmux_gcp_vertex.auth import (
 
 
 class TestGCPVertexADCAuthProvider:
-    def test_get_credentials(self) -> None:
-        mock_creds = MagicMock()
-        with patch("google.auth.default", return_value=(mock_creds, "my-project")) as mock_default:
-            provider = GCPVertexADCAuthProvider()
-            result = provider.get_credentials()
+    @pytest.fixture
+    def mock_creds(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_google_auth_default(self, mock_creds: MagicMock, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch("google.auth.default", return_value=(mock_creds, "my-project"))
+
+    def test_get_credentials(self, mock_creds: MagicMock, mock_google_auth_default: MagicMock) -> None:
+        provider = GCPVertexADCAuthProvider()
+        result = provider.get_credentials()
 
         assert result is mock_creds
-        mock_default.assert_called_once()
+        mock_google_auth_default.assert_called_once()
 
-    async def test_aget_credentials(self) -> None:
-        mock_creds = MagicMock()
-        with patch("google.auth.default", return_value=(mock_creds, "my-project")) as mock_default:
-            provider = GCPVertexADCAuthProvider()
-            result = await provider.aget_credentials()
+    async def test_aget_credentials(self, mock_creds: MagicMock, mock_google_auth_default: MagicMock) -> None:
+        provider = GCPVertexADCAuthProvider()
+        result = await provider.aget_credentials()
 
         assert result is mock_creds
-        mock_default.assert_called_once()
+        mock_google_auth_default.assert_called_once()
 
 
 class TestGCPVertexServiceAccountAuthProvider:
-    def test_get_credentials(self) -> None:
-        mock_creds = MagicMock()
-        with patch(
+    @pytest.fixture
+    def mock_creds(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_from_service_account_file(self, mock_creds: MagicMock, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch(
             "google.oauth2.service_account.Credentials.from_service_account_file",
             return_value=mock_creds,
-        ) as mock_from_file:
-            provider = GCPVertexServiceAccountAuthProvider(service_account_file="/path/to/key.json")
-            result = provider.get_credentials()
+        )
+
+    def test_get_credentials(self, mock_creds: MagicMock, mock_from_service_account_file: MagicMock) -> None:
+        provider = GCPVertexServiceAccountAuthProvider(service_account_file="/path/to/key.json")
+        result = provider.get_credentials()
 
         assert result is mock_creds
-        mock_from_file.assert_called_once_with(
+        mock_from_service_account_file.assert_called_once_with(
             "/path/to/key.json", scopes=["https://www.googleapis.com/auth/cloud-platform"]
         )
 
-    async def test_aget_credentials(self) -> None:
-        mock_creds = MagicMock()
-        with patch(
-            "google.oauth2.service_account.Credentials.from_service_account_file",
-            return_value=mock_creds,
-        ) as mock_from_file:
-            provider = GCPVertexServiceAccountAuthProvider(service_account_file="/path/to/key.json")
-            result = await provider.aget_credentials()
+    async def test_aget_credentials(self, mock_creds: MagicMock, mock_from_service_account_file: MagicMock) -> None:
+        provider = GCPVertexServiceAccountAuthProvider(service_account_file="/path/to/key.json")
+        result = await provider.aget_credentials()
 
         assert result is mock_creds
-        mock_from_file.assert_called_once_with(
+        mock_from_service_account_file.assert_called_once_with(
             "/path/to/key.json", scopes=["https://www.googleapis.com/auth/cloud-platform"]
         )
 
-    def test_custom_scopes(self) -> None:
-        mock_creds = MagicMock()
+    def test_custom_scopes(self, mock_from_service_account_file: MagicMock) -> None:
         custom_scopes = ["https://www.googleapis.com/auth/bigquery"]
-        with patch(
-            "google.oauth2.service_account.Credentials.from_service_account_file",
-            return_value=mock_creds,
-        ) as mock_from_file:
-            provider = GCPVertexServiceAccountAuthProvider(
-                service_account_file="/path/to/key.json", scopes=custom_scopes
-            )
-            provider.get_credentials()
+        provider = GCPVertexServiceAccountAuthProvider(service_account_file="/path/to/key.json", scopes=custom_scopes)
+        provider.get_credentials()
 
-        mock_from_file.assert_called_once_with("/path/to/key.json", scopes=custom_scopes)
+        mock_from_service_account_file.assert_called_once_with("/path/to/key.json", scopes=custom_scopes)
 
 
 class TestGCPVertexAPIKeyAuthProvider:
@@ -85,23 +84,23 @@ class TestGCPVertexAPIKeyAuthProvider:
         provider = GCPVertexAPIKeyAuthProvider(api_key="test-key")
         assert await provider.aget_credentials() == "test-key"
 
-    def test_get_credentials_from_env_var(self) -> None:
-        with patch.dict("os.environ", {"GOOGLE_API_KEY": "env-key"}):
-            provider = GCPVertexAPIKeyAuthProvider()
-            assert provider.get_credentials() == "env-key"
+    def test_get_credentials_from_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GOOGLE_API_KEY", "env-key")
+        provider = GCPVertexAPIKeyAuthProvider()
+        assert provider.get_credentials() == "env-key"
 
-    def test_get_credentials_custom_env_var(self) -> None:
-        with patch.dict("os.environ", {"MY_KEY": "custom-key"}):
-            provider = GCPVertexAPIKeyAuthProvider(env_var="MY_KEY")
-            assert provider.get_credentials() == "custom-key"
+    def test_get_credentials_custom_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MY_KEY", "custom-key")
+        provider = GCPVertexAPIKeyAuthProvider(env_var="MY_KEY")
+        assert provider.get_credentials() == "custom-key"
 
-    def test_get_credentials_missing_env_var_raises(self) -> None:
-        with patch.dict("os.environ", {}, clear=True):
-            provider = GCPVertexAPIKeyAuthProvider()
-            with pytest.raises(AuthenticationError, match="GOOGLE_API_KEY environment variable is not set"):
-                provider.get_credentials()
+    def test_get_credentials_missing_env_var_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        provider = GCPVertexAPIKeyAuthProvider()
+        with pytest.raises(AuthenticationError, match="GOOGLE_API_KEY environment variable is not set"):
+            provider.get_credentials()
 
-    def test_explicit_key_takes_precedence_over_env(self) -> None:
-        with patch.dict("os.environ", {"GOOGLE_API_KEY": "env-key"}):
-            provider = GCPVertexAPIKeyAuthProvider(api_key="explicit-key")
-            assert provider.get_credentials() == "explicit-key"
+    def test_explicit_key_takes_precedence_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GOOGLE_API_KEY", "env-key")
+        provider = GCPVertexAPIKeyAuthProvider(api_key="explicit-key")
+        assert provider.get_credentials() == "explicit-key"

--- a/packages/lmux-gcp-vertex/tests/test_provider.py
+++ b/packages/lmux-gcp-vertex/tests/test_provider.py
@@ -1,10 +1,10 @@
 """Tests for Google Vertex AI provider."""
 
-from collections.abc import Iterator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from lmux.cost import ModelPricing, PricingTier
 from lmux.exceptions import ProviderError
@@ -119,9 +119,8 @@ def mock_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_create(mock_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_gcp_vertex.provider.create_client", return_value=mock_client) as mock_create:
-        yield mock_create
+def mock_create(mock_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_gcp_vertex.provider.create_client", return_value=mock_client)
 
 
 @pytest.fixture

--- a/packages/lmux-groq/tests/test_provider.py
+++ b/packages/lmux-groq/tests/test_provider.py
@@ -1,8 +1,7 @@
 """Tests for Groq provider."""
 
-from collections.abc import Iterator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import groq
 import pytest
@@ -11,6 +10,7 @@ from groq.types.chat.chat_completion import Choice
 from groq.types.chat.chat_completion_chunk import Choice as ChunkChoice
 from groq.types.chat.chat_completion_chunk import ChoiceDelta
 from groq.types.completion_usage import CompletionUsage
+from pytest_mock import MockerFixture
 
 from lmux.cost import ModelPricing, PricingTier
 from lmux.exceptions import AuthenticationError, InvalidRequestError, ProviderError
@@ -94,9 +94,8 @@ def mock_sync_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_sync_create(mock_sync_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_groq.provider.create_sync_client", return_value=mock_sync_client) as mock_create:
-        yield mock_create
+def mock_sync_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_groq.provider.create_sync_client", return_value=mock_sync_client)
 
 
 @pytest.fixture
@@ -112,9 +111,8 @@ def mock_async_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_async_create(mock_async_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_groq.provider.create_async_client", return_value=mock_async_client) as mock_create:
-        yield mock_create
+def mock_async_create(mock_async_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_groq.provider.create_async_client", return_value=mock_async_client)
 
 
 @pytest.fixture

--- a/packages/lmux-openai/tests/test_provider.py
+++ b/packages/lmux-openai/tests/test_provider.py
@@ -1,8 +1,7 @@
 """Tests for OpenAI provider."""
 
-from collections.abc import Iterator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import openai
 import pytest
@@ -14,6 +13,7 @@ from openai.types.completion_usage import CompletionUsage
 from openai.types.create_embedding_response import CreateEmbeddingResponse
 from openai.types.create_embedding_response import Usage as EmbUsage
 from openai.types.embedding import Embedding
+from pytest_mock import MockerFixture
 
 from lmux.cost import ModelPricing, PricingTier
 from lmux.exceptions import AuthenticationError, InvalidRequestError, NotFoundError, ProviderError
@@ -120,9 +120,8 @@ def mock_sync_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_sync_create(mock_sync_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_openai.provider.create_sync_client", return_value=mock_sync_client) as mock_create:
-        yield mock_create
+def mock_sync_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_openai.provider.create_sync_client", return_value=mock_sync_client)
 
 
 @pytest.fixture
@@ -140,9 +139,8 @@ def mock_async_client() -> MagicMock:
 
 
 @pytest.fixture
-def mock_async_create(mock_async_client: MagicMock) -> Iterator[MagicMock]:
-    with patch("lmux_openai.provider.create_async_client", return_value=mock_async_client) as mock_create:
-        yield mock_create
+def mock_async_create(mock_async_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_openai.provider.create_async_client", return_value=mock_async_client)
 
 
 @pytest.fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dev = [
   "pytest~=9.0.2",
   "pytest-asyncio~=1.3.0",
   "pytest-cov~=7.0.0",
+  "pytest-mock~=3.15.1",
   "ruff~=0.15.4",
   "types-aiobotocore[bedrock-runtime]~=3.2.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -921,6 +921,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "ruff" },
     { name = "types-aiobotocore", extra = ["bedrock-runtime"] },
 ]
@@ -934,6 +935,7 @@ dev = [
     { name = "pytest", specifier = "~=9.0.2" },
     { name = "pytest-asyncio", specifier = "~=1.3.0" },
     { name = "pytest-cov", specifier = "~=7.0.0" },
+    { name = "pytest-mock", specifier = "~=3.15.1" },
     { name = "ruff", specifier = "~=0.15.4" },
     { name = "types-aiobotocore", extras = ["bedrock-runtime"], specifier = "~=3.2.0" },
 ]
@@ -1337,6 +1339,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replace all `unittest.mock.patch` context managers with `mocker.patch()` via pytest-mock, enforcing a fixtures-only rule where `mocker.patch()` only appears in `@pytest.fixture` functions. Non-mock value replacements use `monkeypatch` directly in test methods.

Closes #22