### PR TITLE
docs: add lmux value prop and registry examples to provider READMEs

### DIFF
--- a/packages/lmux-anthropic/README.md
+++ b/packages/lmux-anthropic/README.md
@@ -2,7 +2,7 @@
 
 Anthropic provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [anthropic](https://pypi.org/project/anthropic/) SDK.
 
-Supports chat completions and streaming.
+Supports chat completions and streaming. Standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Auth
 
@@ -37,6 +37,18 @@ for chunk in provider.chat_stream("claude-sonnet-4-20250514", [UserMessage(conte
 ### Async
 
 All methods have async variants: `achat`, `achat_stream`.
+
+### Registry
+
+Use with the lmux registry to route across multiple providers:
+
+```python
+from lmux import Registry
+
+registry = Registry()
+registry.register("anthropic", provider)
+response = registry.chat("anthropic/claude-sonnet-4-20250514", messages)
+```
 
 ## Provider Params
 

--- a/packages/lmux-aws-bedrock/README.md
+++ b/packages/lmux-aws-bedrock/README.md
@@ -2,7 +2,7 @@
 
 AWS Bedrock provider for [lmux](https://github.com/cluebbehusen/lmux). Uses [boto3](https://pypi.org/project/boto3/) and the Converse API.
 
-Supports chat completions, streaming, and embeddings.
+Supports chat completions, streaming, and embeddings. Standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Optional Extras
 
@@ -59,6 +59,18 @@ print(response.embeddings)
 ### Async
 
 Requires the `[async]` extra. All methods have async variants: `achat`, `achat_stream`, `aembed`.
+
+### Registry
+
+Use with the lmux registry to route across multiple providers:
+
+```python
+from lmux import Registry
+
+registry = Registry()
+registry.register("bedrock", provider)
+response = registry.chat("bedrock/anthropic.claude-sonnet-4-20250514-v1:0", messages)
+```
 
 ## Provider Params
 

--- a/packages/lmux-azure-foundry/README.md
+++ b/packages/lmux-azure-foundry/README.md
@@ -2,7 +2,7 @@
 
 Azure AI Foundry provider for [lmux](https://github.com/cluebbehusen/lmux). Uses the [openai](https://pypi.org/project/openai/) SDK's `AzureOpenAI` client.
 
-Supports chat completions, streaming, and embeddings.
+Supports chat completions, streaming, and embeddings. Standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Optional Extras
 
@@ -74,6 +74,18 @@ print(response.embeddings)
 ### Async
 
 All methods have async variants: `achat`, `achat_stream`, `aembed`.
+
+### Registry
+
+Use with the lmux registry to route across multiple providers:
+
+```python
+from lmux import Registry
+
+registry = Registry()
+registry.register("azure", provider)
+response = registry.chat("azure/gpt-4o", messages)
+```
 
 ## Provider Params
 

--- a/packages/lmux-gcp-vertex/README.md
+++ b/packages/lmux-gcp-vertex/README.md
@@ -2,7 +2,7 @@
 
 Google Cloud Vertex AI provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [google-genai](https://pypi.org/project/google-genai/) SDK.
 
-Supports chat completions, streaming, and embeddings.
+Supports chat completions, streaming, and embeddings. Standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Auth
 
@@ -70,6 +70,18 @@ print(response.embeddings)
 ### Async
 
 All methods have async variants: `achat`, `achat_stream`, `aembed`.
+
+### Registry
+
+Use with the lmux registry to route across multiple providers:
+
+```python
+from lmux import Registry
+
+registry = Registry()
+registry.register("gcp", provider)
+response = registry.chat("gcp/gemini-2.5-pro", messages)
+```
 
 ## Provider Params
 

--- a/packages/lmux-groq/README.md
+++ b/packages/lmux-groq/README.md
@@ -2,7 +2,7 @@
 
 Groq provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [groq](https://pypi.org/project/groq/) SDK.
 
-Supports chat completions and streaming.
+Supports chat completions and streaming. Standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Auth
 
@@ -37,6 +37,18 @@ for chunk in provider.chat_stream("llama-3.3-70b-versatile", [UserMessage(conten
 ### Async
 
 All methods have async variants: `achat`, `achat_stream`.
+
+### Registry
+
+Use with the lmux registry to route across multiple providers:
+
+```python
+from lmux import Registry
+
+registry = Registry()
+registry.register("groq", provider)
+response = registry.chat("groq/llama-3.3-70b-versatile", messages)
+```
 
 ## Provider Params
 

--- a/packages/lmux-openai/README.md
+++ b/packages/lmux-openai/README.md
@@ -2,7 +2,7 @@
 
 OpenAI provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [openai](https://pypi.org/project/openai/) SDK.
 
-Supports chat completions, streaming, embeddings, and the Responses API.
+Supports chat completions, streaming, embeddings, and the Responses API. Standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Auth
 
@@ -57,6 +57,18 @@ print(response.output_text)
 ### Async
 
 All methods have async variants: `achat`, `achat_stream`, `aembed`, `acreate_response`.
+
+### Registry
+
+Use with the lmux registry to route across multiple providers:
+
+```python
+from lmux import Registry
+
+registry = Registry()
+registry.register("openai", provider)
+response = registry.chat("openai/gpt-4o", messages)
+```
 
 ## Provider Params
 


### PR DESCRIPTION
## Summary

- Add a one-line value prop to each provider README explaining why lmux exists (standardized interface, cost tracking, registry routing)
- Add a registry usage example to each provider README so someone landing on e.g. lmux-groq understands the bigger picture