### PR TITLE
docs: fix value prop phrasing in provider READMEs

### DIFF
--- a/packages/lmux-anthropic/README.md
+++ b/packages/lmux-anthropic/README.md
@@ -2,7 +2,9 @@
 
 Anthropic provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [anthropic](https://pypi.org/project/anthropic/) SDK.
 
-Supports chat completions and streaming. Standardized interface, cost tracking on every response, and registry-based routing across providers.
+Supports chat completions and streaming.
+
+Part of the [lmux](https://github.com/cluebbehusen/lmux) ecosystem: standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Auth
 

--- a/packages/lmux-aws-bedrock/README.md
+++ b/packages/lmux-aws-bedrock/README.md
@@ -2,7 +2,9 @@
 
 AWS Bedrock provider for [lmux](https://github.com/cluebbehusen/lmux). Uses [boto3](https://pypi.org/project/boto3/) and the Converse API.
 
-Supports chat completions, streaming, and embeddings. Standardized interface, cost tracking on every response, and registry-based routing across providers.
+Supports chat completions, streaming, and embeddings.
+
+Part of the [lmux](https://github.com/cluebbehusen/lmux) ecosystem: standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Optional Extras
 

--- a/packages/lmux-azure-foundry/README.md
+++ b/packages/lmux-azure-foundry/README.md
@@ -2,7 +2,9 @@
 
 Azure AI Foundry provider for [lmux](https://github.com/cluebbehusen/lmux). Uses the [openai](https://pypi.org/project/openai/) SDK's `AzureOpenAI` client.
 
-Supports chat completions, streaming, and embeddings. Standardized interface, cost tracking on every response, and registry-based routing across providers.
+Supports chat completions, streaming, and embeddings.
+
+Part of the [lmux](https://github.com/cluebbehusen/lmux) ecosystem: standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Optional Extras
 

--- a/packages/lmux-gcp-vertex/README.md
+++ b/packages/lmux-gcp-vertex/README.md
@@ -2,7 +2,9 @@
 
 Google Cloud Vertex AI provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [google-genai](https://pypi.org/project/google-genai/) SDK.
 
-Supports chat completions, streaming, and embeddings. Standardized interface, cost tracking on every response, and registry-based routing across providers.
+Supports chat completions, streaming, and embeddings.
+
+Part of the [lmux](https://github.com/cluebbehusen/lmux) ecosystem: standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Auth
 

--- a/packages/lmux-groq/README.md
+++ b/packages/lmux-groq/README.md
@@ -2,7 +2,9 @@
 
 Groq provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [groq](https://pypi.org/project/groq/) SDK.
 
-Supports chat completions and streaming. Standardized interface, cost tracking on every response, and registry-based routing across providers.
+Supports chat completions and streaming.
+
+Part of the [lmux](https://github.com/cluebbehusen/lmux) ecosystem: standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Auth
 

--- a/packages/lmux-openai/README.md
+++ b/packages/lmux-openai/README.md
@@ -2,7 +2,9 @@
 
 OpenAI provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [openai](https://pypi.org/project/openai/) SDK.
 
-Supports chat completions, streaming, embeddings, and the Responses API. Standardized interface, cost tracking on every response, and registry-based routing across providers.
+Supports chat completions, streaming, embeddings, and the Responses API.
+
+Part of the [lmux](https://github.com/cluebbehusen/lmux) ecosystem: standardized interface, cost tracking on every response, and registry-based routing across providers.
 
 ## Auth
 


### PR DESCRIPTION
## Summary

- Split the value prop into its own line with "Part of the lmux ecosystem" phrasing
- Separates capabilities from the ecosystem pitch for better readability