### PR TITLE
fix: update provider pricing data across all packages

### DIFF
--- a/packages/lmux-anthropic/src/lmux_anthropic/cost.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/cost.py
@@ -19,13 +19,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.50),
                 cache_creation_cost_per_token=per_million_tokens(6.25),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(10.00),
-                output_cost_per_token=per_million_tokens(37.50),
-                cache_read_cost_per_token=per_million_tokens(1.00),
-                cache_creation_cost_per_token=per_million_tokens(12.50),
-                min_input_tokens=200_000,
-            ),
         ],
     ),
     "claude-sonnet-4-6": ModelPricing(
@@ -35,13 +28,6 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(15.00),
                 cache_read_cost_per_token=per_million_tokens(0.30),
                 cache_creation_cost_per_token=per_million_tokens(3.75),
-            ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.00),
-                output_cost_per_token=per_million_tokens(22.50),
-                cache_read_cost_per_token=per_million_tokens(0.60),
-                cache_creation_cost_per_token=per_million_tokens(7.50),
-                min_input_tokens=200_000,
             ),
         ],
     ),

--- a/packages/lmux-anthropic/tests/test_cost.py
+++ b/packages/lmux-anthropic/tests/test_cost.py
@@ -81,18 +81,26 @@ class TestCalculateAnthropicCost:
     def test_long_context_pricing(self) -> None:
         """Models with long context pricing should use premium rates for large inputs."""
         usage = Usage(input_tokens=250_000, output_tokens=1000)
-        cost = calculate_anthropic_cost("claude-opus-4-6", usage)
+        cost = calculate_anthropic_cost("claude-sonnet-4", usage)
         assert cost is not None
-        # Long context: $10/MTok input, $37.50/MTok output
-        assert cost.input_cost == pytest.approx(250_000 * 10.0 / 1_000_000)
-        assert cost.output_cost == pytest.approx(1000 * 37.50 / 1_000_000)
+        # Long context: $6/MTok input, $22.50/MTok output
+        assert cost.input_cost == pytest.approx(250_000 * 6.0 / 1_000_000)
+        assert cost.output_cost == pytest.approx(1000 * 22.50 / 1_000_000)
 
     def test_standard_context_uses_standard_pricing(self) -> None:
         """Below threshold, standard rates apply even for models with long context pricing."""
         usage = Usage(input_tokens=100_000, output_tokens=1000)
+        cost = calculate_anthropic_cost("claude-sonnet-4", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(100_000 * 3.0 / 1_000_000)
+        assert cost.output_cost == pytest.approx(1000 * 15.0 / 1_000_000)
+
+    def test_opus_4_6_flat_pricing_at_high_token_count(self) -> None:
+        """Claude Opus 4.6 uses flat pricing across the full 1M context window."""
+        usage = Usage(input_tokens=500_000, output_tokens=1000)
         cost = calculate_anthropic_cost("claude-opus-4-6", usage)
         assert cost is not None
-        assert cost.input_cost == pytest.approx(100_000 * 5.0 / 1_000_000)
+        assert cost.input_cost == pytest.approx(500_000 * 5.0 / 1_000_000)
         assert cost.output_cost == pytest.approx(1000 * 25.0 / 1_000_000)
 
 

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
@@ -273,10 +273,10 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_creation_cost_per_token=per_million_tokens(6.25),
             ),
             PricingTier(
-                input_cost_per_token=per_million_tokens(10.0),
-                output_cost_per_token=per_million_tokens(37.5),
-                cache_read_cost_per_token=per_million_tokens(1.0),
-                cache_creation_cost_per_token=per_million_tokens(12.5),
+                input_cost_per_token=per_million_tokens(5.0),
+                output_cost_per_token=per_million_tokens(25.0),
+                cache_read_cost_per_token=per_million_tokens(0.5),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
                 min_input_tokens=200000,
             ),
         ],
@@ -317,10 +317,10 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
             PricingTier(
-                input_cost_per_token=per_million_tokens(6.0),
-                output_cost_per_token=per_million_tokens(22.5),
-                cache_read_cost_per_token=per_million_tokens(0.6),
-                cache_creation_cost_per_token=per_million_tokens(7.5),
+                input_cost_per_token=per_million_tokens(3.0),
+                output_cost_per_token=per_million_tokens(15.0),
+                cache_read_cost_per_token=per_million_tokens(0.3),
+                cache_creation_cost_per_token=per_million_tokens(3.75),
                 min_input_tokens=200000,
             ),
         ],
