### PR TITLE
fix: use dereferenced commit SHA for pypi-publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,6 +117,6 @@ jobs:
           name: dist
           path: dist/
 
-      - uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598 # v1.13.0
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           repository-url: ${{ needs.resolve.outputs.environment == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}


### PR DESCRIPTION
## Summary

- Fix `pypa/gh-action-pypi-publish` SHA pin to use the dereferenced commit (`ed0c539...`) instead of the annotated tag object (`106e0b0...`)
- Docker-based actions need the actual commit SHA to find the container image on GHCR

Ref #29