### PR TITLE
feat(azure-foundry): add Responses API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ provider.register_pricing("my-fine-tune", ModelPricing(tiers=[
 | [lmux-openai](packages/lmux-openai)                 | Completion, Embedding, Responses | `OPENAI_API_KEY`                                  |
 | [lmux-anthropic](packages/lmux-anthropic)           | Completion                       | `ANTHROPIC_API_KEY`                               |
 | [lmux-anthropic\[vertex\]](packages/lmux-anthropic) | Completion                       | ADC, service account                              |
-| [lmux-azure-foundry](packages/lmux-azure-foundry)   | Completion, Embedding            | `AZURE_FOUNDRY_API_KEY`, Azure AD, token provider |
+| [lmux-azure-foundry](packages/lmux-azure-foundry)   | Completion, Embedding, Responses | `AZURE_FOUNDRY_API_KEY`, Azure AD, token provider |
 | [lmux-aws-bedrock](packages/lmux-aws-bedrock)       | Completion, Embedding            | boto3 credential chain                            |
 | [lmux-google](packages/lmux-google)                 | Completion, Embedding            | ADC, service account, `GOOGLE_API_KEY`            |
 | [lmux-groq](packages/lmux-groq)                     | Completion                       | `GROQ_API_KEY`                                    |

--- a/packages/lmux-azure-foundry/README.md
+++ b/packages/lmux-azure-foundry/README.md
@@ -75,7 +75,7 @@ print(response.embeddings)
 
 ### Responses API
 
-Required for Responses-only deployments such as `gpt-5-pro`, `o3-pro`, the codex models, and `computer-use-preview`:
+Required for models that are only served through the Responses API:
 
 ```python
 response = provider.create_response("gpt-5-pro", "Hello")

--- a/packages/lmux-azure-foundry/README.md
+++ b/packages/lmux-azure-foundry/README.md
@@ -2,7 +2,7 @@
 
 Azure AI Foundry provider for [lmux](https://github.com/cluebbehusen/lmux). Uses the [openai](https://pypi.org/project/openai/) SDK's `AzureOpenAI` client.
 
-Supports chat completions, streaming, and embeddings.
+Supports chat completions, streaming, embeddings, and the Responses API.
 
 Part of the [lmux](https://github.com/cluebbehusen/lmux) ecosystem: standardized interface, cost tracking on every response, and registry-based routing across providers.
 
@@ -73,9 +73,18 @@ response = provider.embed("text-embedding-3-small", "Hello")
 print(response.embeddings)
 ```
 
+### Responses API
+
+Required for Responses-only deployments such as `gpt-5-pro`, `o3-pro`, the codex models, and `computer-use-preview`:
+
+```python
+response = provider.create_response("gpt-5-pro", "Hello")
+print(response.output_text)
+```
+
 ### Async
 
-All methods have async variants: `achat`, `achat_stream`, `aembed`.
+All methods have async variants: `achat`, `achat_stream`, `aembed`, `acreate_response`.
 
 ### Registry
 
@@ -114,7 +123,7 @@ response = provider.chat(
 AzureFoundryProvider(
     endpoint=...,      # required, Azure resource endpoint
     auth=...,          # AuthProvider, default: AzureFoundryKeyAuthProvider()
-    api_version=...,   # API version (default: "2024-12-01-preview")
+    api_version=...,   # API version (default: "2025-04-01-preview")
     timeout=...,       # Request timeout in seconds
     max_retries=...,   # Max retry attempts
 )

--- a/packages/lmux-azure-foundry/pyproject.toml
+++ b/packages/lmux-azure-foundry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-azure-foundry"
-version = "0.5.3"
+version = "0.6.0"
 description = "Azure AI Foundry provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/_mappers.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/_mappers.py
@@ -6,7 +6,7 @@ are identical to those used by the OpenAI provider.
 
 import copy
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lmux.schema import add_additional_properties_false
 from lmux.types import (
@@ -24,6 +24,8 @@ from lmux.types import (
     JsonObjectResponseFormat,
     Message,
     ResponseFormat,
+    ResponseInputItem,
+    ResponseResponse,
     SystemMessage,
     TextContent,
     TextResponseFormat,
@@ -55,6 +57,7 @@ if TYPE_CHECKING:
     from openai.types.chat.chat_completion_tool_message_param import ChatCompletionToolMessageParam
     from openai.types.chat.chat_completion_user_message_param import ChatCompletionUserMessageParam
     from openai.types.create_embedding_response import CreateEmbeddingResponse
+    from openai.types.responses import Response as OAIResponse
     from openai.types.shared_params import (
         FunctionDefinition,
         ResponseFormatJSONObject,
@@ -292,6 +295,47 @@ def map_embedding_response(
     cost = cost_fn(response.model, usage)
     return EmbeddingResponse(
         embeddings=embeddings,
+        usage=usage,
+        cost=cost,
+        model=response.model,
+        provider=provider_name,
+    )
+
+
+def map_response_input(input: str | Sequence[ResponseInputItem]) -> Any:  # noqa: A002, ANN401
+    """Convert lmux ResponseInputItem sequence to OpenAI-compatible dicts.
+
+    Returns ``Any`` because the OpenAI SDK expects its own TypedDict union
+    (``ResponseInputItemParam``), which is structurally compatible with the
+    dicts produced by ``model_dump()`` but not assignable due to nominal typing.
+    """
+    if isinstance(input, str):
+        return input
+    return [item.model_dump(exclude_none=True) for item in input]
+
+
+def map_responses_response(
+    response: "OAIResponse",
+    provider_name: str,
+    cost_fn: CostCalculator,
+) -> ResponseResponse:
+    """Convert OpenAI Responses API Response to lmux ResponseResponse."""
+    usage_data = response.usage
+    usage: Usage | None = None
+    if usage_data:
+        cache_read: int | None = None
+        if usage_data.input_tokens_details and usage_data.input_tokens_details.cached_tokens:
+            cache_read = usage_data.input_tokens_details.cached_tokens
+        usage = Usage(
+            input_tokens=usage_data.input_tokens,
+            output_tokens=usage_data.output_tokens,
+            cache_read_tokens=cache_read,
+        )
+
+    cost = cost_fn(response.model, usage) if usage else None
+    return ResponseResponse(
+        id=response.id,
+        output_text=response.output_text,
         usage=usage,
         cost=cost,
         model=response.model,

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/_mappers.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/_mappers.py
@@ -326,10 +326,14 @@ def map_responses_response(
         cache_read: int | None = None
         if usage_data.input_tokens_details and usage_data.input_tokens_details.cached_tokens:
             cache_read = usage_data.input_tokens_details.cached_tokens
+        reasoning_tokens: int | None = None
+        if usage_data.output_tokens_details and usage_data.output_tokens_details.reasoning_tokens:
+            reasoning_tokens = usage_data.output_tokens_details.reasoning_tokens
         usage = Usage(
             input_tokens=usage_data.input_tokens,
             output_tokens=usage_data.output_tokens,
             cache_read_tokens=cache_read,
+            reasoning_tokens=reasoning_tokens,
         )
 
     cost = cost_fn(response.model, usage) if usage else None

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/provider.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/provider.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     import openai
 
 from lmux.cost import ModelPricing, calculate_cost
-from lmux.protocols import AuthProvider, CompletionProvider, EmbeddingProvider, PricingProvider
+from lmux.protocols import AuthProvider, CompletionProvider, EmbeddingProvider, PricingProvider, ResponsesProvider
 from lmux.types import (
     ChatChunk,
     ChatResponse,
@@ -16,6 +16,8 @@ from lmux.types import (
     EmbeddingResponse,
     Message,
     ResponseFormat,
+    ResponseInputItem,
+    ResponseResponse,
     Tool,
     ToolChoice,
     Usage,
@@ -28,6 +30,8 @@ from lmux_azure_foundry._mappers import (
     map_embedding_response,
     map_messages,
     map_response_format,
+    map_response_input,
+    map_responses_response,
     map_tool_choice,
     map_tools,
 )
@@ -41,12 +45,14 @@ from lmux_azure_foundry.cost import (
 from lmux_azure_foundry.params import AzureFoundryParams
 
 PROVIDER_NAME = "azure-foundry"
-DEFAULT_API_VERSION = "2024-12-01-preview"
+# Minimum version that supports the Responses API (versions are cumulative).
+DEFAULT_API_VERSION = "2025-04-01-preview"
 
 
 class AzureFoundryProvider(
     CompletionProvider[AzureFoundryParams],
     EmbeddingProvider[AzureFoundryParams],
+    ResponsesProvider[AzureFoundryParams],
     PricingProvider,
 ):
     """Azure AI Foundry API provider.
@@ -340,6 +346,44 @@ class AzureFoundryProvider(
         result = map_embedding_response(response, PROVIDER_NAME, self._calculate_cost)
         return self._apply_embedding_multipliers(result, provider_params)
 
+    # MARK: Responses
+
+    @override
+    def create_response(
+        self,
+        model: str,
+        input: str | Sequence[ResponseInputItem],
+        *,
+        provider_params: AzureFoundryParams | None = None,
+    ) -> ResponseResponse:
+        extra = self._responses_kwargs(provider_params)
+        try:
+            client = self._get_sync_client()
+            response = client.responses.create(model=model, input=map_response_input(input), stream=False, **extra)
+        except Exception as e:
+            raise map_azure_foundry_error(e) from e
+        result = map_responses_response(response, PROVIDER_NAME, self._calculate_cost)
+        return self._apply_response_multipliers(result, provider_params)
+
+    @override
+    async def acreate_response(
+        self,
+        model: str,
+        input: str | Sequence[ResponseInputItem],
+        *,
+        provider_params: AzureFoundryParams | None = None,
+    ) -> ResponseResponse:
+        extra = self._responses_kwargs(provider_params)
+        try:
+            client = await self._get_async_client()
+            response = await client.responses.create(
+                model=model, input=map_response_input(input), stream=False, **extra
+            )
+        except Exception as e:
+            raise map_azure_foundry_error(e) from e
+        result = map_responses_response(response, PROVIDER_NAME, self._calculate_cost)
+        return self._apply_response_multipliers(result, provider_params)
+
     # MARK: Cost Multipliers
 
     @staticmethod
@@ -374,6 +418,15 @@ class AzureFoundryProvider(
         self, response: EmbeddingResponse, provider_params: AzureFoundryParams | None
     ) -> EmbeddingResponse:
         """Apply deployment_type cost multipliers to an embedding response."""
+        adjusted = self._apply_cost_multipliers(response.cost, provider_params)
+        if adjusted is response.cost:
+            return response
+        return response.model_copy(update={"cost": adjusted})
+
+    def _apply_response_multipliers(
+        self, response: ResponseResponse, provider_params: AzureFoundryParams | None
+    ) -> ResponseResponse:
+        """Apply deployment_type cost multipliers to a Responses API response."""
         adjusted = self._apply_cost_multipliers(response.cost, provider_params)
         if adjusted is response.cost:
             return response
@@ -433,3 +486,18 @@ class AzureFoundryProvider(
         if params.user is not None:
             kwargs["user"] = params.user
         return kwargs
+
+    @staticmethod
+    def _responses_kwargs(provider_params: AzureFoundryParams | None) -> dict[str, Any]:
+        """Build extra kwargs for the Responses API."""
+        if provider_params is None:
+            return {}
+        extra: dict[str, Any] = {}
+        # Responses API uses reasoning={"effort": ...}, not flat reasoning_effort
+        if provider_params.reasoning_effort is not None:
+            extra["reasoning"] = {"effort": provider_params.reasoning_effort}
+        if provider_params.seed is not None:
+            extra["seed"] = provider_params.seed
+        if provider_params.user is not None:
+            extra["user"] = provider_params.user
+        return extra

--- a/packages/lmux-azure-foundry/tests/test_provider.py
+++ b/packages/lmux-azure-foundry/tests/test_provider.py
@@ -22,6 +22,7 @@ from lmux.exceptions import AuthenticationError, InvalidRequestError, ProviderEr
 from lmux.types import (
     FunctionDefinition,
     JsonObjectResponseFormat,
+    ResponseInputMessage,
     Tool,
     UserMessage,
 )
@@ -149,8 +150,22 @@ def mock_async_client() -> MagicMock:
     mock = MagicMock()
     mock.chat.completions.create = AsyncMock()
     mock.embeddings.create = AsyncMock()
+    mock.responses.create = AsyncMock()
     mock.close = AsyncMock()
     return mock
+
+
+@pytest.fixture
+def responses_mock() -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.id = "resp_123"
+    mock_response.output_text = "Hi!"
+    mock_response.model = "gpt-5-pro"
+    mock_response.usage = MagicMock()
+    mock_response.usage.input_tokens = 10
+    mock_response.usage.output_tokens = 5
+    mock_response.usage.input_tokens_details = None
+    return mock_response
 
 
 @pytest.fixture
@@ -972,7 +987,7 @@ class TestClientManagement:
         mock_sync_create.assert_called_once_with(
             credential="fake-api-key",
             azure_endpoint="https://test.openai.azure.com/",
-            api_version="2024-12-01-preview",
+            api_version="2025-04-01-preview",
             timeout=30.0,
             max_retries=5,
         )
@@ -1042,7 +1057,7 @@ class TestClientManagement:
         mock_async_create.assert_called_once_with(
             credential="fake-api-key",
             azure_endpoint="https://test.openai.azure.com/",
-            api_version="2024-12-01-preview",
+            api_version="2025-04-01-preview",
             timeout=30.0,
             max_retries=5,
         )
@@ -1060,7 +1075,7 @@ class TestClientManagement:
         mock_sync_create.assert_called_once_with(
             credential=AzureAdToken(token="fake-ad-token"),  # noqa: S106
             azure_endpoint="https://test.openai.azure.com/",
-            api_version="2024-12-01-preview",
+            api_version="2025-04-01-preview",
             timeout=None,
             max_retries=None,
         )
@@ -1079,7 +1094,7 @@ class TestClientManagement:
         mock_sync_create.assert_called_once_with(
             credential=FakeTokenProviderAuth._provider,  # pyright: ignore[reportPrivateUsage]
             azure_endpoint="https://test.openai.azure.com/",
-            api_version="2024-12-01-preview",
+            api_version="2025-04-01-preview",
             timeout=None,
             max_retries=None,
         )
@@ -1099,7 +1114,7 @@ class TestClientManagement:
         mock_sync_create.assert_called_once_with(
             credential="env-key",
             azure_endpoint="https://test.openai.azure.com/",
-            api_version="2024-12-01-preview",
+            api_version="2025-04-01-preview",
             timeout=None,
             max_retries=None,
         )
@@ -1284,3 +1299,124 @@ class TestAclose:
 class TestPreload:
     def test_preload_imports_openai(self) -> None:
         preload()  # should not raise
+
+
+# MARK: CreateResponse
+
+
+class TestCreateResponse:
+    def test_basic(
+        self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        mock_sync_client.responses.create.return_value = responses_mock
+
+        result = sync_provider.create_response("gpt-5-pro", "Hello")
+
+        assert result.id == "resp_123"
+        assert result.output_text == "Hi!"
+        assert result.provider == "azure-foundry"
+        assert result.usage is not None
+        assert result.usage.input_tokens == 10
+        assert result.cost is not None
+        mock_sync_client.responses.create.assert_called_once_with(model="gpt-5-pro", input="Hello", stream=False)
+        mock_sync_client.chat.completions.create.assert_not_called()
+
+    def test_input_items_mapped_to_dicts(
+        self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        mock_sync_client.responses.create.return_value = responses_mock
+
+        _ = sync_provider.create_response("gpt-5-pro", [ResponseInputMessage(role="user", content="Hello")])
+
+        mock_sync_client.responses.create.assert_called_once_with(
+            model="gpt-5-pro", input=[{"role": "user", "content": "Hello"}], stream=False
+        )
+
+    def test_with_provider_params(
+        self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        """The Responses API takes reasoning={"effort": ...} instead of flat reasoning_effort."""
+        mock_sync_client.responses.create.return_value = responses_mock
+        params = AzureFoundryParams(reasoning_effort="low", seed=42, user="u1")
+
+        _ = sync_provider.create_response("gpt-5-pro", "Hello", provider_params=params)
+
+        mock_sync_client.responses.create.assert_called_once_with(
+            model="gpt-5-pro", input="Hello", stream=False, reasoning={"effort": "low"}, seed=42, user="u1"
+        )
+
+    def test_deployment_multiplier_applied(
+        self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        mock_sync_client.responses.create.return_value = responses_mock
+
+        result_global = sync_provider.create_response("gpt-5-pro", "Hello")
+        result_data_zone = sync_provider.create_response(
+            "gpt-5-pro", "Hello", provider_params=AzureFoundryParams(deployment_type="data_zone")
+        )
+
+        assert result_global.cost is not None
+        assert result_data_zone.cost is not None
+        assert result_data_zone.cost.total_cost == pytest.approx(result_global.cost.total_cost * 1.1)
+
+    def test_cached_tokens_mapped(
+        self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        responses_mock.usage.input_tokens_details = MagicMock(cached_tokens=3)
+        mock_sync_client.responses.create.return_value = responses_mock
+
+        result = sync_provider.create_response("gpt-5-pro", "Hello")
+
+        assert result.usage is not None
+        assert result.usage.cache_read_tokens == 3
+
+    def test_no_usage(
+        self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        responses_mock.usage = None
+        mock_sync_client.responses.create.return_value = responses_mock
+
+        result = sync_provider.create_response("gpt-5-pro", "Hello")
+
+        assert result.usage is None
+        assert result.cost is None
+
+    def test_exception_mapping(
+        self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, auth_error: openai.AuthenticationError
+    ) -> None:
+        mock_sync_client.responses.create.side_effect = auth_error
+
+        with pytest.raises(AuthenticationError):
+            _ = sync_provider.create_response("gpt-5-pro", "Hello")
+
+    async def test_acreate_response(
+        self, async_provider: AzureFoundryProvider, mock_async_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        mock_async_client.responses.create.return_value = responses_mock
+
+        result = await async_provider.acreate_response("gpt-5-pro", "Hello")
+
+        assert result.output_text == "Hi!"
+        assert result.provider == "azure-foundry"
+        mock_async_client.responses.create.assert_awaited_once_with(model="gpt-5-pro", input="Hello", stream=False)
+
+    async def test_acreate_response_with_provider_params(
+        self, async_provider: AzureFoundryProvider, mock_async_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        mock_async_client.responses.create.return_value = responses_mock
+
+        _ = await async_provider.acreate_response(
+            "gpt-5-pro", "Hello", provider_params=AzureFoundryParams(reasoning_effort="high")
+        )
+
+        mock_async_client.responses.create.assert_awaited_once_with(
+            model="gpt-5-pro", input="Hello", stream=False, reasoning={"effort": "high"}
+        )
+
+    async def test_acreate_response_exception_mapping(
+        self, async_provider: AzureFoundryProvider, mock_async_client: MagicMock, auth_error: openai.AuthenticationError
+    ) -> None:
+        mock_async_client.responses.create.side_effect = auth_error
+
+        with pytest.raises(AuthenticationError):
+            _ = await async_provider.acreate_response("gpt-5-pro", "Hello")

--- a/packages/lmux-azure-foundry/tests/test_provider.py
+++ b/packages/lmux-azure-foundry/tests/test_provider.py
@@ -165,6 +165,7 @@ def responses_mock() -> MagicMock:
     mock_response.usage.input_tokens = 10
     mock_response.usage.output_tokens = 5
     mock_response.usage.input_tokens_details = None
+    mock_response.usage.output_tokens_details = None
     return mock_response
 
 
@@ -1369,6 +1370,17 @@ class TestCreateResponse:
 
         assert result.usage is not None
         assert result.usage.cache_read_tokens == 3
+
+    def test_reasoning_tokens_mapped(
+        self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        responses_mock.usage.output_tokens_details = MagicMock(reasoning_tokens=4)
+        mock_sync_client.responses.create.return_value = responses_mock
+
+        result = sync_provider.create_response("gpt-5-pro", "Hello")
+
+        assert result.usage is not None
+        assert result.usage.reasoning_tokens == 4
 
     def test_no_usage(
         self, sync_provider: AzureFoundryProvider, mock_sync_client: MagicMock, responses_mock: MagicMock

--- a/packages/lmux-openai/pyproject.toml
+++ b/packages/lmux-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-openai"
-version = "0.5.4"
+version = "0.5.5"
 description = "OpenAI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-openai/src/lmux_openai/_mappers.py
+++ b/packages/lmux-openai/src/lmux_openai/_mappers.py
@@ -318,10 +318,14 @@ def map_responses_response(
         cache_read: int | None = None
         if usage_data.input_tokens_details and usage_data.input_tokens_details.cached_tokens:
             cache_read = usage_data.input_tokens_details.cached_tokens
+        reasoning_tokens: int | None = None
+        if usage_data.output_tokens_details and usage_data.output_tokens_details.reasoning_tokens:
+            reasoning_tokens = usage_data.output_tokens_details.reasoning_tokens
         usage = Usage(
             input_tokens=usage_data.input_tokens,
             output_tokens=usage_data.output_tokens,
             cache_read_tokens=cache_read,
+            reasoning_tokens=reasoning_tokens,
         )
 
     cost = cost_fn(response.model, usage) if usage else None

--- a/packages/lmux-openai/tests/test_mappers.py
+++ b/packages/lmux-openai/tests/test_mappers.py
@@ -104,6 +104,7 @@ def responses_mock() -> MagicMock:
     mock.usage.input_tokens = 10
     mock.usage.output_tokens = 5
     mock.usage.input_tokens_details = None
+    mock.usage.output_tokens_details = None
     return mock
 
 
@@ -567,6 +568,12 @@ class TestMapResponsesResponse:
         result = map_responses_response(mock, "openai", noop_cost_fn)
         assert result.usage is not None
         assert result.usage.cache_read_tokens == 50
+
+    def test_with_reasoning_tokens(self, responses_mock: MagicMock, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        responses_mock.usage.output_tokens_details = MagicMock(reasoning_tokens=4)
+        result = map_responses_response(responses_mock, "openai", noop_cost_fn)
+        assert result.usage is not None
+        assert result.usage.reasoning_tokens == 4
 
     def test_none_usage(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         mock = MagicMock()

--- a/packages/lmux-openai/tests/test_provider.py
+++ b/packages/lmux-openai/tests/test_provider.py
@@ -113,6 +113,7 @@ def responses_mock() -> MagicMock:
     mock_response.usage.input_tokens = 10
     mock_response.usage.output_tokens = 5
     mock_response.usage.input_tokens_details = None
+    mock_response.usage.output_tokens_details = None
     return mock_response
 
 
@@ -807,6 +808,17 @@ class TestCreateResponse:
         mock_sync_client.responses.create.assert_called_once_with(
             model="gpt-4o", input="Hello", stream=False, service_tier="flex"
         )
+
+    def test_reasoning_tokens_mapped(
+        self, sync_provider: OpenAIProvider, mock_sync_client: MagicMock, responses_mock: MagicMock
+    ) -> None:
+        responses_mock.usage.output_tokens_details = MagicMock(reasoning_tokens=4)
+        mock_sync_client.responses.create.return_value = responses_mock
+
+        result = sync_provider.create_response("gpt-4o", "Hello")
+
+        assert result.usage is not None
+        assert result.usage.reasoning_tokens == 4
 
     def test_exception_mapping(
         self, sync_provider: OpenAIProvider, mock_sync_client: MagicMock, not_found_error: openai.NotFoundError

--- a/uv.lock
+++ b/uv.lock
@@ -852,7 +852,7 @@ provides-extras = ["async"]
 
 [[package]]
 name = "lmux-azure-foundry"
-version = "0.5.3"
+version = "0.6.0"
 source = { editable = "packages/lmux-azure-foundry" }
 dependencies = [
     { name = "lmux" },

--- a/uv.lock
+++ b/uv.lock
@@ -915,7 +915,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-openai"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "packages/lmux-openai" }
 dependencies = [
     { name = "lmux" },


### PR DESCRIPTION
Implements `ResponsesProvider` on `AzureFoundryProvider` (0.6.0), un-stranding the Responses-only pricing entries (`gpt-5-pro`, `o3-pro`, the codex line, `computer-use-preview`) that were unreachable through `chat()`.

- `create_response`/`acreate_response` use the existing `AzureOpenAI` client — `/responses` is a resource-level route (not deployment-scoped), so no client changes were needed. Mappers transplanted from lmux-openai.
- `DEFAULT_API_VERSION` bumped `2024-12-01-preview` → `2025-04-01-preview`, the minimum dated version with the Responses API; Azure api-versions are cumulative, so chat/embeddings are unaffected (overridable via the existing `api_version` constructor arg).
- Deployment-type cost multipliers (data zone/regional) apply to Responses results, matching chat and embeddings.
- `reasoning_effort` maps to the Responses-shaped `reasoning={"effort": ...}`.