### PR TITLE
fix(groq): populate Usage.reasoning_tokens from completion_tokens_details

### DIFF
--- a/packages/lmux-groq/pyproject.toml
+++ b/packages/lmux-groq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-groq"
-version = "0.4.2"
+version = "0.4.3"
 description = "Groq provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-groq/src/lmux_groq/_mappers.py
+++ b/packages/lmux-groq/src/lmux_groq/_mappers.py
@@ -184,10 +184,15 @@ def _map_completion_usage(completion: "ChatCompletion") -> Usage | None:
     if oai_usage.prompt_tokens_details and oai_usage.prompt_tokens_details.cached_tokens:
         cache_read = oai_usage.prompt_tokens_details.cached_tokens
 
+    reasoning_tokens = None
+    if oai_usage.completion_tokens_details and oai_usage.completion_tokens_details.reasoning_tokens:
+        reasoning_tokens = oai_usage.completion_tokens_details.reasoning_tokens
+
     return Usage(
         input_tokens=oai_usage.prompt_tokens,
         output_tokens=oai_usage.completion_tokens,
         cache_read_tokens=cache_read,
+        reasoning_tokens=reasoning_tokens,
     )
 
 
@@ -225,10 +230,14 @@ def map_chat_chunk(chunk: "ChatCompletionChunk") -> ChatChunk:
         cache_read = None
         if chunk.usage.prompt_tokens_details and chunk.usage.prompt_tokens_details.cached_tokens:
             cache_read = chunk.usage.prompt_tokens_details.cached_tokens
+        reasoning_tokens = None
+        if chunk.usage.completion_tokens_details and chunk.usage.completion_tokens_details.reasoning_tokens:
+            reasoning_tokens = chunk.usage.completion_tokens_details.reasoning_tokens
         usage = Usage(
             input_tokens=chunk.usage.prompt_tokens,
             output_tokens=chunk.usage.completion_tokens,
             cache_read_tokens=cache_read,
+            reasoning_tokens=reasoning_tokens,
         )
 
     return ChatChunk(

--- a/packages/lmux-groq/tests/test_mappers.py
+++ b/packages/lmux-groq/tests/test_mappers.py
@@ -10,7 +10,7 @@ from groq.types.chat.chat_completion_chunk import Choice as ChunkChoice
 from groq.types.chat.chat_completion_chunk import ChoiceDelta, ChoiceDeltaToolCall, ChoiceDeltaToolCallFunction
 from groq.types.chat.chat_completion_message_tool_call import ChatCompletionMessageToolCall
 from groq.types.chat.chat_completion_message_tool_call import Function as ToolCallFunction
-from groq.types.completion_usage import CompletionUsage, PromptTokensDetails
+from groq.types.completion_usage import CompletionTokensDetails, CompletionUsage, PromptTokensDetails
 from pytest_mock import MockerFixture
 
 from lmux.types import (
@@ -282,6 +282,30 @@ class TestMapChatCompletion:
         assert result.usage is not None
         assert result.usage.cache_read_tokens == 50
 
+    def test_with_reasoning_tokens(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        completion = ChatCompletion(
+            id="chatcmpl-123",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(content="Hello!", role="assistant"),
+                )
+            ],
+            created=1234567890,
+            model="openai/gpt-oss-120b",
+            object="chat.completion",
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                completion_tokens_details=CompletionTokensDetails(reasoning_tokens=4),
+            ),
+        )
+        result = map_chat_completion(completion, "groq", noop_cost_fn)
+        assert result.usage is not None
+        assert result.usage.reasoning_tokens == 4
+
     def test_none_usage(self, chat_completion: ChatCompletion, noop_cost_fn: Any) -> None:  # noqa: ANN401
         chat_completion.usage = None
         result = map_chat_completion(chat_completion, "groq", noop_cost_fn)
@@ -411,6 +435,24 @@ class TestMapChatChunk:
         result = map_chat_chunk(chunk)
         assert result.usage is not None
         assert result.usage.cache_read_tokens == 3
+
+    def test_usage_chunk_with_reasoning(self) -> None:
+        chunk = ChatCompletionChunk(
+            id="chatcmpl-123",
+            choices=[],
+            created=1234567890,
+            model="openai/gpt-oss-120b",
+            object="chat.completion.chunk",
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                completion_tokens_details=CompletionTokensDetails(reasoning_tokens=4),
+            ),
+        )
+        result = map_chat_chunk(chunk)
+        assert result.usage is not None
+        assert result.usage.reasoning_tokens == 4
 
     def test_empty_choices(self) -> None:
         chunk = ChatCompletionChunk(

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-05-30T16:22:14.952751Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -876,7 +876,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-groq"
-version = "0.4.2"
+version = "0.4.3"
 source = { editable = "packages/lmux-groq" }
 dependencies = [
     { name = "groq" },


### PR DESCRIPTION
Groq reports reasoning tokens under `completion_tokens_details.reasoning_tokens`, but the usage mapper never read them, so `Usage.reasoning_tokens` was always `None` for Groq. This populates it for both non-streaming and streaming completions.