### PR TITLE
docs: add tool_choice to README examples and type listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ from lmux import (
     Message,
     ResponseFormat,
     Tool,
+    ToolChoice,
 )
 
 
@@ -166,6 +167,7 @@ class MyProvider(CompletionProvider[None]):
         top_p: float | None = None,
         stop: str | list[str] | None = None,
         tools: list[Tool] | None = None,
+        tool_choice: ToolChoice | None = None,
         response_format: ResponseFormat | None = None,
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         provider_params: None = None,

--- a/packages/lmux/README.md
+++ b/packages/lmux/README.md
@@ -32,6 +32,7 @@ You don't need to install this directly; provider packages (e.g., `lmux-openai`)
 ### Tools
 
 - `Tool`: function tool definition
+- `ToolChoice` / `ToolChoiceFunction`: control whether and which tool the model calls
 - `ToolCall` / `ToolCallDelta`: tool call in responses and streaming
 - `FunctionDefinition` / `FunctionCallResult` / `FunctionCallDelta`
 


### PR DESCRIPTION
Updates the root README's custom provider example and the core lmux README's type listing to include the new `tool_choice` / `ToolChoiceFunction` types added in #57.