### PR TITLE
feat: refresh provider pricing data

### DIFF
--- a/packages/lmux-aws-bedrock/pyproject.toml
+++ b/packages/lmux-aws-bedrock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-aws-bedrock"
-version = "0.5.1"
+version = "0.5.2"
 description = "AWS Bedrock provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
@@ -327,7 +327,7 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    "anthropic.claude-3-7-sonnet-20250219-v1": ModelPricing(
+    "anthropic.claude-3-7-sonnet-v1": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(3.0),
@@ -417,13 +417,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.55),
                 cache_creation_cost_per_token=per_million_tokens(6.875),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(5.5),
-                output_cost_per_token=per_million_tokens(27.5),
-                cache_read_cost_per_token=per_million_tokens(0.55),
-                cache_creation_cost_per_token=per_million_tokens(6.875),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "anthropic.claude-opus-4-7": ModelPricing(
@@ -444,13 +437,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.3),
                 cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.0),
-                output_cost_per_token=per_million_tokens(22.5),
-                cache_read_cost_per_token=per_million_tokens(0.6),
-                cache_creation_cost_per_token=per_million_tokens(7.5),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "anthropic.claude-sonnet-4-5-20250929-v1": ModelPricing(
@@ -460,13 +446,6 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(16.5),
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
-            ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.6),
-                output_cost_per_token=per_million_tokens(24.75),
-                cache_read_cost_per_token=per_million_tokens(0.66),
-                cache_creation_cost_per_token=per_million_tokens(8.25),
-                min_input_tokens=200000,
             ),
         ],
     ),
@@ -478,13 +457,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(3.3),
-                output_cost_per_token=per_million_tokens(16.5),
-                cache_read_cost_per_token=per_million_tokens(0.33),
-                cache_creation_cost_per_token=per_million_tokens(4.125),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "anthropic.claude-v2": ModelPricing(
@@ -492,16 +464,6 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(8.0),
                 output_cost_per_token=per_million_tokens(24.0),
-            ),
-        ],
-    ),
-    "apac.anthropic.claude-3-7-sonnet-20250219-v1": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(3.0),
-                output_cost_per_token=per_million_tokens(15.0),
-                cache_read_cost_per_token=per_million_tokens(0.3),
-                cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
         ],
     ),
@@ -529,13 +491,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.3),
                 cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.0),
-                output_cost_per_token=per_million_tokens(22.5),
-                cache_read_cost_per_token=per_million_tokens(0.6),
-                cache_creation_cost_per_token=per_million_tokens(7.5),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "au.anthropic.claude-haiku-4-5-20251001-v1": ModelPricing(
@@ -556,12 +511,15 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.55),
                 cache_creation_cost_per_token=per_million_tokens(6.875),
             ),
+        ],
+    ),
+    "au.anthropic.claude-opus-4-7": ModelPricing(
+        tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(5.5),
                 output_cost_per_token=per_million_tokens(27.5),
                 cache_read_cost_per_token=per_million_tokens(0.55),
                 cache_creation_cost_per_token=per_million_tokens(6.875),
-                min_input_tokens=200000,
             ),
         ],
     ),
@@ -573,13 +531,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.6),
-                output_cost_per_token=per_million_tokens(24.75),
-                cache_read_cost_per_token=per_million_tokens(0.66),
-                cache_creation_cost_per_token=per_million_tokens(8.25),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "au.anthropic.claude-sonnet-4-6": ModelPricing(
@@ -589,23 +540,6 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(16.5),
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
-            ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(3.3),
-                output_cost_per_token=per_million_tokens(16.5),
-                cache_read_cost_per_token=per_million_tokens(0.33),
-                cache_creation_cost_per_token=per_million_tokens(4.125),
-                min_input_tokens=200000,
-            ),
-        ],
-    ),
-    "eu.anthropic.claude-3-7-sonnet-20250219-v1": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(3.0),
-                output_cost_per_token=per_million_tokens(15.0),
-                cache_read_cost_per_token=per_million_tokens(0.3),
-                cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
         ],
     ),
@@ -653,13 +587,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.55),
                 cache_creation_cost_per_token=per_million_tokens(6.875),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(5.5),
