### PR TITLE
feat(openai): add data residency cost uplift; refresh pricing

### DIFF
--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-anthropic"
-version = "0.4.0"
+version = "0.4.1"
 description = "Anthropic provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-anthropic/src/lmux_anthropic/cost.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/cost.py
@@ -10,6 +10,17 @@ from lmux.types import Cost, Usage
 # 1-hour cache writes (2x input) are set per-content-block and can't be detected from
 # the API response, so accurate costing for extended TTL caches is not supported.
 _PRICING: dict[str, ModelPricing] = {
+    # Claude 4.7 family
+    "claude-opus-4-7": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(25.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
+            ),
+        ],
+    ),
     # Claude 4.6 family
     "claude-opus-4-6": ModelPricing(
         tiers=[

--- a/packages/lmux-aws-bedrock/pyproject.toml
+++ b/packages/lmux-aws-bedrock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-aws-bedrock"
-version = "0.5.0"
+version = "0.5.1"
 description = "AWS Bedrock provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
@@ -426,6 +426,16 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "anthropic.claude-opus-4-7": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.5),
+                output_cost_per_token=per_million_tokens(27.5),
+                cache_read_cost_per_token=per_million_tokens(0.55),
+                cache_creation_cost_per_token=per_million_tokens(6.875),
+            ),
+        ],
+    ),
     "anthropic.claude-sonnet-4-20250514-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -652,6 +662,16 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "eu.anthropic.claude-opus-4-7": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.5),
+                output_cost_per_token=per_million_tokens(27.5),
+                cache_read_cost_per_token=per_million_tokens(0.55),
+                cache_creation_cost_per_token=per_million_tokens(6.875),
+            ),
+        ],
+    ),
     "eu.anthropic.claude-sonnet-4-20250514-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -740,6 +760,16 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "global.anthropic.claude-opus-4-7": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.0),
+                output_cost_per_token=per_million_tokens(25.0),
+                cache_read_cost_per_token=per_million_tokens(0.5),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
+            ),
+        ],
+    ),
     "global.anthropic.claude-sonnet-4-20250514-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -798,6 +828,16 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(5.5),
                 cache_read_cost_per_token=per_million_tokens(0.11),
                 cache_creation_cost_per_token=per_million_tokens(1.375),
+            ),
+        ],
+    ),
+    "jp.anthropic.claude-opus-4-7": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.5),
+                output_cost_per_token=per_million_tokens(27.5),
+                cache_read_cost_per_token=per_million_tokens(0.55),
+                cache_creation_cost_per_token=per_million_tokens(6.875),
             ),
         ],
     ),
@@ -925,6 +965,16 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.55),
                 cache_creation_cost_per_token=per_million_tokens(6.875),
                 min_input_tokens=200000,
+            ),
+        ],
+    ),
+    "us.anthropic.claude-opus-4-7": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.5),
+                output_cost_per_token=per_million_tokens(27.5),
+                cache_read_cost_per_token=per_million_tokens(0.55),
+                cache_creation_cost_per_token=per_million_tokens(6.875),
             ),
         ],
     ),
@@ -1452,6 +1502,14 @@ _PRICING: dict[str, ModelPricing] = {
     ),
     # -- Nvidia (via Bedrock) ------------------------------------
     "nvidia.nemotron-nano-12b-v2": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.2),
+                output_cost_per_token=per_million_tokens(0.6),
+            ),
+        ],
+    ),
+    "nvidia.nemotron-nano-12b-v2-vl": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.2),

--- a/packages/lmux-gcp-vertex/pyproject.toml
+++ b/packages/lmux-gcp-vertex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-gcp-vertex"
-version = "0.6.1"
+version = "0.6.2"
 description = "Google Cloud Vertex AI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-gcp-vertex/src/lmux_gcp_vertex/cost.py