@@ -579,6 +579,14 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "minimax.minimax-m2.5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.3),
+                output_cost_per_token=per_million_tokens(1.2),
+            ),
+        ],
+    ),
     # -- Mistral (via Bedrock) -----------------------------------
     "mistral.devstral-2-123b": ModelPricing(
         tiers=[
@@ -718,6 +726,14 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "nvidia.nemotron-super-3-120b": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.15),
+                output_cost_per_token=per_million_tokens(0.65),
+            ),
+        ],
+    ),
     # -- OpenAI (via Bedrock) ------------------------------------
     "openai.gpt-oss-120b": ModelPricing(
         tiers=[
@@ -809,6 +825,14 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # -- Writer (via Bedrock) ------------------------------------
+    "writer.palmyra-vision-7b": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.15),
+                output_cost_per_token=per_million_tokens(0.6),
+            ),
+        ],
+    ),
     "writer.palmyra-x4-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -839,6 +863,14 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.07),
                 output_cost_per_token=per_million_tokens(0.4),
+            ),
+        ],
+    ),
+    "zai.glm5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.0),
+                output_cost_per_token=per_million_tokens(3.2),
             ),
         ],
     ),

--- a/packages/lmux-aws-bedrock/tests/test_cost.py
+++ b/packages/lmux-aws-bedrock/tests/test_cost.py
@@ -64,7 +64,7 @@ class TestCalculateBedrockCost:
     def test_long_context_tier(self) -> None:
         """Claude models with long-context tiers use higher pricing above threshold."""
         usage = Usage(input_tokens=300_000, output_tokens=1000)
-        cost = calculate_bedrock_cost("anthropic.claude-sonnet-4-6-v1", usage)
+        cost = calculate_bedrock_cost("anthropic.claude-sonnet-4-5-v1", usage)
         assert cost is not None
         # Above 200K threshold, uses LCtx tier pricing
         assert cost.input_cost == pytest.approx(300_000 * 6.0 / 1_000_000)

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
@@ -56,6 +56,15 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    # --- OpenAI: GPT-4.5 ---
+    "gpt-4.5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(60.00),
+                output_cost_per_token=per_million_tokens(150.00),
+            )
+        ],
+    ),
     # --- OpenAI: GPT-4.1 family ---
     "gpt-4.1": ModelPricing(
         tiers=[
@@ -193,6 +202,14 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    "deepseek-v3.1": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.23),
+                output_cost_per_token=per_million_tokens(4.94),
+            )
+        ],
+    ),
     "deepseek-v3.2": ModelPricing(
         tiers=[
             PricingTier(
@@ -218,11 +235,35 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    "grok-4.2": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.00),
+                output_cost_per_token=per_million_tokens(6.00),
+            )
+        ],
+    ),
+    "grok-4-fast": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.20),
+                output_cost_per_token=per_million_tokens(0.50),
+            )
+        ],
+    ),
     "grok-4": ModelPricing(
         tiers=[
             PricingTier(
-                input_cost_per_token=per_million_tokens(5.50),
-                output_cost_per_token=per_million_tokens(27.50),
+                input_cost_per_token=per_million_tokens(3.00),
+                output_cost_per_token=per_million_tokens(15.00),
+            )
+        ],
+    ),
+    "grok-code-fast-1": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.20),
+                output_cost_per_token=per_million_tokens(1.50),
             )
         ],
     ),
@@ -240,6 +281,14 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.71),
                 output_cost_per_token=per_million_tokens(0.71),
+            )
+        ],
+    ),
+    "llama-4-scout": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.16),
+                output_cost_per_token=per_million_tokens(0.64),
             )
         ],
     ),