-                output_cost_per_token=per_million_tokens(27.5),
-                cache_read_cost_per_token=per_million_tokens(0.55),
-                cache_creation_cost_per_token=per_million_tokens(6.875),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "eu.anthropic.claude-opus-4-7": ModelPricing(
@@ -680,13 +607,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.3),
                 cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.0),
-                output_cost_per_token=per_million_tokens(22.5),
-                cache_read_cost_per_token=per_million_tokens(0.6),
-                cache_creation_cost_per_token=per_million_tokens(7.5),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "eu.anthropic.claude-sonnet-4-5-20250929-v1": ModelPricing(
@@ -697,13 +617,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.6),
-                output_cost_per_token=per_million_tokens(24.75),
-                cache_read_cost_per_token=per_million_tokens(0.66),
-                cache_creation_cost_per_token=per_million_tokens(8.25),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "eu.anthropic.claude-sonnet-4-6": ModelPricing(
@@ -713,13 +626,6 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(16.5),
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
-            ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(3.3),
-                output_cost_per_token=per_million_tokens(16.5),
-                cache_read_cost_per_token=per_million_tokens(0.33),
-                cache_creation_cost_per_token=per_million_tokens(4.125),
-                min_input_tokens=200000,
             ),
         ],
     ),
@@ -751,13 +657,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.5),
                 cache_creation_cost_per_token=per_million_tokens(6.25),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(5.0),
-                output_cost_per_token=per_million_tokens(25.0),
-                cache_read_cost_per_token=per_million_tokens(0.5),
-                cache_creation_cost_per_token=per_million_tokens(6.25),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "global.anthropic.claude-opus-4-7": ModelPricing(
@@ -778,13 +677,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.3),
                 cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.0),
-                output_cost_per_token=per_million_tokens(22.5),
-                cache_read_cost_per_token=per_million_tokens(0.6),
-                cache_creation_cost_per_token=per_million_tokens(7.5),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "global.anthropic.claude-sonnet-4-5-20250929-v1": ModelPricing(
@@ -795,13 +687,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.3),
                 cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.0),
-                output_cost_per_token=per_million_tokens(22.5),
-                cache_read_cost_per_token=per_million_tokens(0.6),
-                cache_creation_cost_per_token=per_million_tokens(7.5),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "global.anthropic.claude-sonnet-4-6": ModelPricing(
@@ -811,13 +696,6 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(15.0),
                 cache_read_cost_per_token=per_million_tokens(0.3),
                 cache_creation_cost_per_token=per_million_tokens(3.75),
-            ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(3.0),
-                output_cost_per_token=per_million_tokens(15.0),
-                cache_read_cost_per_token=per_million_tokens(0.3),
-                cache_creation_cost_per_token=per_million_tokens(3.75),
-                min_input_tokens=200000,
             ),
         ],
     ),
@@ -849,13 +727,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.6),
-                output_cost_per_token=per_million_tokens(24.75),
-                cache_read_cost_per_token=per_million_tokens(0.66),
-                cache_creation_cost_per_token=per_million_tokens(8.25),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "jp.anthropic.claude-sonnet-4-6": ModelPricing(
@@ -866,13 +737,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(3.3),
-                output_cost_per_token=per_million_tokens(16.5),
-                cache_read_cost_per_token=per_million_tokens(0.33),
-                cache_creation_cost_per_token=per_million_tokens(4.125),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "us.anthropic.claude-3-5-haiku-20241022-v1": ModelPricing(
@@ -882,16 +746,6 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(4.0),
                 cache_read_cost_per_token=per_million_tokens(0.08),
                 cache_creation_cost_per_token=per_million_tokens(1.0),
-            ),
-        ],
-    ),
-    "us.anthropic.claude-3-7-sonnet-20250219-v1": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(3.0),
-                output_cost_per_token=per_million_tokens(15.0),
-                cache_read_cost_per_token=per_million_tokens(0.3),
-                cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
         ],
     ),
@@ -959,13 +813,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.55),
                 cache_creation_cost_per_token=per_million_tokens(6.875),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(5.5),
-                output_cost_per_token=per_million_tokens(27.5),
-                cache_read_cost_per_token=per_million_tokens(0.55),
-                cache_creation_cost_per_token=per_million_tokens(6.875),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "us.anthropic.claude-opus-4-7": ModelPricing(
@@ -986,13 +833,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.3),
                 cache_creation_cost_per_token=per_million_tokens(3.75),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.0),
