### PR TITLE
Fix streaming bugs across four providers

### DIFF
--- a/packages/lmux-azure-foundry/pyproject.toml
+++ b/packages/lmux-azure-foundry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-azure-foundry"
-version = "0.5.0"
+version = "0.5.1"
 description = "Azure AI Foundry provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/provider.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/provider.py
@@ -402,7 +402,10 @@ class AzureFoundryProvider(
         if temperature is not None:
             kwargs["temperature"] = temperature
         if max_tokens is not None:
-            kwargs["max_tokens"] = max_tokens
+            if model.startswith(("gpt-5", "o1", "o3", "o4")):
+                kwargs["max_completion_tokens"] = max_tokens
+            else:
+                kwargs["max_tokens"] = max_tokens
         if top_p is not None:
             kwargs["top_p"] = top_p
         if stop is not None:

--- a/packages/lmux-azure-foundry/tests/test_provider.py
+++ b/packages/lmux-azure-foundry/tests/test_provider.py
@@ -262,6 +262,20 @@ class TestChat:
             stop=["END"],
         )
 
+    def test_chat_maps_max_tokens_to_max_completion_tokens_for_newer_models(
+        self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, chat_completion: ChatCompletion
+    ) -> None:
+        mock_sync_client.chat.completions.create.return_value = chat_completion
+
+        _ = sync_provider.chat("gpt-5-mini", [UserMessage(content="Hi")], max_tokens=100)
+
+        mock_sync_client.chat.completions.create.assert_called_once_with(
+            model="gpt-5-mini",
+            messages=[{"role": "user", "content": "Hi"}],
+            stream=False,
+            max_completion_tokens=100,
+        )
+
     def test_chat_with_tools(
         self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, chat_completion: ChatCompletion
     ) -> None:

--- a/packages/lmux-gcp-vertex/pyproject.toml
+++ b/packages/lmux-gcp-vertex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-gcp-vertex"
-version = "0.6.0"
+version = "0.6.1"
 description = "Google Cloud Vertex AI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-gcp-vertex/src/lmux_gcp_vertex/provider.py
+++ b/packages/lmux-gcp-vertex/src/lmux_gcp_vertex/provider.py
@@ -280,8 +280,8 @@ class GCPVertexProvider(
                 contents=contents,
                 config=config,  # pyright: ignore[reportArgumentType]
             )
-            async for chunk in stream:  # pyright: ignore[reportGeneralTypeIssues,reportUnknownVariableType]
-                mapped = map_generate_content_chunk(chunk, model)  # pyright: ignore[reportUnknownArgumentType]
+            async for chunk in await stream:
+                mapped = map_generate_content_chunk(chunk, model)
                 if mapped.usage is not None:
                     mapped = mapped.model_copy(update={"cost": self._calculate_cost(model, mapped.usage)})
                 yield mapped

--- a/packages/lmux-gcp-vertex/tests/test_provider.py
+++ b/packages/lmux-gcp-vertex/tests/test_provider.py
@@ -441,7 +441,10 @@ class TestAchatStream:
             yield chunk1
             yield chunk2
 
-        mock_client.aio.models.generate_content_stream.return_value = _async_iter()
+        async def _coro() -> Any:  # noqa: ANN401
+            return _async_iter()
+
+        mock_client.aio.models.generate_content_stream.return_value = _coro()
 
         chunks = [chunk async for chunk in async_provider.achat_stream("gemini-2.0-flash", [UserMessage(content="Hi")])]
 
@@ -459,7 +462,10 @@ class TestAchatStream:
             yield _make_response_mock(text="Hi")
             raise server_error
 
-        mock_client.aio.models.generate_content_stream.return_value = _failing_iter()
+        async def _coro() -> Any:  # noqa: ANN401
+            return _failing_iter()
+
+        mock_client.aio.models.generate_content_stream.return_value = _coro()
 
         with pytest.raises(ProviderError, match="test error"):
             async for _ in async_provider.achat_stream("gemini-2.0-flash", [UserMessage(content="Hi")]):

--- a/packages/lmux-groq/pyproject.toml
+++ b/packages/lmux-groq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-groq"
-version = "0.4.0"
+version = "0.4.1"
 description = "Groq provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-groq/src/lmux_groq/provider.py