--- a/packages/lmux-gcp-vertex/src/lmux_gcp_vertex/cost.py
+++ b/packages/lmux-gcp-vertex/src/lmux_gcp_vertex/cost.py
@@ -39,6 +39,31 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "gemini-3.1-flash-lite-preview": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.25),
+                output_cost_per_token=per_million_tokens(1.50),
+                cache_read_cost_per_token=per_million_tokens(0.03),
+            ),
+        ],
+    ),
+    "gemini-3.1-flash-image-preview": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.50),
+                output_cost_per_token=per_million_tokens(3.00),
+            ),
+        ],
+    ),
+    "gemini-3-pro-image-preview": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.0),
+                output_cost_per_token=per_million_tokens(12.0),
+            ),
+        ],
+    ),
     "gemini-3-flash-preview": ModelPricing(
         tiers=[
             PricingTier(
@@ -138,12 +163,6 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(25.0),
                 cache_read_cost_per_token=per_million_tokens(0.5),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(10.0),
-                output_cost_per_token=per_million_tokens(37.5),
-                cache_read_cost_per_token=per_million_tokens(1.0),
-                min_input_tokens=200_000,
-            ),
         ],
     ),
     "claude-sonnet-4-6": ModelPricing(
@@ -152,12 +171,6 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(3.0),
                 output_cost_per_token=per_million_tokens(15.0),
                 cache_read_cost_per_token=per_million_tokens(0.3),
-            ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.0),
-                output_cost_per_token=per_million_tokens(22.5),
-                cache_read_cost_per_token=per_million_tokens(0.6),
-                min_input_tokens=200_000,
             ),
         ],
     ),
@@ -314,6 +327,14 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # ── Embedding models ───────────────────────────────────────
+    "gemini-embedding-2-preview": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.20),
+                output_cost_per_token=0.0,
+            ),
+        ],
+    ),
     "gemini-embedding-001": ModelPricing(
         tiers=[
             PricingTier(

--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -1,6 +1,6 @@
 """OpenAI pricing data and cost calculation.
 
-Pricing source: https://openai.com/api/pricing/
+Pricing source: https://developers.openai.com/api/docs/pricing
 """
 
 from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
@@ -36,6 +36,33 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "gpt-5.4-mini": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.75),
+                output_cost_per_token=per_million_tokens(4.50),
+                cache_read_cost_per_token=per_million_tokens(0.075),
+            )
+        ],
+    ),
+    "gpt-5.4-nano": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.20),
+                output_cost_per_token=per_million_tokens(1.25),
+                cache_read_cost_per_token=per_million_tokens(0.02),
+            )
+        ],
+    ),
+    "gpt-5.3-codex": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.75),
+                output_cost_per_token=per_million_tokens(14.00),
+                cache_read_cost_per_token=per_million_tokens(0.175),
+            )
+        ],
+    ),
     "gpt-5.2-pro": ModelPricing(
         tiers=[
             PricingTier(
@@ -50,6 +77,33 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(1.75),
                 output_cost_per_token=per_million_tokens(14.00),
                 cache_read_cost_per_token=per_million_tokens(0.175),
+            )
+        ],
+    ),
+    "gpt-5.2-codex": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.75),
+                output_cost_per_token=per_million_tokens(14.00),
+                cache_read_cost_per_token=per_million_tokens(0.175),
+            )
+        ],
+    ),
+    "gpt-5.1-codex-mini": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.25),
+                output_cost_per_token=per_million_tokens(2.00),
+                cache_read_cost_per_token=per_million_tokens(0.025),
+            )
+        ],
+    ),
+    "gpt-5.1-codex": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(10.00),
+                cache_read_cost_per_token=per_million_tokens(0.125),
             )
         ],
     ),
@@ -85,6 +139,15 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(0.05),
                 output_cost_per_token=per_million_tokens(0.40),
                 cache_read_cost_per_token=per_million_tokens(0.005),
+            )
+        ],
+    ),
+    "gpt-5-codex": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(10.00),
+                cache_read_cost_per_token=per_million_tokens(0.125),
             )
         ],
     ),

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 
+[options]
+exclude-newer = "2026-03-22T15:29:08.824824Z"
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "lmux",


### PR DESCRIPTION
- OpenAI: add gpt-5.4-mini, gpt-5.4-nano, gpt-5.3-codex, gpt-5.2-codex, gpt-5.1-codex, gpt-5.1-codex-mini, gpt-5-codex; update pricing source URL to developers.openai.com
- Anthropic: remove >200k tiers from claude-opus-4-6 and claude-sonnet-4-6 (1M context at standard pricing)
- Azure Foundry: fix grok-4 price drop ($5.50→$3.00/$27.50→$15.00); add grok-4.2, grok-4-fast, grok-code-fast-1, deepseek-v3.1, llama-4-scout, gpt-4.5
- GCP Vertex: remove >200k tiers from claude-opus-4-6 and claude-sonnet-4-6; add gemini-3.1-flash-lite-preview, gemini-3.1-flash-image-preview, gemini-3-pro-image-preview, gemini-embedding-2-preview
- AWS Bedrock: regenerate cost.py from AWS Pricing API (99 models)