-                output_cost_per_token=per_million_tokens(22.5),
-                cache_read_cost_per_token=per_million_tokens(0.6),
-                cache_creation_cost_per_token=per_million_tokens(7.5),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "us.anthropic.claude-sonnet-4-5-20250929-v1": ModelPricing(
@@ -1003,13 +843,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
             ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(6.6),
-                output_cost_per_token=per_million_tokens(24.75),
-                cache_read_cost_per_token=per_million_tokens(0.66),
-                cache_creation_cost_per_token=per_million_tokens(8.25),
-                min_input_tokens=200000,
-            ),
         ],
     ),
     "us.anthropic.claude-sonnet-4-6": ModelPricing(
@@ -1019,13 +852,6 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(16.5),
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
-            ),
-            PricingTier(
-                input_cost_per_token=per_million_tokens(3.3),
-                output_cost_per_token=per_million_tokens(16.5),
-                cache_read_cost_per_token=per_million_tokens(0.33),
-                cache_creation_cost_per_token=per_million_tokens(4.125),
-                min_input_tokens=200000,
             ),
         ],
     ),

--- a/packages/lmux-aws-bedrock/tests/test_cost.py
+++ b/packages/lmux-aws-bedrock/tests/test_cost.py
@@ -61,15 +61,6 @@ class TestCalculateBedrockCost:
         assert exact_cost is not None
         assert cost.total_cost == pytest.approx(exact_cost.total_cost)
 
-    def test_long_context_tier(self) -> None:
-        """Claude Sonnet 4.5 on Bedrock uses higher pricing above 200K threshold."""
-        usage = Usage(input_tokens=300_000, output_tokens=1000)
-        cost = calculate_bedrock_cost("anthropic.claude-sonnet-4-5-20250929-v1", usage)
-        assert cost is not None
-        # Above 200K threshold, uses long-context tier pricing
-        assert cost.input_cost == pytest.approx(300_000 * 6.6 / 1_000_000)
-        assert cost.output_cost == pytest.approx(1000 * 24.75 / 1_000_000)
-
     def test_region_none_uses_default(self) -> None:
         usage = Usage(input_tokens=1000, output_tokens=500)
         cost_none = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1", usage, region=None)

--- a/packages/lmux-azure-foundry/pyproject.toml
+++ b/packages/lmux-azure-foundry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-azure-foundry"
-version = "0.5.1"
+version = "0.5.2"
 description = "Azure AI Foundry provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
@@ -77,7 +77,12 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(30.00),
                 output_cost_per_token=per_million_tokens(180.00),
-            )
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(60.00),
+                output_cost_per_token=per_million_tokens(270.00),
+                min_input_tokens=272_000,
+            ),
         ],
     ),
     "gpt-5.4-mini": ModelPricing(
@@ -95,6 +100,25 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(0.20),
                 output_cost_per_token=per_million_tokens(1.25),
                 cache_read_cost_per_token=per_million_tokens(0.02),
+            )
+        ],
+    ),
+    # --- OpenAI: GPT-5.3 family ---
+    "gpt-5.3-codex": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.75),
+                output_cost_per_token=per_million_tokens(14.00),
+                cache_read_cost_per_token=per_million_tokens(0.175),
+            )
+        ],
+    ),
+    "gpt-5.3-chat": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.75),
+                output_cost_per_token=per_million_tokens(14.00),
+                cache_read_cost_per_token=per_million_tokens(0.175),
             )
         ],
     ),
@@ -118,6 +142,15 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     "gpt-5.2-chat": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.75),
+                output_cost_per_token=per_million_tokens(14.00),
+                cache_read_cost_per_token=per_million_tokens(0.175),
+            )
+        ],
+    ),
+    "gpt-5.2-codex": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(1.75),
@@ -308,7 +341,7 @@ _PRICING: dict[str, ModelPricing] = {
     ),
     # --- OpenAI: Embedding models ---
     "text-embedding-3-small": ModelPricing(
-        tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.02), output_cost_per_token=0.0)]
+        tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.022), output_cost_per_token=0.0)]
     ),
     "text-embedding-3-large": ModelPricing(
         tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.143), output_cost_per_token=0.0)]