+++ b/packages/lmux-gcp-vertex/src/lmux_gcp_vertex/cost.py
@@ -156,6 +156,15 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # ── Anthropic Claude (via Vertex AI) ───────────────────────
+    "claude-opus-4-7": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.0),
+                output_cost_per_token=per_million_tokens(25.0),
+                cache_read_cost_per_token=per_million_tokens(0.5),
+            ),
+        ],
+    ),
     "claude-opus-4-6": ModelPricing(
         tiers=[
             PricingTier(
@@ -393,6 +402,133 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(1.25),
                 output_cost_per_token=per_million_tokens(10.00),
+            ),
+        ],
+    ),
+    # ── xAI Grok (via Vertex AI) ───────────────────────────────
+    "grok-4-20-non-reasoning": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.00),
+                output_cost_per_token=per_million_tokens(6.00),
+                cache_read_cost_per_token=per_million_tokens(0.20),
+            ),
+        ],
+    ),
+    "grok-4-1-fast-reasoning": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.20),
+                output_cost_per_token=per_million_tokens(0.50),
+                cache_read_cost_per_token=per_million_tokens(0.05),
+            ),
+        ],
+    ),
+    "grok-4-1-fast-non-reasoning": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.20),
+                output_cost_per_token=per_million_tokens(0.50),
+                cache_read_cost_per_token=per_million_tokens(0.05),
+            ),
+        ],
+    ),
+    # ── MiniMax (via Vertex AI) ────────────────────────────────
+    "minimax-m2": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.30),
+                output_cost_per_token=per_million_tokens(1.20),
+                cache_read_cost_per_token=per_million_tokens(0.03),
+            ),
+        ],
+    ),
+    # ── Moonshot AI (via Vertex AI) ────────────────────────────
+    "kimi-k2-thinking": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.60),
+                output_cost_per_token=per_million_tokens(2.50),
+                cache_read_cost_per_token=per_million_tokens(0.06),
+            ),
+        ],
+    ),
+    # ── Qwen (via Vertex AI) ───────────────────────────────────
+    "qwen3-coder-480b-a35b-instruct": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.22),
+                output_cost_per_token=per_million_tokens(1.80),
+                cache_read_cost_per_token=per_million_tokens(0.022),
+            ),
+        ],
+    ),
+    "qwen3-next-80b-thinking": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.15),
+                output_cost_per_token=per_million_tokens(1.20),
+            ),
+        ],
+    ),
+    "qwen3-next-80b-instruct": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.15),
+                output_cost_per_token=per_million_tokens(1.20),
+            ),
+        ],
+    ),
+    "qwen3-235b-a22b-instruct-2507": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.22),
+                output_cost_per_token=per_million_tokens(0.88),
+            ),
+        ],
+    ),
+    # ── Zhipu AI GLM (via Vertex AI) ───────────────────────────
+    "glm-4.7": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.60),
+                output_cost_per_token=per_million_tokens(2.20),
+            ),
+        ],
+    ),
+    "glm-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.00),
+                output_cost_per_token=per_million_tokens(3.20),
+                cache_read_cost_per_token=per_million_tokens(0.10),
+            ),
+        ],
+    ),
+    # ── OpenAI gpt-oss (via Vertex AI) ─────────────────────────
+    "gpt-oss-120b": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.09),
+                output_cost_per_token=per_million_tokens(0.36),
+            ),
+        ],
+    ),
+    "gpt-oss-20b": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.07),
+                output_cost_per_token=per_million_tokens(0.25),
+                cache_read_cost_per_token=per_million_tokens(0.007),
+            ),
+        ],
+    ),
+    # ── Google Gemma (via Vertex AI) ───────────────────────────
+    "gemma-4-26b": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.15),
+                output_cost_per_token=per_million_tokens(0.60),
             ),
         ],
     ),

