### PR TITLE
feat(anthropic): add Claude-in-Microsoft-Foundry provider

### DIFF
--- a/.agents/skills/update-pricing/SKILL.md
+++ b/.agents/skills/update-pricing/SKILL.md
@@ -156,6 +156,10 @@ multi-region endpoint premium) and the `_VERTEX_PREMIUM_PRICING_MODELS` /
 `_VERTEX_UNIFORM_PRICING_MODELS` scope lists against the Vertex page's
 per-endpoint tables.
 
+Claude in Microsoft Foundry bills Anthropic's standard API pricing, so it
+needs no separate pricing check — but if the Anthropic docs start describing
+Foundry-specific deployment types or premiums, flag that in Caveats.
+
 ---
 
 ## Subagent Instructions

--- a/README.md
+++ b/README.md
@@ -128,15 +128,16 @@ provider.register_pricing("my-fine-tune", ModelPricing(tiers=[
 
 ## Providers
 
-| Package                                             | Protocols                        | Auth                                              |
-| --------------------------------------------------- | -------------------------------- | ------------------------------------------------- |
-| [lmux-openai](packages/lmux-openai)                 | Completion, Embedding, Responses | `OPENAI_API_KEY`                                  |
-| [lmux-anthropic](packages/lmux-anthropic)           | Completion                       | `ANTHROPIC_API_KEY`                               |
-| [lmux-anthropic\[vertex\]](packages/lmux-anthropic) | Completion                       | ADC, service account                              |
-| [lmux-azure-foundry](packages/lmux-azure-foundry)   | Completion, Embedding, Responses | `AZURE_FOUNDRY_API_KEY`, Azure AD, token provider |
-| [lmux-aws-bedrock](packages/lmux-aws-bedrock)       | Completion, Embedding            | boto3 credential chain                            |
-| [lmux-google](packages/lmux-google)                 | Completion, Embedding            | ADC, service account, `GOOGLE_API_KEY`            |
-| [lmux-groq](packages/lmux-groq)                     | Completion                       | `GROQ_API_KEY`                                    |
+| Package                                             | Protocols                        | Auth                                                 |
+| --------------------------------------------------- | -------------------------------- | ---------------------------------------------------- |
+| [lmux-openai](packages/lmux-openai)                 | Completion, Embedding, Responses | `OPENAI_API_KEY`                                     |
+| [lmux-anthropic](packages/lmux-anthropic)           | Completion                       | `ANTHROPIC_API_KEY`                                  |
+| [lmux-anthropic\[vertex\]](packages/lmux-anthropic) | Completion                       | ADC, service account                                 |
+| [lmux-anthropic](packages/lmux-anthropic) (Foundry) | Completion                       | `ANTHROPIC_FOUNDRY_API_KEY`, Entra ID token provider |
+| [lmux-azure-foundry](packages/lmux-azure-foundry)   | Completion, Embedding, Responses | `AZURE_FOUNDRY_API_KEY`, Azure AD, token provider    |
+| [lmux-aws-bedrock](packages/lmux-aws-bedrock)       | Completion, Embedding            | boto3 credential chain                               |
+| [lmux-google](packages/lmux-google)                 | Completion, Embedding            | ADC, service account, `GOOGLE_API_KEY`               |
+| [lmux-groq](packages/lmux-groq)                     | Completion                       | `GROQ_API_KEY`                                       |
 
 ## Custom Providers
 

--- a/packages/lmux-anthropic/README.md
+++ b/packages/lmux-anthropic/README.md
@@ -132,6 +132,44 @@ Any `AuthProvider` that returns `google.auth` `Credentials` works — either bar
 
 `AnthropicParams.service_tier` and `AnthropicParams.inference_geo` are Anthropic-API-only: the Vertex provider drops them from outgoing requests, and the `inference_geo` US cost multiplier never applies.
 
+## Claude in Microsoft Foundry
+
+No extra needed — `AnthropicFoundryProvider` ships with the base package and serves Claude through a Foundry resource with the same chat/streaming interface:
+
+```python
+from lmux_anthropic import AnthropicFoundryProvider
+
+provider = AnthropicFoundryProvider(resource="example-resource")
+response = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hello")])
+print(response.provider)  # "anthropic-foundry"
+print(response.cost)
+```
+
+`resource` and the mutually exclusive `base_url` fall back to the `ANTHROPIC_FOUNDRY_RESOURCE` and `ANTHROPIC_FOUNDRY_BASE_URL` environment variables. Model IDs are Foundry deployment names, which default to the plain model IDs (`claude-sonnet-4-6`, ...). Foundry bills Anthropic's standard API pricing through the Microsoft Marketplace, so costs come from the same pricing table with no multiplier.
+
+### Foundry Auth
+
+The default `AnthropicFoundryEnvAuthProvider` reads an API key from `ANTHROPIC_FOUNDRY_API_KEY`. For Microsoft Entra ID, wrap a bearer-token provider:
+
+```python
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from lmux_anthropic import AnthropicFoundryProvider, AnthropicFoundryTokenAuthProvider
+
+token_provider = get_bearer_token_provider(
+    DefaultAzureCredential(), "https://cognitiveservices.azure.com/.default"
+)
+provider = AnthropicFoundryProvider(
+    resource="example-resource",
+    auth=AnthropicFoundryTokenAuthProvider(token_provider=token_provider),
+)
+```
+
+Any `AuthProvider` that returns an API key string or a `() -> str` token-provider callable works.
+
+### Foundry Params Caveat
+
+Same as Vertex: `service_tier` and `inference_geo` are dropped from outgoing requests, and the `inference_geo` US cost multiplier never applies.
+
 ## Constructor Options
 
 ```python

--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-anthropic"
-version = "0.6.0"
+version = "0.7.0"
 description = "Anthropic provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-anthropic/src/lmux_anthropic/__init__.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/__init__.py
@@ -2,15 +2,20 @@
 
 from lmux_anthropic.auth import (
     AnthropicEnvAuthProvider,
+    AnthropicFoundryEnvAuthProvider,
+    AnthropicFoundryTokenAuthProvider,
     AnthropicVertexADCAuthProvider,
     AnthropicVertexServiceAccountAuthProvider,
 )
 from lmux_anthropic.cost import calculate_anthropic_cost
 from lmux_anthropic.params import AnthropicParams
-from lmux_anthropic.provider import AnthropicProvider, AnthropicVertexProvider
+from lmux_anthropic.provider import AnthropicFoundryProvider, AnthropicProvider, AnthropicVertexProvider
 
 __all__ = [
     "AnthropicEnvAuthProvider",
+    "AnthropicFoundryEnvAuthProvider",
+    "AnthropicFoundryProvider",
+    "AnthropicFoundryTokenAuthProvider",
     "AnthropicParams",
     "AnthropicProvider",
     "AnthropicVertexADCAuthProvider",

--- a/packages/lmux-anthropic/src/lmux_anthropic/_lazy.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_lazy.py
@@ -1,5 +1,6 @@
 """Lazy Anthropic SDK loading internals."""
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -119,3 +120,80 @@ def create_async_vertex_client(  # noqa: PLR0913
         max_retries=max_retries,
     )
     return anthropic.AsyncAnthropicVertex(**kwargs)
+
+
+def _foundry_client_kwargs(  # noqa: PLR0913
+    *,
+    api_key: str | None,
+    azure_ad_token_provider: Callable[[], str] | None,
+    resource: str | None,
+    base_url: str | None,
+    timeout: float | None,
+    max_retries: int | None,
+) -> dict[str, Any]:
+    """Build AnthropicFoundry constructor kwargs, omitting None values.
+
+    Omitted api_key/resource/base_url fall back to the SDK's
+    ANTHROPIC_FOUNDRY_API_KEY, ANTHROPIC_FOUNDRY_RESOURCE, and
+    ANTHROPIC_FOUNDRY_BASE_URL environment variables.
+    """
+    kwargs: dict[str, Any] = {}
+    if api_key is not None:
+        kwargs["api_key"] = api_key
+    if azure_ad_token_provider is not None:
+        kwargs["azure_ad_token_provider"] = azure_ad_token_provider
+    if resource is not None:
+        kwargs["resource"] = resource
+    if base_url is not None:
+        kwargs["base_url"] = base_url
+    if timeout is not None:
+        kwargs["timeout"] = timeout
+    if max_retries is not None:
+        kwargs["max_retries"] = max_retries
+    return kwargs
+
+
+def create_sync_foundry_client(  # noqa: PLR0913
+    *,
+    api_key: str | None = None,
+    azure_ad_token_provider: Callable[[], str] | None = None,
+    resource: str | None = None,
+    base_url: str | None = None,
+    timeout: float | None = None,
+    max_retries: int | None = None,
+) -> "anthropic.AnthropicFoundry":
+    """Create an anthropic.AnthropicFoundry client, lazily importing the SDK."""
+    import anthropic  # noqa: PLC0415
+
+    kwargs = _foundry_client_kwargs(
+        api_key=api_key,
+        azure_ad_token_provider=azure_ad_token_provider,
+        resource=resource,
+        base_url=base_url,
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+    return anthropic.AnthropicFoundry(**kwargs)
+
+
+def create_async_foundry_client(  # noqa: PLR0913
+    *,
+    api_key: str | None = None,
+    azure_ad_token_provider: Callable[[], str] | None = None,
+    resource: str | None = None,
+    base_url: str | None = None,
+    timeout: float | None = None,
+    max_retries: int | None = None,
+) -> "anthropic.AsyncAnthropicFoundry":
+    """Create an anthropic.AsyncAnthropicFoundry client, lazily importing the SDK."""
+    import anthropic  # noqa: PLC0415
+
+    kwargs = _foundry_client_kwargs(
+        api_key=api_key,
+        azure_ad_token_provider=azure_ad_token_provider,
+        resource=resource,
+        base_url=base_url,
+        timeout=timeout,
+        max_retries=max_retries,
+    )
+    return anthropic.AsyncAnthropicFoundry(**kwargs)

--- a/packages/lmux-anthropic/src/lmux_anthropic/auth.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/auth.py
@@ -1,6 +1,7 @@
-"""Auth providers for the Anthropic API and Claude on Vertex AI."""
+"""Auth providers for the Anthropic API, Claude on Vertex AI, and Claude in Microsoft Foundry."""
 
 import os
+from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
 from lmux.exceptions import AuthenticationError
@@ -79,3 +80,36 @@ class AnthropicVertexServiceAccountAuthProvider:
 
     async def aget_credentials(self) -> "tuple[Credentials, str | None]":
         return self.get_credentials()
+
+
+class AnthropicFoundryEnvAuthProvider:
+    """Auth provider that reads the API key from the ANTHROPIC_FOUNDRY_API_KEY environment variable."""
+
+    def get_credentials(self) -> str:
+        api_key = os.environ.get("ANTHROPIC_FOUNDRY_API_KEY")
+        if api_key is None:
+            msg = "ANTHROPIC_FOUNDRY_API_KEY environment variable is not set"
+            raise AuthenticationError(msg, provider="anthropic-foundry")
+        return api_key
+
+    async def aget_credentials(self) -> str:
+        return self.get_credentials()
+
+
+class AnthropicFoundryTokenAuthProvider:
+    """Foundry auth provider that wraps a Microsoft Entra ID token provider.
+
+    Pass a callable that returns a bearer token, e.g.
+    ``azure.identity.get_bearer_token_provider(DefaultAzureCredential(),
+    "https://cognitiveservices.azure.com/.default")``. The SDK invokes the
+    callable on every request.
+    """
+
+    def __init__(self, *, token_provider: Callable[[], str]) -> None:
+        self._token_provider: Callable[[], str] = token_provider
+
+    def get_credentials(self) -> Callable[[], str]:
+        return self._token_provider
+
+    async def aget_credentials(self) -> Callable[[], str]:
+        return self._token_provider

--- a/packages/lmux-anthropic/src/lmux_anthropic/cost.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/cost.py
@@ -8,6 +8,10 @@ Vertex endpoints carry a 10% premium on Claude Sonnet 4.5/Haiku 4.5/Opus 4.5
 and all later models (see VERTEX_REGIONAL_MULTIPLIER); older models are
 priced uniformly across all endpoints. Vertex pricing reference:
 https://cloud.google.com/vertex-ai/generative-ai/pricing
+
+Claude in Microsoft Foundry bills Anthropic's standard API pricing (Global
+Standard deployments only), so this table also covers
+AnthropicFoundryProvider with no multiplier.
 """
 
 from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens

--- a/packages/lmux-anthropic/src/lmux_anthropic/provider.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/provider.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import os
-from collections.abc import AsyncIterator, Iterator, Sequence
+from collections.abc import AsyncIterator, Callable, Iterator, Sequence
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, override
 
 if TYPE_CHECKING:
@@ -15,8 +15,10 @@ from lmux.types import ChatChunk, ChatResponse, Cost, Message, ResponseFormat, T
 from lmux_anthropic._exceptions import map_anthropic_error
 from lmux_anthropic._lazy import (
     create_async_client,
+    create_async_foundry_client,
     create_async_vertex_client,
     create_sync_client,
+    create_sync_foundry_client,
     create_sync_vertex_client,
 )
 from lmux_anthropic._mappers import (
@@ -30,7 +32,11 @@ from lmux_anthropic._mappers import (
     map_tool_choice,
     map_tools,
 )
-from lmux_anthropic.auth import AnthropicEnvAuthProvider, AnthropicVertexADCAuthProvider
+from lmux_anthropic.auth import (
+    AnthropicEnvAuthProvider,
+    AnthropicFoundryEnvAuthProvider,
+    AnthropicVertexADCAuthProvider,
+)
 from lmux_anthropic.cost import (
     US_INFERENCE_MULTIPLIER,
     VERTEX_REGIONAL_MULTIPLIER,
@@ -42,14 +48,21 @@ from lmux_anthropic.params import AnthropicParams
 
 PROVIDER_NAME = "anthropic"
 VERTEX_PROVIDER_NAME = "anthropic-vertex"
+FOUNDRY_PROVIDER_NAME = "anthropic-foundry"
 DEFAULT_MAX_TOKENS = 4096
 
-type SyncAnthropicClient = "anthropic.Anthropic | anthropic.AnthropicVertex"
-type AsyncAnthropicClient = "anthropic.AsyncAnthropic | anthropic.AsyncAnthropicVertex"
+type SyncAnthropicClient = "anthropic.Anthropic | anthropic.AnthropicVertex | anthropic.AnthropicFoundry"
+type AsyncAnthropicClient = (
+    "anthropic.AsyncAnthropic | anthropic.AsyncAnthropicVertex | anthropic.AsyncAnthropicFoundry"
+)
 
 # Vertex auth providers may return bare credentials, or credentials together
 # with the project ID they resolved (e.g. from ADC or a service account file).
 type VertexAuthResult = "Credentials | tuple[Credentials, str | None]"
+
+# Foundry auth providers return an API key, or a Microsoft Entra ID bearer
+# token provider that the SDK invokes on every request.
+type FoundryAuthResult = "str | Callable[[], str]"
 
 
 class AnthropicProvider(
@@ -509,4 +522,83 @@ class AnthropicVertexProvider(AnthropicProvider):
             return 1.0
         if has_vertex_regional_premium(model):
             return VERTEX_REGIONAL_MULTIPLIER
+        return 1.0
+
+
+class AnthropicFoundryProvider(AnthropicProvider):
+    """Claude in Microsoft Foundry provider.
+
+    Reuses the Anthropic API request/response handling unchanged; only client
+    creation and auth differ. ``service_tier`` and ``inference_geo`` are
+    Anthropic-API-only parameters and are dropped from outgoing requests; the
+    US-inference cost multiplier never applies.
+    """
+
+    _provider_name: ClassVar[str] = FOUNDRY_PROVIDER_NAME
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        auth: AuthProvider["FoundryAuthResult"] | None = None,
+        resource: str | None = None,
+        base_url: str | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        default_max_tokens: int = DEFAULT_MAX_TOKENS,
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            timeout=timeout,
+            max_retries=max_retries,
+            default_max_tokens=default_max_tokens,
+        )
+        self._foundry_auth: AuthProvider[FoundryAuthResult] = auth or AnthropicFoundryEnvAuthProvider()
+        self._resource: str | None = resource
+
+    @staticmethod
+    def _split_foundry_auth(auth_result: "FoundryAuthResult") -> "tuple[str | None, Callable[[], str] | None]":
+        if isinstance(auth_result, str):
+            return auth_result, None
+        return None, auth_result
+
+    @override
+    def _create_sync_client(self) -> "anthropic.AnthropicFoundry":
+        api_key, azure_ad_token_provider = self._split_foundry_auth(self._foundry_auth.get_credentials())
+        return create_sync_foundry_client(
+            api_key=api_key,
+            azure_ad_token_provider=azure_ad_token_provider,
+            resource=self._resource,
+            base_url=self._base_url,
+            timeout=self._timeout,
+            max_retries=self._max_retries,
+        )
+
+    @override
+    async def _create_async_client(self) -> "anthropic.AsyncAnthropicFoundry":
+        api_key, azure_ad_token_provider = self._split_foundry_auth(await self._foundry_auth.aget_credentials())
+        return create_async_foundry_client(
+            api_key=api_key,
+            azure_ad_token_provider=azure_ad_token_provider,
+            resource=self._resource,
+            base_url=self._base_url,
+            timeout=self._timeout,
+            max_retries=self._max_retries,
+        )
+
+    @staticmethod
+    @override
+    def _provider_params_kwargs(params: AnthropicParams) -> dict[str, Any]:
+        """Convert AnthropicParams to SDK kwargs, dropping Anthropic-API-only parameters."""
+        kwargs = AnthropicProvider._provider_params_kwargs(params)
+        kwargs.pop("service_tier", None)
+        kwargs.pop("inference_geo", None)
+        return kwargs
+
+    @override
+    def _cost_multiplier(self, model: str, provider_params: AnthropicParams | None) -> float:
+        """Foundry bills Anthropic's standard API pricing (Global Standard deployments only).
+
+        ``inference_geo`` is Anthropic-API-only and never contributes a
+        multiplier here.
+        """
         return 1.0

--- a/packages/lmux-anthropic/tests/test_auth.py
+++ b/packages/lmux-anthropic/tests/test_auth.py
@@ -8,6 +8,8 @@ from pytest_mock import MockerFixture
 from lmux.exceptions import AuthenticationError
 from lmux_anthropic.auth import (
     AnthropicEnvAuthProvider,
+    AnthropicFoundryEnvAuthProvider,
+    AnthropicFoundryTokenAuthProvider,
     AnthropicVertexADCAuthProvider,
     AnthropicVertexServiceAccountAuthProvider,
 )
@@ -114,3 +116,38 @@ class TestAnthropicVertexServiceAccountAuthProvider:
         provider = AnthropicVertexServiceAccountAuthProvider(service_account_file="/path/to/key.json")
         with pytest.raises(ImportError, match=r"\[vertex\] extra group is required"):
             _ = provider.get_credentials()
+
+
+class TestAnthropicFoundryEnvAuthProvider:
+    def test_get_credentials_returns_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "foundry-test-key")
+        provider = AnthropicFoundryEnvAuthProvider()
+        assert provider.get_credentials() == "foundry-test-key"
+
+    def test_get_credentials_raises_when_not_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_FOUNDRY_API_KEY", raising=False)
+        provider = AnthropicFoundryEnvAuthProvider()
+        with pytest.raises(AuthenticationError, match="ANTHROPIC_FOUNDRY_API_KEY") as exc_info:
+            _ = provider.get_credentials()
+        assert exc_info.value.provider == "anthropic-foundry"
+
+    async def test_aget_credentials_returns_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_API_KEY", "foundry-test-key")
+        provider = AnthropicFoundryEnvAuthProvider()
+        assert await provider.aget_credentials() == "foundry-test-key"
+
+
+class TestAnthropicFoundryTokenAuthProvider:
+    def test_get_credentials_returns_token_provider(self) -> None:
+        def token_provider() -> str:
+            return "entra-token"  # pragma: no cover
+
+        provider = AnthropicFoundryTokenAuthProvider(token_provider=token_provider)
+        assert provider.get_credentials() is token_provider
+
+    async def test_aget_credentials_returns_token_provider(self) -> None:
+        def token_provider() -> str:
+            return "entra-token"  # pragma: no cover
+
+        provider = AnthropicFoundryTokenAuthProvider(token_provider=token_provider)
+        assert await provider.aget_credentials() is token_provider

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -1,6 +1,7 @@
 """Tests for Anthropic provider."""
 
 import asyncio
+from collections.abc import Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -25,9 +26,9 @@ from lmux.types import (
     UserMessage,
 )
 from lmux_anthropic import preload
-from lmux_anthropic.auth import AnthropicVertexADCAuthProvider
+from lmux_anthropic.auth import AnthropicFoundryEnvAuthProvider, AnthropicVertexADCAuthProvider
 from lmux_anthropic.params import AnthropicParams
-from lmux_anthropic.provider import AnthropicProvider, AnthropicVertexProvider
+from lmux_anthropic.provider import AnthropicFoundryProvider, AnthropicProvider, AnthropicVertexProvider
 
 # MARK: Shared Fixtures
 
@@ -1436,3 +1437,250 @@ class TestVertexClientManagement:
     def test_default_auth_is_adc(self) -> None:
         provider = AnthropicVertexProvider()
         assert isinstance(provider._vertex_auth, AnthropicVertexADCAuthProvider)  # pyright: ignore[reportPrivateUsage]
+
+
+# MARK: Foundry
+
+
+class FakeFoundryAuth:
+    """Fake Foundry auth provider returning an API key."""
+
+    def get_credentials(self) -> str:
+        return "foundry-key"
+
+    async def aget_credentials(self) -> str:
+        return "foundry-key"
+
+
+class FakeFoundryTokenAuth:
+    """Fake Foundry auth provider returning an Entra ID token-provider callable."""
+
+    def __init__(self) -> None:
+        def _token_provider() -> str:
+            return "entra-token"  # pragma: no cover
+
+        self.token_provider: Callable[[], str] = _token_provider
+
+    def get_credentials(self) -> Callable[[], str]:
+        return self.token_provider
+
+    async def aget_credentials(self) -> Callable[[], str]:
+        return self.token_provider
+
+
+@pytest.fixture
+def fake_foundry_auth() -> FakeFoundryAuth:
+    return FakeFoundryAuth()
+
+
+@pytest.fixture
+def mock_sync_foundry_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_anthropic.provider.create_sync_foundry_client", return_value=mock_sync_client)
+
+
+@pytest.fixture
+def mock_async_foundry_create(mock_async_client: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_anthropic.provider.create_async_foundry_client", return_value=mock_async_client)
+
+
+@pytest.fixture
+def foundry_sync_provider(
+    fake_foundry_auth: FakeFoundryAuth, mock_sync_foundry_create: MagicMock
+) -> AnthropicFoundryProvider:
+    assert mock_sync_foundry_create  # fixture activates the patch
+    return AnthropicFoundryProvider(auth=fake_foundry_auth, resource="my-resource")
+
+
+@pytest.fixture
+def foundry_async_provider(
+    fake_foundry_auth: FakeFoundryAuth, mock_async_foundry_create: MagicMock
+) -> AnthropicFoundryProvider:
+    assert mock_async_foundry_create  # fixture activates the patch
+    return AnthropicFoundryProvider(auth=fake_foundry_auth, resource="my-resource")
+
+
+class TestFoundryChat:
+    def test_basic_chat(
+        self,
+        foundry_sync_provider: AnthropicFoundryProvider,
+        mock_sync_client: MagicMock,
+        mock_sync_create: MagicMock,
+        message_response: MagicMock,
+    ) -> None:
+        mock_sync_client.messages.create.return_value = message_response
+
+        result = foundry_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+
+        assert result.content == "Hello!"
+        assert result.provider == "anthropic-foundry"
+        assert result.cost is not None
+        mock_sync_client.messages.create.assert_called_once()
+        mock_sync_create.assert_not_called()  # the Anthropic API client factory must never be used
+
+    def test_api_only_params_dropped(
+        self,
+        foundry_sync_provider: AnthropicFoundryProvider,
+        mock_sync_client: MagicMock,
+        message_response: MagicMock,
+    ) -> None:
+        """service_tier and inference_geo are Anthropic-API-only and must not reach Foundry."""
+        mock_sync_client.messages.create.return_value = message_response
+
+        _ = foundry_sync_provider.chat(
+            "claude-sonnet-4-6",
+            [UserMessage(content="Hi")],
+            provider_params=AnthropicParams(
+                thinking={"type": "enabled", "budget_tokens": 1024},
+                top_k=40,
+                service_tier="auto",
+                inference_geo="us",
+            ),
+        )
+
+        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
+        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+        assert call_kwargs["top_k"] == 40
+        assert "service_tier" not in call_kwargs
+        assert "inference_geo" not in call_kwargs
+
+    def test_inference_geo_multiplier_not_applied(
+        self,
+        foundry_sync_provider: AnthropicFoundryProvider,
+        mock_sync_client: MagicMock,
+        message_response: MagicMock,
+    ) -> None:
+        """Foundry bills Anthropic list prices; no multiplier ever applies."""
+        mock_sync_client.messages.create.return_value = message_response
+
+        result_standard = foundry_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+        result_us = foundry_sync_provider.chat(
+            "claude-sonnet-4-6",
+            [UserMessage(content="Hi")],
+            provider_params=AnthropicParams(inference_geo="us"),
+        )
+
+        assert result_standard.cost is not None
+        assert result_us.cost is not None
+        assert result_us.cost.total_cost == result_standard.cost.total_cost
+
+    def test_chat_exception_reports_foundry_provider(
+        self,
+        foundry_sync_provider: AnthropicFoundryProvider,
+        mock_sync_client: MagicMock,
+        bad_request_error: anthropic.BadRequestError,
+    ) -> None:
+        mock_sync_client.messages.create.side_effect = bad_request_error
+
+        with pytest.raises(InvalidRequestError) as exc_info:
+            _ = foundry_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+
+        assert exc_info.value.provider == "anthropic-foundry"
+
+
+class TestFoundryAchat:
+    async def test_basic_achat(
+        self,
+        foundry_async_provider: AnthropicFoundryProvider,
+        mock_async_client: MagicMock,
+        message_response: MagicMock,
+    ) -> None:
+        mock_async_client.messages.create.return_value = message_response
+
+        result = await foundry_async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+
+        assert result.content == "Hello!"
+        assert result.provider == "anthropic-foundry"
+        mock_async_client.messages.create.assert_awaited_once()
+
+
+class TestFoundryClientManagement:
+    def test_factory_receives_api_key_auth(
+        self,
+        foundry_sync_provider: AnthropicFoundryProvider,
+        mock_sync_foundry_create: MagicMock,
+        mock_sync_client: MagicMock,
+        message_response: MagicMock,
+    ) -> None:
+        mock_sync_client.messages.create.return_value = message_response
+
+        _ = foundry_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+
+        mock_sync_foundry_create.assert_called_once_with(
+            api_key="foundry-key",
+            azure_ad_token_provider=None,
+            resource="my-resource",
+            base_url=None,
+            timeout=None,
+            max_retries=None,
+        )
+
+    def test_factory_receives_token_provider_auth(
+        self,
+        mock_sync_foundry_create: MagicMock,
+        mock_sync_client: MagicMock,
+        message_response: MagicMock,
+    ) -> None:
+        mock_sync_client.messages.create.return_value = message_response
+        token_auth = FakeFoundryTokenAuth()
+        provider = AnthropicFoundryProvider(auth=token_auth, resource="my-resource")
+
+        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+
+        mock_sync_foundry_create.assert_called_once_with(
+            api_key=None,
+            azure_ad_token_provider=token_auth.token_provider,
+            resource="my-resource",
+            base_url=None,
+            timeout=None,
+            max_retries=None,
+        )
+
+    def test_factory_receives_overrides(
+        self,
+        fake_foundry_auth: FakeFoundryAuth,
+        mock_sync_foundry_create: MagicMock,
+        mock_sync_client: MagicMock,
+        message_response: MagicMock,
+    ) -> None:
+        mock_sync_client.messages.create.return_value = message_response
+        provider = AnthropicFoundryProvider(
+            auth=fake_foundry_auth,
+            base_url="https://example-resource.services.ai.azure.com/anthropic/",
+            timeout=30.0,
+            max_retries=5,
+        )
+
+        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+
+        mock_sync_foundry_create.assert_called_once_with(
+            api_key="foundry-key",
+            azure_ad_token_provider=None,
+            resource=None,
+            base_url="https://example-resource.services.ai.azure.com/anthropic/",
+            timeout=30.0,
+            max_retries=5,
+        )
+
+    async def test_async_factory_receives_api_key_auth(
+        self,
+        foundry_async_provider: AnthropicFoundryProvider,
+        mock_async_foundry_create: MagicMock,
+        mock_async_client: MagicMock,
+        message_response: MagicMock,
+    ) -> None:
+        mock_async_client.messages.create.return_value = message_response
+
+        _ = await foundry_async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+
+        mock_async_foundry_create.assert_called_once_with(
+            api_key="foundry-key",
+            azure_ad_token_provider=None,
+            resource="my-resource",
+            base_url=None,
+            timeout=None,
+            max_retries=None,
+        )
+
+    def test_default_auth_is_env(self) -> None:
+        provider = AnthropicFoundryProvider()
+        assert isinstance(provider._foundry_auth, AnthropicFoundryEnvAuthProvider)  # pyright: ignore[reportPrivateUsage]

--- a/uv.lock
+++ b/uv.lock
@@ -808,7 +808,7 @@ requires-dist = [{ name = "pydantic", specifier = "~=2.10" }]
 
 [[package]]
 name = "lmux-anthropic"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/lmux-anthropic" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Adds `AnthropicFoundryProvider` to lmux-anthropic (0.7.0) — the Foundry sibling of `AnthropicVertexProvider`, reusing the same subclass seams. Claude in Microsoft Foundry is served via the Anthropic Messages API (`{resource}.services.ai.azure.com/anthropic/v1/*`), not Foundry's unified chat-completions API, so it belongs here rather than in lmux-azure-foundry.

- **No new dependency or extra**: the `AnthropicFoundry` clients ship in the base `anthropic` SDK; Entra ID auth takes a user-supplied token-provider callable (no azure-identity dependency).
- Auth: `AnthropicFoundryEnvAuthProvider` (`ANTHROPIC_FOUNDRY_API_KEY`, default) and `AnthropicFoundryTokenAuthProvider` wrapping an Entra bearer-token provider (scope `https://cognitiveservices.azure.com/.default`); `resource`/`base_url` fall back to the SDK's `ANTHROPIC_FOUNDRY_*` env vars.
- Pricing: per Anthropic's docs, Foundry bills Anthropic's standard API pricing (Global Standard deployments only) — the existing pricing table covers it with no multiplier; `service_tier`/`inference_geo` are dropped from requests like on Vertex.
- Responses and errors report `provider="anthropic-foundry"`.