--- a/packages/lmux-azure-foundry/tests/test_cost.py
+++ b/packages/lmux-azure-foundry/tests/test_cost.py
@@ -39,7 +39,7 @@ class TestCalculateAzureFoundryCost:
         usage = Usage(input_tokens=100, output_tokens=0)
         cost = calculate_azure_foundry_cost("text-embedding-3-small", usage)
         assert cost is not None
-        assert cost.input_cost == pytest.approx(100 * 0.02 / 1_000_000)
+        assert cost.input_cost == pytest.approx(100 * 0.022 / 1_000_000)
         assert cost.output_cost == 0.0
 
     def test_zero_tokens(self) -> None:

--- a/packages/lmux-gcp-vertex/pyproject.toml
+++ b/packages/lmux-gcp-vertex/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-gcp-vertex"
-version = "0.6.2"
+version = "0.6.3"
 description = "Google Cloud Vertex AI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-gcp-vertex/src/lmux_gcp_vertex/cost.py
+++ b/packages/lmux-gcp-vertex/src/lmux_gcp_vertex/cost.py
@@ -44,7 +44,7 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.25),
                 output_cost_per_token=per_million_tokens(1.50),
-                cache_read_cost_per_token=per_million_tokens(0.03),
+                cache_read_cost_per_token=per_million_tokens(0.025),
             ),
         ],
     ),
@@ -406,6 +406,15 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # ── xAI Grok (via Vertex AI) ───────────────────────────────
+    "grok-4-20-reasoning": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.00),
+                output_cost_per_token=per_million_tokens(6.00),
+                cache_read_cost_per_token=per_million_tokens(0.20),
+            ),
+        ],
+    ),
     "grok-4-20-non-reasoning": ModelPricing(
         tiers=[
             PricingTier(
@@ -529,6 +538,7 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.15),
                 output_cost_per_token=per_million_tokens(0.60),
+                cache_read_cost_per_token=per_million_tokens(0.015),
             ),
         ],
     ),

--- a/packages/lmux-groq/pyproject.toml
+++ b/packages/lmux-groq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-groq"
-version = "0.4.1"
+version = "0.4.2"
 description = "Groq provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-groq/src/lmux_groq/cost.py
+++ b/packages/lmux-groq/src/lmux_groq/cost.py
@@ -35,6 +35,15 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # Moonshot Kimi family (prompt caching: 50% discount on cached input tokens)
+    "moonshotai/kimi-k2-instruct-0905": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.00),
+                output_cost_per_token=per_million_tokens(3.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+            )
+        ],
+    ),
     "moonshotai/kimi-k2-instruct": ModelPricing(
         tiers=[
             PricingTier(

--- a/packages/lmux-openai/pyproject.toml
+++ b/packages/lmux-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-openai"
-version = "0.5.2"
+version = "0.5.3"
 description = "OpenAI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -297,24 +297,6 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
-    # Search API
-    "gpt-5-search-api": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(1.25),
-                output_cost_per_token=per_million_tokens(10.00),
-                cache_read_cost_per_token=per_million_tokens(0.125),
-            )
-        ],
-    ),
-    "gpt-4o-search-preview": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(2.50),
-                output_cost_per_token=per_million_tokens(10.00),
-            )
-        ],
-    ),
     # Reasoning models
     "o3-pro": ModelPricing(
         tiers=[

--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -8,6 +8,34 @@ from lmux.types import Cost, Usage
 
 _PRICING: dict[str, ModelPricing] = {
     # GPT-5 family
+    "gpt-5.5-pro": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(30.00),
+                output_cost_per_token=per_million_tokens(180.00),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(60.00),
+                output_cost_per_token=per_million_tokens(270.00),
+                min_input_tokens=272_000,
+            ),
+        ]
+    ),
+    "gpt-5.5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(30.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(10.00),
+                output_cost_per_token=per_million_tokens(45.00),
+                cache_read_cost_per_token=per_million_tokens(1.00),
+                min_input_tokens=272_000,
+            ),
+        ],
+    ),
     "gpt-5.4-pro": ModelPricing(
         tiers=[
             PricingTier(
@@ -98,6 +126,24 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    "gpt-5.2-chat-latest": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.75),
+                output_cost_per_token=per_million_tokens(14.00),
+                cache_read_cost_per_token=per_million_tokens(0.175),
+            )
+        ],
+    ),
+    "gpt-5.1-codex-max": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(10.00),
+                cache_read_cost_per_token=per_million_tokens(0.125),
+            )
+        ],
+    ),
     "gpt-5.1-codex-mini": ModelPricing(
         tiers=[
             PricingTier(
@@ -117,6 +163,15 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     "gpt-5.1": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(10.00),
+                cache_read_cost_per_token=per_million_tokens(0.125),
+            )
+        ],
+    ),
+    "gpt-5.1-chat-latest": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(1.25),
@@ -169,6 +224,15 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    "gpt-5-chat-latest": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(10.00),
+                cache_read_cost_per_token=per_million_tokens(0.125),
+            )
+        ],
+    ),
     # GPT-4.1 family
     "gpt-4.1-mini": ModelPricing(
         tiers=[
@@ -213,6 +277,41 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(2.50),
                 output_cost_per_token=per_million_tokens(10.00),
                 cache_read_cost_per_token=per_million_tokens(1.25),
+            )
+        ],
+    ),
+    "chatgpt-4o-latest": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(15.00),
+            )
+        ],
+    ),
+    "chat-latest": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(30.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+            )
+        ],
+    ),
+    # Search API
+    "gpt-5-search-api": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(10.00),
+                cache_read_cost_per_token=per_million_tokens(0.125),
+            )
+        ],
+    ),
+    "gpt-4o-search-preview": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.50),
+                output_cost_per_token=per_million_tokens(10.00),
             )
         ],
     ),