--- a/packages/lmux-openai/README.md
+++ b/packages/lmux-openai/README.md
@@ -86,20 +86,36 @@ response = provider.chat(
 )
 ```
 
-| Parameter | Type | Description |
-|---|---|---|
-| `service_tier` | `"auto" \| "default" \| "flex"` | Service tier selection |
-| `reasoning_effort` | `"low" \| "medium" \| "high"` | Reasoning effort for o-series models |
-| `seed` | `int` | Deterministic sampling seed |
-| `user` | `str` | End-user identifier |
+| Parameter          | Type                            | Description                          |
+| ------------------ | ------------------------------- | ------------------------------------ |
+| `service_tier`     | `"auto" \| "default" \| "flex"` | Service tier selection               |
+| `reasoning_effort` | `"low" \| "medium" \| "high"`   | Reasoning effort for o-series models |
+| `seed`             | `int`                           | Deterministic sampling seed          |
+| `user`             | `str`                           | End-user identifier                  |
 
 ## Constructor Options
 
 ```python
 OpenAIProvider(
-    auth=...,           # AuthProvider[str], default: OpenAIEnvAuthProvider()
-    base_url=...,       # Optional base URL override
-    timeout=...,        # Request timeout in seconds
-    max_retries=...,    # Max retry attempts
+    auth=...,            # AuthProvider[str], default: OpenAIEnvAuthProvider()
+    base_url=...,        # Optional base URL override
+    timeout=...,         # Request timeout in seconds
+    max_retries=...,     # Max retry attempts
+    data_residency=...,  # bool, default: False — apply 10% uplift for regional endpoints
 )
 ```
+
+### Data Residency
+
+OpenAI charges a 10% uplift on the `gpt-5.4` family (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`) when requests go through a [regional processing (data residency) endpoint](https://developers.openai.com/api/docs/guides/your-data).
+
+Data residency is selected at the _transport_ layer (regional hostname like `eu.api.openai.com`), not via a per-request parameter. Set `data_residency=True` on the provider so lmux applies the uplift to the reported cost.
+
+```python
+provider = OpenAIProvider(
+    base_url="https://eu.api.openai.com/v1",
+    data_residency=True,
+)
+```
+
+The uplift is only applied to eligible models (checked via `regional_uplift_applies`); other models (e.g. `gpt-4o`, embeddings) return their standard cost even when `data_residency=True`.

--- a/packages/lmux-openai/pyproject.toml
+++ b/packages/lmux-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-openai"
-version = "0.5.1"
+version = "0.5.2"
 description = "OpenAI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-openai/src/lmux_openai/__init__.py
+++ b/packages/lmux-openai/src/lmux_openai/__init__.py
@@ -1,16 +1,19 @@
 """lmux-openai — OpenAI provider for lmux."""
 
 from lmux_openai.auth import OpenAIEnvAuthProvider
-from lmux_openai.cost import calculate_openai_cost
+from lmux_openai.cost import REGIONAL_UPLIFT, apply_cost_multiplier, calculate_openai_cost, regional_uplift_applies
 from lmux_openai.params import OpenAIParams
 from lmux_openai.provider import OpenAIProvider
 
 __all__ = [
+    "REGIONAL_UPLIFT",
     "OpenAIEnvAuthProvider",
     "OpenAIParams",
     "OpenAIProvider",
+    "apply_cost_multiplier",
     "calculate_openai_cost",
     "preload",
+    "regional_uplift_applies",
 ]
 
 

--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -63,6 +63,15 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    "gpt-5.3-chat-latest": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.75),
+                output_cost_per_token=per_million_tokens(14.00),
+                cache_read_cost_per_token=per_million_tokens(0.175),
+            )
+        ],
+    ),
     "gpt-5.2-pro": ModelPricing(
         tiers=[
             PricingTier(
@@ -320,6 +329,11 @@ _PRICING: dict[str, ModelPricing] = {
 # Pre-sorted by key length descending for prefix matching (longest match first)
 _PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
 
+# 10% uplift for regional processing (data residency) endpoints. Per OpenAI, this
+# applies only to the gpt-5.4 family (gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro).
+REGIONAL_UPLIFT = 1.1
+_REGIONAL_UPLIFT_PREFIXES = ("gpt-5.4",)
+
 
 def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:
     """Calculate cost for an OpenAI API call. Returns None if model pricing is unknown."""
@@ -332,3 +346,19 @@ def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:
     if pricing is None:
         return None
     return calculate_cost(usage, pricing)
+
+
+def regional_uplift_applies(model: str) -> bool:
+    """Whether the regional processing (data residency) uplift applies to this model."""
+    return any(model.startswith(prefix) for prefix in _REGIONAL_UPLIFT_PREFIXES)
+
+
+def apply_cost_multiplier(cost: Cost, multiplier: float) -> Cost:
+    """Apply a multiplier to all fields in a cost breakdown."""
+    return Cost(
+        input_cost=cost.input_cost * multiplier,
+        output_cost=cost.output_cost * multiplier,
+        total_cost=cost.total_cost * multiplier,
+        cache_read_cost=cost.cache_read_cost * multiplier if cost.cache_read_cost is not None else None,
+        cache_creation_cost=cost.cache_creation_cost * multiplier if cost.cache_creation_cost is not None else None,
+    )

--- a/packages/lmux-openai/src/lmux_openai/provider.py
+++ b/packages/lmux-openai/src/lmux_openai/provider.py
@@ -36,7 +36,12 @@ from lmux_openai._mappers import (
     map_tools,
 )
 from lmux_openai.auth import OpenAIEnvAuthProvider
-from lmux_openai.cost import calculate_openai_cost
+from lmux_openai.cost import (
+    REGIONAL_UPLIFT,
+    apply_cost_multiplier,
+    calculate_openai_cost,
+    regional_uplift_applies,
+)
 from lmux_openai.params import OpenAIParams
 
 PROVIDER_NAME = "openai"
@@ -57,11 +62,13 @@ class OpenAIProvider(
         base_url: str | None = None,
         timeout: float | None = None,
         max_retries: int | None = None,
+        data_residency: bool = False,
     ) -> None:
         self._auth: AuthProvider[str] = auth or OpenAIEnvAuthProvider()
         self._base_url: str | None = base_url
         self._timeout: float | None = timeout
         self._max_retries: int | None = max_retries
+        self._data_residency: bool = data_residency
         self._sync_client: openai.OpenAI | None = None
         self._async_client: openai.AsyncOpenAI | None = None
         self._async_loop: asyncio.AbstractEventLoop | None = None
@@ -78,6 +85,23 @@ class OpenAIProvider(
         if pricing is not None:
             return calculate_cost(usage, pricing)
         return calculate_openai_cost(model, usage)
+
+    def _apply_cost_multipliers(self, cost: Cost | None, model: str) -> Cost | None:
+        """Apply the regional-processing uplift when configured for this model."""
+        if cost is None:
+            return None
+        if self._data_residency and regional_uplift_applies(model):
+            return apply_cost_multiplier(cost, REGIONAL_UPLIFT)
+        return cost
+
+    def _apply_response_multipliers[T: ChatResponse | EmbeddingResponse | ResponseResponse](
+        self, response: T, model: str
+    ) -> T:
+        """Wrap a completed response with any applicable cost multipliers."""
+        adjusted = self._apply_cost_multipliers(response.cost, model)
+        if adjusted is response.cost:
+            return response
+        return response.model_copy(update={"cost": adjusted})
 
     def _get_sync_client(self) -> "openai.OpenAI":
         if self._sync_client is None:
@@ -144,7 +168,8 @@ class OpenAIProvider(
             completion = client.chat.completions.create(**kwargs, stream=False)
         except Exception as e:
             raise map_openai_error(e) from e
-        return map_chat_completion(completion, PROVIDER_NAME, self._calculate_cost)
+        response = map_chat_completion(completion, PROVIDER_NAME, self._calculate_cost)
+        return self._apply_response_multipliers(response, completion.model)
 
     @override
     async def achat(
@@ -180,7 +205,8 @@ class OpenAIProvider(
             completion = await client.chat.completions.create(**kwargs, stream=False)
         except Exception as e:
             raise map_openai_error(e) from e
-        return map_chat_completion(completion, PROVIDER_NAME, self._calculate_cost)
+        response = map_chat_completion(completion, PROVIDER_NAME, self._calculate_cost)
+        return self._apply_response_multipliers(response, completion.model)
 
     @override
     def chat_stream(
@@ -222,7 +248,8 @@ class OpenAIProvider(
             for chunk in stream:
                 mapped = map_chat_chunk(chunk)
                 if mapped.usage is not None:
-                    mapped = mapped.model_copy(update={"cost": self._calculate_cost(chunk.model, mapped.usage)})
+                    cost = self._apply_cost_multipliers(self._calculate_cost(chunk.model, mapped.usage), chunk.model)
+                    mapped = mapped.model_copy(update={"cost": cost})
                 yield mapped
         except Exception as e:
             raise map_openai_error(e) from e
@@ -267,7 +294,8 @@ class OpenAIProvider(
             async for chunk in stream:
                 mapped = map_chat_chunk(chunk)
                 if mapped.usage is not None:
-                    mapped = mapped.model_copy(update={"cost": self._calculate_cost(chunk.model, mapped.usage)})
+                    cost = self._apply_cost_multipliers(self._calculate_cost(chunk.model, mapped.usage), chunk.model)
+                    mapped = mapped.model_copy(update={"cost": cost})
                 yield mapped
         except Exception as e:
             raise map_openai_error(e) from e
@@ -291,7 +319,8 @@ class OpenAIProvider(
             response = client.embeddings.create(model=model, input=input, **extra)
         except Exception as e:
             raise map_openai_error(e) from e
-        return map_embedding_response(response, PROVIDER_NAME, self._calculate_cost)
+        mapped = map_embedding_response(response, PROVIDER_NAME, self._calculate_cost)
+        return self._apply_response_multipliers(mapped, response.model)
 
     @override
     async def aembed(
@@ -310,7 +339,8 @@ class OpenAIProvider(
             response = await client.embeddings.create(model=model, input=input, **extra)
         except Exception as e:
             raise map_openai_error(e) from e
-        return map_embedding_response(response, PROVIDER_NAME, self._calculate_cost)
+        mapped = map_embedding_response(response, PROVIDER_NAME, self._calculate_cost)
+        return self._apply_response_multipliers(mapped, response.model)
 
     # MARK: Responses API
 
@@ -328,7 +358,8 @@ class OpenAIProvider(
             response = client.responses.create(model=model, input=map_response_input(input), stream=False, **extra)
         except Exception as e:
             raise map_openai_error(e) from e
-        return map_responses_response(response, PROVIDER_NAME, self._calculate_cost)
+        mapped = map_responses_response(response, PROVIDER_NAME, self._calculate_cost)
+        return self._apply_response_multipliers(mapped, response.model)
 
     @override
     async def acreate_response(
@@ -346,7 +377,8 @@ class OpenAIProvider(
             )
         except Exception as e:
             raise map_openai_error(e) from e
-        return map_responses_response(response, PROVIDER_NAME, self._calculate_cost)
+        mapped = map_responses_response(response, PROVIDER_NAME, self._calculate_cost)
+        return self._apply_response_multipliers(mapped, response.model)
 
     # MARK: Internal Helpers
 

--- a/packages/lmux-openai/tests/test_cost.py
+++ b/packages/lmux-openai/tests/test_cost.py
@@ -2,8 +2,13 @@
 
 import pytest
 
-from lmux.types import Usage
-from lmux_openai.cost import calculate_openai_cost
+from lmux.types import Cost, Usage
+from lmux_openai.cost import (
+    REGIONAL_UPLIFT,
+    apply_cost_multiplier,
+    calculate_openai_cost,
+    regional_uplift_applies,
+)
 
 
 class TestCalculateOpenAICost:
@@ -56,3 +61,42 @@ class TestCalculateOpenAICost:
         mini_cost = calculate_openai_cost("gpt-4o-mini", usage)
         assert mini_cost is not None
         assert cost.total_cost == pytest.approx(mini_cost.total_cost)
+
+
+class TestRegionalUpliftApplies:
+    @pytest.mark.parametrize(
+        "model",
+        ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro", "gpt-5.4-2025-11-01"],
+    )
+    def test_applies_to_gpt_5_4_family(self, model: str) -> None:
+        assert regional_uplift_applies(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        ["gpt-4o", "gpt-5", "gpt-5.3-codex", "o3", "text-embedding-3-small", "unknown-model"],
+    )
+    def test_does_not_apply_to_other_models(self, model: str) -> None:
+        assert regional_uplift_applies(model) is False
+
+
+class TestApplyCostMultiplier:
+    def test_applies_multiplier_to_all_fields(self) -> None:
+        cost = Cost(
+            input_cost=1.0,
+            output_cost=2.0,
+            total_cost=3.0,
+            cache_read_cost=0.5,
+            cache_creation_cost=0.25,
+        )
+        result = apply_cost_multiplier(cost, REGIONAL_UPLIFT)
+        assert result.input_cost == pytest.approx(1.1)
+        assert result.output_cost == pytest.approx(2.2)
+        assert result.total_cost == pytest.approx(3.3)
+        assert result.cache_read_cost == pytest.approx(0.55)
+        assert result.cache_creation_cost == pytest.approx(0.275)
+
+    def test_preserves_none_cache_costs(self) -> None:
+        cost = Cost(input_cost=1.0, output_cost=2.0, total_cost=3.0)
+        result = apply_cost_multiplier(cost, 2.0)
+        assert result.cache_read_cost is None
+        assert result.cache_creation_cost is None

--- a/packages/lmux-openai/tests/test_provider.py
+++ b/packages/lmux-openai/tests/test_provider.py
@@ -25,6 +25,7 @@ from lmux.types import (
     UserMessage,
 )
 from lmux_openai import preload
+from lmux_openai.cost import calculate_openai_cost
 from lmux_openai.params import OpenAIParams
 from lmux_openai.provider import OpenAIProvider
 
@@ -182,6 +183,57 @@ def not_found_error() -> openai.NotFoundError:
     response.status_code = 404
     response.headers = {}
     return openai.NotFoundError(message="test error", response=response, body=None)
+
+
+@pytest.fixture
+def gpt_5_4_completion() -> ChatCompletion:
+    return ChatCompletion(
+        id="chatcmpl-abc",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(content="Hi!", role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="gpt-5.4-2025-11-01",
+        object="chat.completion",
+        usage=CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+@pytest.fixture
+def gpt_5_4_stream_chunks() -> list[ChatCompletionChunk]:
+    return [
+        ChatCompletionChunk(
+            id="chatcmpl-abc",
+            choices=[ChunkChoice(delta=ChoiceDelta(content="Hi"), index=0, finish_reason=None)],
+            created=1234567890,
+            model="gpt-5.4-2025-11-01",
+            object="chat.completion.chunk",
+        ),
+        ChatCompletionChunk(
+            id="chatcmpl-abc",
+            choices=[ChunkChoice(delta=ChoiceDelta(), index=0, finish_reason="stop")],
+            created=1234567890,
+            model="gpt-5.4-2025-11-01",
+            object="chat.completion.chunk",
+            usage=CompletionUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        ),
+    ]
+
+
+@pytest.fixture
+def residency_provider(fake_auth: FakeAuth, mock_sync_create: MagicMock) -> OpenAIProvider:
+    mock_sync_create.assert_not_called()
+    return OpenAIProvider(auth=fake_auth, data_residency=True)
+
+
+@pytest.fixture
+def async_residency_provider(fake_auth: FakeAuth, mock_async_create: MagicMock) -> OpenAIProvider:
+    mock_async_create.assert_not_called()
+    return OpenAIProvider(auth=fake_auth, data_residency=True)
 
 
 # MARK: Chat
@@ -355,6 +407,69 @@ class TestChat:
         assert result.cost is not None
         assert result.cost.total_cost > 0
 
+    def test_chat_default_applies_no_residency_uplift(
+        self,
+        sync_provider: OpenAIProvider,
+        mock_sync_client: MagicMock,
+        gpt_5_4_completion: ChatCompletion,
+    ) -> None:
+        mock_sync_client.chat.completions.create.return_value = gpt_5_4_completion
+
+        result = sync_provider.chat("gpt-5.4", [UserMessage(content="Hi")])
+
+        assert result.cost is not None
+        base_cost = calculate_openai_cost("gpt-5.4", result.usage) if result.usage else None
+        assert base_cost is not None
+        assert result.cost.total_cost == pytest.approx(base_cost.total_cost)
+
+    def test_chat_residency_uplifts_eligible_model(
+        self,
+        sync_provider: OpenAIProvider,
+        residency_provider: OpenAIProvider,
+        mock_sync_client: MagicMock,
+        gpt_5_4_completion: ChatCompletion,
+    ) -> None:
+        mock_sync_client.chat.completions.create.return_value = gpt_5_4_completion
+        standard = sync_provider.chat("gpt-5.4", [UserMessage(content="Hi")])
+
+        mock_sync_client.chat.completions.create.return_value = gpt_5_4_completion
+        residency = residency_provider.chat("gpt-5.4", [UserMessage(content="Hi")])
+
+        assert standard.cost is not None
+        assert residency.cost is not None
+        assert residency.cost.total_cost == pytest.approx(standard.cost.total_cost * 1.1)
+
+    def test_chat_residency_does_not_uplift_ineligible_model(
+        self,
+        sync_provider: OpenAIProvider,
+        residency_provider: OpenAIProvider,
+        mock_sync_client: MagicMock,
+        chat_completion: ChatCompletion,
+    ) -> None:
+        mock_sync_client.chat.completions.create.return_value = chat_completion
+        standard = sync_provider.chat("gpt-4o", [UserMessage(content="Hi")])
+
+        mock_sync_client.chat.completions.create.return_value = chat_completion
+        residency = residency_provider.chat("gpt-4o", [UserMessage(content="Hi")])
+
+        assert standard.cost is not None
+        assert residency.cost is not None
+        assert residency.cost.total_cost == pytest.approx(standard.cost.total_cost)
+
+    def test_chat_residency_does_not_send_sdk_param(
+        self,
+        residency_provider: OpenAIProvider,
+        mock_sync_client: MagicMock,
+        gpt_5_4_completion: ChatCompletion,
+    ) -> None:
+        mock_sync_client.chat.completions.create.return_value = gpt_5_4_completion
+
+        _ = residency_provider.chat("gpt-5.4", [UserMessage(content="Hi")])
+
+        call_kwargs = mock_sync_client.chat.completions.create.call_args.kwargs
+        assert "data_residency" not in call_kwargs
+        assert "regional" not in call_kwargs
+
 
 # MARK: Achat
 
@@ -379,6 +494,23 @@ class TestAchat:
 
         with pytest.raises(AuthenticationError):
             _ = await async_provider.achat("gpt-4o", [UserMessage(content="Hi")])
+
+    async def test_achat_residency_uplifts_eligible_model(
+        self,
+        async_provider: OpenAIProvider,
+        async_residency_provider: OpenAIProvider,
+        mock_async_client: MagicMock,
+        gpt_5_4_completion: ChatCompletion,
+    ) -> None:
+        mock_async_client.chat.completions.create.return_value = gpt_5_4_completion
+        standard = await async_provider.achat("gpt-5.4", [UserMessage(content="Hi")])
+
+        mock_async_client.chat.completions.create.return_value = gpt_5_4_completion
+        residency = await async_residency_provider.achat("gpt-5.4", [UserMessage(content="Hi")])
+
+        assert standard.cost is not None
+        assert residency.cost is not None
+        assert residency.cost.total_cost == pytest.approx(standard.cost.total_cost * 1.1)
 
 
 # MARK: ChatStream
@@ -439,6 +571,23 @@ class TestChatStream:
         with pytest.raises(ProviderError, match="test error"):
             _ = list(sync_provider.chat_stream("gpt-4o", [UserMessage(content="Hi")]))
 
+    def test_stream_residency_uplifts_final_chunk(
+        self,
+        sync_provider: OpenAIProvider,
+        residency_provider: OpenAIProvider,
+        mock_sync_client: MagicMock,
+        gpt_5_4_stream_chunks: list[ChatCompletionChunk],
+    ) -> None:
+        mock_sync_client.chat.completions.create.return_value = iter(gpt_5_4_stream_chunks)
+        standard_chunks = list(sync_provider.chat_stream("gpt-5.4", [UserMessage(content="Hi")]))
+
+        mock_sync_client.chat.completions.create.return_value = iter(gpt_5_4_stream_chunks)
+        residency_chunks = list(residency_provider.chat_stream("gpt-5.4", [UserMessage(content="Hi")]))
+
+        assert standard_chunks[-1].cost is not None
+        assert residency_chunks[-1].cost is not None
+        assert residency_chunks[-1].cost.total_cost == pytest.approx(standard_chunks[-1].cost.total_cost * 1.1)
+
 
 # MARK: AchatStream
 
@@ -488,6 +637,29 @@ class TestAchatStream:
         with pytest.raises(ProviderError, match="test error"):
             async for _ in async_provider.achat_stream("gpt-4o", [UserMessage(content="Hi")]):
                 pass
+
+    async def test_async_stream_residency_uplifts_final_chunk(
+        self,
+        async_provider: OpenAIProvider,
+        async_residency_provider: OpenAIProvider,
+        mock_async_client: MagicMock,
+        gpt_5_4_stream_chunks: list[ChatCompletionChunk],
+    ) -> None:
+        async def _async_iter(chunks: list[ChatCompletionChunk]) -> Any:  # noqa: ANN401
+            for chunk in chunks:
+                yield chunk
+
+        mock_async_client.chat.completions.create.return_value = _async_iter(gpt_5_4_stream_chunks)
+        standard_chunks = [chunk async for chunk in async_provider.achat_stream("gpt-5.4", [UserMessage(content="Hi")])]
+
+        mock_async_client.chat.completions.create.return_value = _async_iter(gpt_5_4_stream_chunks)
+        residency_chunks = [
+            chunk async for chunk in async_residency_provider.achat_stream("gpt-5.4", [UserMessage(content="Hi")])
+        ]
+
+        assert standard_chunks[-1].cost is not None
+        assert residency_chunks[-1].cost is not None
+        assert residency_chunks[-1].cost.total_cost == pytest.approx(standard_chunks[-1].cost.total_cost * 1.1)
 
 
 # MARK: Embed

--- a/scripts/update_bedrock_pricing.py
+++ b/scripts/update_bedrock_pricing.py
@@ -43,6 +43,7 @@ LCTX_THRESHOLD = 200_000
 # Foundation Models API: servicename (after stripping " (Amazon Bedrock Edition)") -> Bedrock model ID
 FM_SERVICENAME_MAP: dict[str, str] = {
     # Anthropic Claude
+    "Claude Opus 4.7": "anthropic.claude-opus-4-7-v1",
     "Claude Opus 4.6": "anthropic.claude-opus-4-6-v1",
     "Claude Sonnet 4.6": "anthropic.claude-sonnet-4-6",
     "Claude Opus 4.5": "anthropic.claude-opus-4-5-v1",
@@ -113,6 +114,8 @@ NON_MANTLE_MODEL_MAP: dict[str, str] = {
     "Mistral Large": "mistral.mistral-large-2402-v1",
     "Mistral Small": "mistral.mistral-small-2402-v1",
     "Mistral Large 3": "mistral.mistral-large-3-675b-instruct",
+    # Nvidia
+    "NVIDIA Nemotron Nano 2 VL": "nvidia.nemotron-nano-12b-v2-vl",
 }
 
 # For entries with empty model attribute: usagetype key -> Bedrock model ID
@@ -592,7 +595,11 @@ def parse_amazon_models(data: dict[str, Any]) -> tuple[dict[str, ModelPrices], d
 def _parse_fm_dimension(usagetype: str) -> tuple[str, bool] | None:
     """Extract (dimension, is_lctx) from a Foundation Models usagetype.
 
-    Usagetype format: {REGION}-MP:{REGION}_{Dimension}[-{Variant}]-Units
+    Supports two naming schemes:
+    - Legacy PascalCase: ``{REGION}-MP:{REGION}_{Dimension}[_{Variant}]-Units``
+      e.g. ``USE1-MP:USE1_InputTokenCount_Global-Units``
+    - New snake_case (Claude Opus 4.7+): ``{REGION}-MP:{REGION}_{token_kind}[_1h][_global]_standard-Units``
+      e.g. ``USE1-MP:USE1_cache_write_tokens_global_standard-Units``
 
     Returns None for usagetypes we don't care about.
     """
@@ -617,7 +624,8 @@ def _parse_fm_dimension(usagetype: str) -> tuple[str, bool] | None:
         "Customization",
         "search_units",
         "MillionBatch",
-        "CacheWrite1h",
+        "CacheWrite1h",  # Legacy 1h cache-write
+        "_1h_",  # New-format 1h cache-write (e.g. cache_write_tokens_1h_standard)
         "Created_image",
         "created_image",
         "inputAudioSecond",
@@ -629,14 +637,21 @@ def _parse_fm_dimension(usagetype: str) -> tuple[str, bool] | None:
     if any(p in field for p in skip_patterns):
         return None
 
-    is_lctx = "_LCtx" in field
+    is_lctx = "_LCtx" in field or "_lctx" in field
 
-    # Determine dimension (order matters: CacheRead before Input)
+    # Determine dimension (order matters: CacheRead/CacheWrite before Input/Output
+    # so PascalCase CacheReadInputTokenCount isn't partial-matched by InputTokenCount).
     dimension_patterns = [
+        # Legacy PascalCase
         ("CacheReadInputTokenCount", "cache_read"),
         ("CacheWriteInputTokenCount", "cache_write"),
         ("InputTokenCount", "input"),
         ("OutputTokenCount", "output"),
+        # New snake_case
+        ("cache_read_tokens", "cache_read"),
+        ("cache_write_tokens", "cache_write"),
+        ("input_tokens", "input"),
+        ("output_tokens", "output"),
     ]
     return next(
         ((dim, is_lctx) for pattern, dim in dimension_patterns if pattern in field),
@@ -645,10 +660,15 @@ def _parse_fm_dimension(usagetype: str) -> tuple[str, bool] | None:
 
 
 def _is_global_fm(usagetype: str) -> bool:
-    """Whether this FM usagetype is Global (cross-region) pricing."""
+    """Whether this FM usagetype is Global (cross-region) pricing.
+
+    Legacy PascalCase uses ``_Global`` (but ``_Global_Batch`` is batch, not global-standard).
+    New snake_case (Opus 4.7+) uses lowercase ``_global_`` before ``_standard``.
+    """
     dim_part = usagetype.split("-MP:")[1] if "-MP:" in usagetype else ""
-    # Check for _Global but NOT _Global_Batch
-    return "_Global" in dim_part and "_Batch" not in dim_part
+    legacy_global = "_Global" in dim_part and "_Batch" not in dim_part
+    snake_global = "_global_" in dim_part
+    return legacy_global or snake_global
 
 
 def parse_foundation_models(data: dict[str, Any]) -> tuple[dict[str, ModelPrices], dict[str, ModelPrices]]:

--- a/uv.lock
+++ b/uv.lock
@@ -3,17 +3,8 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-04-01T16:42:56.730423Z"
+exclude-newer = "2026-04-09T18:15:37.5295Z"
 exclude-newer-span = "P7D"
-
-[options.exclude-newer-package]
-lmux = false
-lmux-anthropic = false
-lmux-aws-bedrock = false
-lmux-azure-foundry = false
-lmux-gcp-vertex = false
-lmux-openai = false
-lmux-groq = false
 
 [manifest]
 members = [
@@ -811,7 +802,7 @@ requires-dist = [{ name = "pydantic", specifier = "~=2.10" }]
 
 [[package]]
 name = "lmux-anthropic"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "packages/lmux-anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -826,7 +817,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-aws-bedrock"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/lmux-aws-bedrock" }
 dependencies = [
     { name = "boto3" },
@@ -870,7 +861,7 @@ provides-extras = ["identity"]
 
 [[package]]
 name = "lmux-gcp-vertex"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "packages/lmux-gcp-vertex" }
 dependencies = [
     { name = "google-genai" },
@@ -900,7 +891,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-openai"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "packages/lmux-openai" }
 dependencies = [
     { name = "lmux" },


### PR DESCRIPTION
- **openai**: `OpenAIProvider(data_residency=True)` applies a 10% uplift to reported cost for the `gpt-5.4` family when the provider points at a regional endpoint. Not forwarded to the SDK — OpenAI's data residency is a base-URL feature, not a request param, so this is a one-shot deployment flag rather than an `OpenAIParams` field. Adds `gpt-5.3-chat-latest`.
- **anthropic**: add `claude-opus-4-7`.
- **gcp-vertex**: add 15 new partner/model entries (claude-opus-4-7, Grok 4.20 / 4.1-fast variants, minimax-m2, kimi-k2-thinking, four Qwen3 variants, glm-4.7, glm-5, gpt-oss-120b/20b, gemma-4-26b).
- **aws-bedrock**: regenerate `cost.py`. `scripts/update_bedrock_pricing.py` now handles Opus 4.7's new snake_case usagetype scheme (`input_tokens_standard`, `cache_write_tokens_1h_global_standard`, etc.) alongside the legacy PascalCase format, and maps NVIDIA Nemotron Nano 2 VL.
- Patch-bumps lmux-openai, lmux-anthropic, lmux-gcp-vertex, lmux-aws-bedrock.