+++ b/packages/lmux-groq/src/lmux_groq/provider.py
@@ -194,7 +194,6 @@ class GroqProvider(
             reasoning_effort,
             provider_params,
         )
-        kwargs["stream_options"] = {"include_usage": True}
         try:
             client = self._get_sync_client()
             stream = client.chat.completions.create(**kwargs, stream=True)
@@ -239,7 +238,6 @@ class GroqProvider(
             reasoning_effort,
             provider_params,
         )
-        kwargs["stream_options"] = {"include_usage": True}
         try:
             client = await self._get_async_client()
             stream = await client.chat.completions.create(**kwargs, stream=True)

--- a/packages/lmux-openai/pyproject.toml
+++ b/packages/lmux-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-openai"
-version = "0.5.0"
+version = "0.5.1"
 description = "OpenAI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-openai/src/lmux_openai/provider.py
+++ b/packages/lmux-openai/src/lmux_openai/provider.py
@@ -380,7 +380,10 @@ class OpenAIProvider(
         if temperature is not None:
             kwargs["temperature"] = temperature
         if max_tokens is not None:
-            kwargs["max_tokens"] = max_tokens
+            if model.startswith(("gpt-5", "o1", "o3", "o4")):
+                kwargs["max_completion_tokens"] = max_tokens
+            else:
+                kwargs["max_tokens"] = max_tokens
         if top_p is not None:
             kwargs["top_p"] = top_p
         if stop is not None:

--- a/packages/lmux-openai/tests/test_provider.py
+++ b/packages/lmux-openai/tests/test_provider.py
@@ -228,6 +228,20 @@ class TestChat:
             stop=["END"],
         )
 
+    def test_chat_maps_max_tokens_to_max_completion_tokens_for_newer_models(
+        self, sync_provider: OpenAIProvider, mock_sync_client: MagicMock, chat_completion: ChatCompletion
+    ) -> None:
+        mock_sync_client.chat.completions.create.return_value = chat_completion
+
+        _ = sync_provider.chat("gpt-5-mini", [UserMessage(content="Hi")], max_tokens=100)
+
+        mock_sync_client.chat.completions.create.assert_called_once_with(
+            model="gpt-5-mini",
+            messages=[{"role": "user", "content": "Hi"}],
+            stream=False,
+            max_completion_tokens=100,
+        )
+
     def test_chat_with_tools(
         self, sync_provider: OpenAIProvider, mock_sync_client: MagicMock, chat_completion: ChatCompletion
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-03-30T22:31:44.967902Z"
+exclude-newer = "2026-04-01T16:42:56.730423Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -848,7 +848,7 @@ provides-extras = ["async"]
 
 [[package]]
 name = "lmux-azure-foundry"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/lmux-azure-foundry" }
 dependencies = [
     { name = "lmux" },
@@ -870,7 +870,7 @@ provides-extras = ["identity"]
 
 [[package]]
 name = "lmux-gcp-vertex"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/lmux-gcp-vertex" }
 dependencies = [
     { name = "google-genai" },
@@ -885,7 +885,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-groq"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "packages/lmux-groq" }
 dependencies = [
     { name = "groq" },
@@ -900,7 +900,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-openai"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/lmux-openai" }
 dependencies = [
     { name = "lmux" },


### PR DESCRIPTION
Streaming tests uncovered bugs in four provider packages.

**lmux-groq (0.4.0 -> 0.4.1):** `achat_stream` and `chat_stream` hardcoded `stream_options={"include_usage": True}`, but the groq SDK (v1.1.2) doesn't support this parameter at all, crashing every streaming call with a `TypeError`. Removed it; usage data arrives in the final chunk without it.

**lmux-openai (0.5.0 -> 0.5.1) and lmux-azure-foundry (0.5.0 -> 0.5.1):** `max_tokens` was passed straight through to the SDK, but GPT-5, o1, o3, and o4 models reject it and require `max_completion_tokens`. Now maps to the correct parameter based on model name.

**lmux-gcp-vertex (0.6.0 -> 0.6.1):** `achat_stream` iterated over the stream coroutine without awaiting it first, crashing all Vertex AI async streaming with `TypeError: 'async for' requires an object with __aiter__ method, got coroutine`. Added the missing `await`.