@@ -330,9 +429,10 @@ _PRICING: dict[str, ModelPricing] = {
 _PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
 
 # 10% uplift for regional processing (data residency) endpoints. Per OpenAI, this
-# applies only to the gpt-5.4 family (gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro).
+# applies to the gpt-5.4 family (gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro)
+# and the gpt-5.5 family (gpt-5.5, gpt-5.5-pro).
 REGIONAL_UPLIFT = 1.1
-_REGIONAL_UPLIFT_PREFIXES = ("gpt-5.4",)
+_REGIONAL_UPLIFT_PREFIXES = ("gpt-5.4", "gpt-5.5")
 
 
 def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-04-09T18:31:01.003632425Z"
+exclude-newer = "2026-05-02T11:41:17.907067Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -817,7 +817,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-aws-bedrock"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "packages/lmux-aws-bedrock" }
 dependencies = [
     { name = "boto3" },
@@ -839,7 +839,7 @@ provides-extras = ["async"]
 
 [[package]]
 name = "lmux-azure-foundry"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "packages/lmux-azure-foundry" }
 dependencies = [
     { name = "lmux" },
@@ -861,7 +861,7 @@ provides-extras = ["identity"]
 
 [[package]]
 name = "lmux-gcp-vertex"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "packages/lmux-gcp-vertex" }
 dependencies = [
     { name = "google-genai" },
@@ -876,7 +876,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-groq"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "packages/lmux-groq" }
 dependencies = [
     { name = "groq" },
@@ -891,7 +891,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-openai"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "packages/lmux-openai" }
 dependencies = [
     { name = "lmux" },


### PR DESCRIPTION
Validated against each provider's live pricing page.

- **lmux-openai**: add `gpt-5.5`, `gpt-5.5-pro`, `chat-latest`, `chatgpt-4o-latest`, `gpt-5.x-chat-latest` variants, `gpt-5.1-codex-max`, `gpt-5-search-api`, `gpt-4o-search-preview`; extend regional uplift to `gpt-5.5` family.
- **lmux-azure-foundry**: `text-embedding-3-small` input $0.02 → $0.022; add `gpt-5.3-codex`, `gpt-5.3-chat`, `gpt-5.2-codex`; add >272K tier to `gpt-5.4-pro`.
- **lmux-gcp-vertex**: `gemini-3.1-flash-lite-preview` cache_read $0.03 → $0.025; add cache_read to `gemma-4-26b`; add `grok-4-20-reasoning`.
- **lmux-groq**: add `moonshotai/kimi-k2-instruct-0905`.
- **lmux-aws-bedrock**: regenerated via `scripts/update_bedrock_pricing.py` — drops stale >200K LCtx tiers, renames `claude-3-7-sonnet` to undated form, adds `au.anthropic.claude-opus-4-7`.

Patch versions bumped on all five packages.