### PR TITLE
feat(cost): date-based pricing + Claude Sonnet 5

### DIFF
--- a/packages/lmux-anthropic/src/lmux_anthropic/cost.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/cost.py
@@ -9,12 +9,16 @@ and all later models (see VERTEX_REGIONAL_MULTIPLIER); older models are
 priced uniformly across all endpoints. Vertex pricing reference:
 https://cloud.google.com/vertex-ai/generative-ai/pricing
 
-Claude in Microsoft Foundry bills Anthropic's standard API pricing (Global
-Standard deployments only), so this table also covers
-AnthropicFoundryProvider with no multiplier.
+Claude in Microsoft Foundry bills Anthropic's standard API pricing, so this
+table also covers AnthropicFoundryProvider. Global Standard deployments use
+these list prices with no multiplier; Foundry's US Data Zone Standard
+deployment type (equivalent to inference_geo "us") applies the same 1.1x
+premium as US_INFERENCE_MULTIPLIER.
 """
 
-from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
+from datetime import date
+
+from lmux.cost import ModelPricing, PricingSchedule, PricingTier, calculate_cost, per_million_tokens
 from lmux.types import Cost, Usage
 
 # Standard (global) pricing. Cache writes default to the 5-minute rate (1.25x
@@ -41,6 +45,34 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(1.00),
                 cache_creation_cost_per_token=per_million_tokens(12.50),
                 cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(20.00)},
+            ),
+        ],
+    ),
+    # Claude Sonnet 5 family — introductory pricing through 2026-08-31, then
+    # standard pricing (matching Sonnet 4.6) from 2026-09-01. Full 1M context
+    # at standard pricing, so there is no >200K tier.
+    "claude-sonnet-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.00),
+                output_cost_per_token=per_million_tokens(10.00),
+                cache_read_cost_per_token=per_million_tokens(0.20),
+                cache_creation_cost_per_token=per_million_tokens(2.50),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(4.00)},
+            ),
+        ],
+        schedules=[
+            PricingSchedule(
+                valid_from=date(2026, 9, 1),
+                tiers=[
+                    PricingTier(
+                        input_cost_per_token=per_million_tokens(3.00),
+                        output_cost_per_token=per_million_tokens(15.00),
+                        cache_read_cost_per_token=per_million_tokens(0.30),
+                        cache_creation_cost_per_token=per_million_tokens(3.75),
+                        cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(6.00)},
+                    ),
+                ],
             ),
         ],
     ),
@@ -258,6 +290,7 @@ _VERTEX_UNIFORM_PRICING_MODELS = (
 _VERTEX_PREMIUM_PRICING_MODELS = (
     "claude-fable-5",
     "claude-mythos-5",
+    "claude-sonnet-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
@@ -288,8 +321,13 @@ def has_vertex_regional_premium(model: str) -> bool:
     return True
 
 
-def calculate_anthropic_cost(model: str, usage: Usage) -> Cost | None:
-    """Calculate cost for an Anthropic API call. Returns None if model pricing is unknown."""
+def calculate_anthropic_cost(model: str, usage: Usage, as_of: date | None = None) -> Cost | None:
+    """Calculate cost for an Anthropic API call. Returns None if model pricing is unknown.
+
+    ``as_of`` selects dated pricing for models with scheduled rate changes
+    (e.g. Claude Sonnet 5's introductory period); it defaults to the latest
+    schedule. See ``lmux.cost.calculate_cost``.
+    """
     pricing = _PRICING.get(model)
     if pricing is None:
         for prefix, p in _PRICING_BY_PREFIX:
@@ -298,7 +336,7 @@ def calculate_anthropic_cost(model: str, usage: Usage) -> Cost | None:
                 break
     if pricing is None:
         return None
-    return calculate_cost(usage, pricing)
+    return calculate_cost(usage, pricing, as_of)
 
 
 def apply_cost_multiplier(cost: Cost, multiplier: float) -> Cost:

--- a/packages/lmux-anthropic/tests/test_cost.py
+++ b/packages/lmux-anthropic/tests/test_cost.py
@@ -1,5 +1,7 @@
 """Tests for Anthropic cost calculation."""
 
+from datetime import date
+
 import pytest
 
 from lmux.types import Cost, Usage
@@ -95,6 +97,42 @@ class TestCalculateAnthropicCost:
         assert cost.input_cost == pytest.approx(500_000 * 5.0 / 1_000_000)
         assert cost.output_cost == pytest.approx(1000 * 25.0 / 1_000_000)
 
+    def test_sonnet_5_introductory_pricing_before_sep_2026(self) -> None:
+        """Before 2026-09-01, Claude Sonnet 5 bills at the introductory rate."""
+        usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=200, cache_creation_tokens=100)
+        cost = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 7, 1))
+        assert cost is not None
+        assert cost.input_cost == pytest.approx((1000 - 200 - 100) * 2.0 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 10.0 / 1_000_000)
+        assert cost.cache_read_cost == pytest.approx(200 * 0.20 / 1_000_000)
+        assert cost.cache_creation_cost == pytest.approx(100 * 2.50 / 1_000_000)
+
+    def test_sonnet_5_standard_pricing_from_sep_2026(self) -> None:
+        """On/after 2026-09-01, Claude Sonnet 5 bills at the standard rate."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        cost = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 9, 1))
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1000 * 3.0 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 15.0 / 1_000_000)
+
+    def test_sonnet_5_defaults_to_standard_pricing(self) -> None:
+        """With no ``as_of``, Claude Sonnet 5 bills at the latest (standard) schedule."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        cost = calculate_anthropic_cost("claude-sonnet-5", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1000 * 3.0 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 15.0 / 1_000_000)
+
+    def test_sonnet_5_per_ttl_cache_write_rates_differ_by_schedule(self) -> None:
+        """The 1h cache-write rate is $4.00/M introductory and $6.00/M standard."""
+        usage = Usage(input_tokens=1000, output_tokens=0, cache_creation_tokens_by_ttl={"1h": 1000})
+        intro = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 7, 1))
+        standard = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 9, 1))
+        assert intro is not None
+        assert standard is not None
+        assert intro.cache_creation_cost == pytest.approx(1000 * 4.0 / 1_000_000)
+        assert standard.cache_creation_cost == pytest.approx(1000 * 6.0 / 1_000_000)
+
 
 class TestApplyCostMultiplier:
     def test_applies_multiplier_to_all_fields(self) -> None:
@@ -137,4 +175,4 @@ class TestHasVertexRegionalPremium:
         assert has_vertex_regional_premium("claude-opus-4@20250514") is False
 
     def test_unknown_future_models_default_to_premium(self) -> None:
-        assert has_vertex_regional_premium("claude-sonnet-5") is True
+        assert has_vertex_regional_premium("claude-sonnet-6") is True

--- a/packages/lmux/README.md
+++ b/packages/lmux/README.md
@@ -26,8 +26,9 @@ You don't need to install this directly; provider packages (e.g., `lmux-openai`)
 - `Usage`: token counts (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`)
 - `Cost`: cost breakdown (`input_cost`, `output_cost`, `total_cost`, plus cache costs)
 - `ModelPricing` / `PricingTier`: tiered pricing configuration
+- `PricingSchedule`: dated price overrides for models whose rate changes on a known date (e.g. an introductory rate)
 - `per_million_tokens()`: converts per-million price to per-token price
-- `calculate_cost()`: calculates cost from usage and pricing
+- `calculate_cost()`: calculates cost from usage and pricing; pass `as_of=<date>` to bill at the rate in effect on that day (defaults to the latest schedule)
 
 ### Tools
 

--- a/packages/lmux/src/lmux/__init__.py
+++ b/packages/lmux/src/lmux/__init__.py
@@ -1,6 +1,6 @@
 """lmux — Modular Python language model multiplexer."""
 
-from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
+from lmux.cost import ModelPricing, PricingSchedule, PricingTier, calculate_cost, per_million_tokens
 from lmux.exceptions import (
     AuthenticationError,
     InvalidRequestError,
@@ -87,6 +87,7 @@ __all__ = [
     "ModelPricing",
     "NotFoundError",
     "PricingProvider",
+    "PricingSchedule",
     "PricingTier",
     "Provider",
     "ProviderError",

--- a/packages/lmux/src/lmux/cost.py
+++ b/packages/lmux/src/lmux/cost.py
@@ -1,5 +1,7 @@
 """Cost calculation utility functions."""
 
+from datetime import date
+
 from pydantic import BaseModel, model_validator
 
 from lmux.types import Cost, Usage
@@ -27,33 +29,101 @@ class PricingTier(BaseModel):
     min_input_tokens: int = 0
 
 
-class ModelPricing(BaseModel):
-    """Pricing data for a specific model.
+def _validate_tiers(tiers: list[PricingTier]) -> None:
+    """Validate a token-count tier list: non-empty, base tier first, strictly ascending thresholds."""
+    if not tiers:
+        msg = "tiers must not be empty"
+        raise ValueError(msg)
+    if tiers[0].min_input_tokens != 0:
+        msg = "first tier must have min_input_tokens == 0 (base tier)"
+        raise ValueError(msg)
+    for i in range(1, len(tiers)):
+        if tiers[i].min_input_tokens <= tiers[i - 1].min_input_tokens:
+            msg = "tiers must be ordered by strictly ascending min_input_tokens"
+            raise ValueError(msg)
 
-    ``tiers`` must contain at least one entry with ``min_input_tokens == 0``
-    (the base tier).  Additional tiers define premium rates that apply when
-    the total input token count exceeds their ``min_input_tokens`` threshold.
-    Tiers must be ordered by ascending ``min_input_tokens``.
+
+class PricingSchedule(BaseModel):
+    """A dated pricing override that takes effect on ``valid_from``.
+
+    A schedule's ``tiers`` follow the same rules as ``ModelPricing.tiers`` (a
+    base tier with ``min_input_tokens == 0`` plus optional higher tiers).
+    Schedules live in ``ModelPricing.schedules``; each one supersedes the
+    model's base pricing from its ``valid_from`` date until the next schedule's
+    ``valid_from``.
     """
 
+    valid_from: date
     tiers: list[PricingTier]
 
     @model_validator(mode="after")
-    def _validate_tiers(self) -> "ModelPricing":
-        if not self.tiers:
-            msg = "tiers must not be empty"
-            raise ValueError(msg)
-        if self.tiers[0].min_input_tokens != 0:
-            msg = "first tier must have min_input_tokens == 0 (base tier)"
-            raise ValueError(msg)
-        for i in range(1, len(self.tiers)):
-            if self.tiers[i].min_input_tokens <= self.tiers[i - 1].min_input_tokens:
-                msg = "tiers must be ordered by strictly ascending min_input_tokens"
-                raise ValueError(msg)
+    def _validate(self) -> "PricingSchedule":
+        _validate_tiers(self.tiers)
         return self
 
 
-def _resolve_tier(usage: Usage, pricing: ModelPricing) -> PricingTier:
+def _validate_schedules(schedules: list[PricingSchedule]) -> None:
+    """Validate dated schedules: non-empty and ordered by strictly ascending ``valid_from``."""
+    if not schedules:
+        msg = "schedules must not be empty when provided"
+        raise ValueError(msg)
+    previous = schedules[0].valid_from
+    for schedule in schedules[1:]:
+        if schedule.valid_from <= previous:
+            msg = "schedules must be ordered by strictly ascending valid_from"
+            raise ValueError(msg)
+        previous = schedule.valid_from
+
+
+class ModelPricing(BaseModel):
+    """Pricing data for a specific model.
+
+    ``tiers`` is the base pricing and must contain at least one entry with
+    ``min_input_tokens == 0`` (the base tier).  Additional tiers define premium
+    rates that apply when the total input token count exceeds their
+    ``min_input_tokens`` threshold; tiers must be ordered by ascending
+    ``min_input_tokens``.
+
+    ``schedules`` holds optional *dated* overrides for models whose price
+    changes on a known date (e.g. an introductory rate that later rises to a
+    standard rate).  Each schedule supersedes ``tiers`` from its ``valid_from``
+    onward; ``calculate_cost``'s ``as_of`` argument selects which schedule
+    applies (defaulting to the latest).  Schedules must be ordered by strictly
+    ascending ``valid_from``.
+    """
+
+    tiers: list[PricingTier]
+    schedules: list[PricingSchedule] | None = None
+
+    @model_validator(mode="after")
+    def _validate(self) -> "ModelPricing":
+        _validate_tiers(self.tiers)
+        if self.schedules is not None:
+            _validate_schedules(self.schedules)
+        return self
+
+
+def _active_tiers(pricing: ModelPricing, as_of: date | None) -> list[PricingTier]:
+    """Resolve the tier list in effect for ``as_of``.
+
+    Models without ``schedules`` always use their base ``tiers``.  For dated
+    models, ``as_of=None`` selects the latest schedule; otherwise the latest
+    schedule whose ``valid_from`` is on or before ``as_of`` wins, falling back
+    to the base ``tiers`` when ``as_of`` predates every schedule.
+    """
+    schedules = pricing.schedules
+    if schedules is None:
+        return pricing.tiers
+    if as_of is None:
+        return schedules[-1].tiers
+    tiers = pricing.tiers
+    for schedule in schedules:
+        if schedule.valid_from <= as_of:
+            tiers = schedule.tiers
+    return tiers
+
+
+def _resolve_tier(usage: Usage, tiers: list[PricingTier]) -> PricingTier:
     """Return the highest-threshold tier whose ``min_input_tokens`` is exceeded by the total input.
 
     A tier with ``min_input_tokens=200_000`` applies when ``total_input > 200_000``,
@@ -62,15 +132,15 @@ def _resolve_tier(usage: Usage, pricing: ModelPricing) -> PricingTier:
     total_input = usage.input_tokens
 
     # Iterate tiers in descending min_input_tokens order; pick the first one whose threshold is exceeded.
-    for tier in sorted(pricing.tiers, key=lambda t: t.min_input_tokens, reverse=True):
+    for tier in sorted(tiers, key=lambda t: t.min_input_tokens, reverse=True):
         if total_input > tier.min_input_tokens:
             return tier
 
     # The validated base tier (min_input_tokens == 0) guarantees a match for total_input == 0.
-    return pricing.tiers[0]
+    return tiers[0]
 
 
-def calculate_cost(usage: Usage, pricing: ModelPricing) -> Cost:
+def calculate_cost(usage: Usage, pricing: ModelPricing, as_of: date | None = None) -> Cost:
     """Calculate the monetary cost from token usage and per-token prices.
 
     ``usage.input_tokens`` is the **total** prompt token count (see ``Usage``
@@ -85,11 +155,15 @@ def calculate_cost(usage: Usage, pricing: ModelPricing) -> Cost:
     When ``pricing`` includes multiple tiers and the total input tokens
     exceed a tier's ``min_input_tokens`` threshold, the higher rates
     are used for all tokens in the request.
+
+    ``as_of`` selects the pricing schedule for models with dated ``schedules``
+    (see ``ModelPricing``).  It defaults to ``None``, which uses the latest
+    schedule; pass a ``date`` to bill at the rate in effect on that day.
     """
     cache_read_tokens = usage.cache_read_tokens or 0
     cache_creation_tokens = _total_cache_creation_tokens(usage)
 
-    tier = _resolve_tier(usage, pricing)
+    tier = _resolve_tier(usage, _active_tiers(pricing, as_of))
 
     # Cached tokens are a subset of input_tokens — bill them at their own rate,
     # not the full input rate.

--- a/packages/lmux/tests/test_cost.py
+++ b/packages/lmux/tests/test_cost.py
@@ -1,9 +1,35 @@
 """Tests for lmux cost calculation utilities."""
 
+from datetime import date
+
 import pytest
 
-from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
+from lmux.cost import ModelPricing, PricingSchedule, PricingTier, calculate_cost, per_million_tokens
 from lmux.types import Usage
+
+
+@pytest.fixture
+def dated_pricing() -> ModelPricing:
+    """A model with introductory base pricing and a dated standard-rate override."""
+    return ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.00),
+                output_cost_per_token=per_million_tokens(10.00),
+            )
+        ],
+        schedules=[
+            PricingSchedule(
+                valid_from=date(2026, 9, 1),
+                tiers=[
+                    PricingTier(
+                        input_cost_per_token=per_million_tokens(3.00),
+                        output_cost_per_token=per_million_tokens(15.00),
+                    )
+                ],
+            )
+        ],
+    )
 
 
 class TestPerMillionTokens:
@@ -36,6 +62,20 @@ class TestPricingTier:
         )
         assert tier.cache_read_cost_per_token == 0.0000003
         assert tier.cache_creation_cost_per_token == 0.00000375
+
+
+class TestPricingSchedule:
+    def test_basic(self) -> None:
+        schedule = PricingSchedule(
+            valid_from=date(2026, 9, 1),
+            tiers=[PricingTier(input_cost_per_token=0.000003, output_cost_per_token=0.000015)],
+        )
+        assert schedule.valid_from == date(2026, 9, 1)
+        assert schedule.tiers[0].input_cost_per_token == 0.000003
+
+    def test_invalid_tiers_rejected(self) -> None:
+        with pytest.raises(ValueError, match="tiers must not be empty"):
+            _ = PricingSchedule(valid_from=date(2026, 9, 1), tiers=[])
 
 
 class TestModelPricing:
@@ -101,6 +141,53 @@ class TestModelPricing:
                     PricingTier(input_cost_per_token=0.000003, output_cost_per_token=0.000015),
                     PricingTier(input_cost_per_token=0.000006, output_cost_per_token=0.00003, min_input_tokens=200_000),
                     PricingTier(input_cost_per_token=0.000009, output_cost_per_token=0.00004, min_input_tokens=200_000),
+                ],
+            )
+
+    def test_with_single_schedule(self, dated_pricing: ModelPricing) -> None:
+        assert dated_pricing.schedules is not None
+        assert len(dated_pricing.schedules) == 1
+        assert dated_pricing.schedules[0].valid_from == date(2026, 9, 1)
+        # The base ``tiers`` are unaffected by the dated override.
+        assert dated_pricing.tiers[0].input_cost_per_token == per_million_tokens(2.00)
+
+    def test_with_multiple_schedules(self) -> None:
+        p = ModelPricing(
+            tiers=[PricingTier(input_cost_per_token=0.000002, output_cost_per_token=0.00001)],
+            schedules=[
+                PricingSchedule(
+                    valid_from=date(2026, 9, 1),
+                    tiers=[PricingTier(input_cost_per_token=0.000003, output_cost_per_token=0.000015)],
+                ),
+                PricingSchedule(
+                    valid_from=date(2027, 1, 1),
+                    tiers=[PricingTier(input_cost_per_token=0.000004, output_cost_per_token=0.00002)],
+                ),
+            ],
+        )
+        assert p.schedules is not None
+        assert [s.valid_from for s in p.schedules] == [date(2026, 9, 1), date(2027, 1, 1)]
+
+    def test_empty_schedules_rejected(self) -> None:
+        with pytest.raises(ValueError, match="schedules must not be empty when provided"):
+            _ = ModelPricing(
+                tiers=[PricingTier(input_cost_per_token=0.000002, output_cost_per_token=0.00001)],
+                schedules=[],
+            )
+
+    def test_unordered_schedules_rejected(self) -> None:
+        with pytest.raises(ValueError, match="schedules must be ordered by strictly ascending valid_from"):
+            _ = ModelPricing(
+                tiers=[PricingTier(input_cost_per_token=0.000002, output_cost_per_token=0.00001)],
+                schedules=[
+                    PricingSchedule(
+                        valid_from=date(2026, 9, 1),
+                        tiers=[PricingTier(input_cost_per_token=0.000003, output_cost_per_token=0.000015)],
+                    ),
+                    PricingSchedule(
+                        valid_from=date(2026, 9, 1),
+                        tiers=[PricingTier(input_cost_per_token=0.000004, output_cost_per_token=0.00002)],
+                    ),
                 ],
             )
 
@@ -389,3 +476,59 @@ class TestCalculateCost:
         usage = Usage(input_tokens=100, output_tokens=10)
         cost = calculate_cost(usage, pricing)
         assert cost.cache_creation_cost is None
+
+    def test_as_of_none_uses_latest_schedule(self, dated_pricing: ModelPricing) -> None:
+        """With no ``as_of``, the latest schedule (standard rate) applies."""
+        cost = calculate_cost(Usage(input_tokens=1_000_000, output_tokens=0), dated_pricing)
+        assert cost.input_cost == pytest.approx(per_million_tokens(3.00) * 1_000_000)
+
+    def test_as_of_before_override_uses_base(self, dated_pricing: ModelPricing) -> None:
+        """An ``as_of`` before every schedule's ``valid_from`` falls back to the base tiers."""
+        cost = calculate_cost(Usage(input_tokens=1_000_000, output_tokens=0), dated_pricing, as_of=date(2026, 7, 1))
+        assert cost.input_cost == pytest.approx(per_million_tokens(2.00) * 1_000_000)
+
+    def test_as_of_on_override_date_uses_override(self, dated_pricing: ModelPricing) -> None:
+        """An ``as_of`` on the override's ``valid_from`` uses the override (boundary is inclusive)."""
+        cost = calculate_cost(Usage(input_tokens=1_000_000, output_tokens=0), dated_pricing, as_of=date(2026, 9, 1))
+        assert cost.input_cost == pytest.approx(per_million_tokens(3.00) * 1_000_000)
+
+    def test_as_of_ignored_without_schedules(self) -> None:
+        """``as_of`` has no effect on a model without dated schedules."""
+        pricing = ModelPricing(
+            tiers=[PricingTier(input_cost_per_token=per_million_tokens(2.00), output_cost_per_token=0.0)]
+        )
+        cost = calculate_cost(Usage(input_tokens=1_000_000, output_tokens=0), pricing, as_of=date(2026, 9, 1))
+        assert cost.input_cost == pytest.approx(per_million_tokens(2.00) * 1_000_000)
+
+    def test_resolves_among_multiple_schedules(self) -> None:
+        """With 3+ schedules, the latest whose ``valid_from`` is on or before ``as_of`` wins."""
+        # 1M input tokens means input_cost == the per-million rate, so each assertion reads as $/M.
+        usage = Usage(input_tokens=1_000_000, output_tokens=0)
+        pricing = ModelPricing(
+            tiers=[PricingTier(input_cost_per_token=per_million_tokens(2.00), output_cost_per_token=0.0)],
+            schedules=[
+                PricingSchedule(
+                    valid_from=date(2026, 9, 1),
+                    tiers=[PricingTier(input_cost_per_token=per_million_tokens(3.00), output_cost_per_token=0.0)],
+                ),
+                PricingSchedule(
+                    valid_from=date(2027, 1, 1),
+                    tiers=[PricingTier(input_cost_per_token=per_million_tokens(4.00), output_cost_per_token=0.0)],
+                ),
+                PricingSchedule(
+                    valid_from=date(2027, 6, 1),
+                    tiers=[PricingTier(input_cost_per_token=per_million_tokens(5.00), output_cost_per_token=0.0)],
+                ),
+            ],
+        )
+        # Before any schedule -> base tiers ($2).
+        assert calculate_cost(usage, pricing, as_of=date(2026, 7, 1)).input_cost == pytest.approx(2.00)
+        # Strictly between the 2nd and 3rd valid_from -> 2nd schedule ($4): kills both an
+        # early-break mutant (would give $3) and an always-use-last mutant (would give $5).
+        assert calculate_cost(usage, pricing, as_of=date(2027, 3, 1)).input_cost == pytest.approx(4.00)
+        # Exactly on a non-first schedule's valid_from -> that schedule (inclusive boundary).
+        assert calculate_cost(usage, pricing, as_of=date(2027, 1, 1)).input_cost == pytest.approx(4.00)
+        # On/after the last schedule -> last schedule ($5).
+        assert calculate_cost(usage, pricing, as_of=date(2027, 6, 1)).input_cost == pytest.approx(5.00)
+        # No as_of -> latest schedule ($5).
+        assert calculate_cost(usage, pricing).input_cost == pytest.approx(5.00)


### PR DESCRIPTION
Adds date-based pricing to the cost model and ships Claude Sonnet 5.

- `PricingSchedule` + `ModelPricing.schedules`: dated price overrides, selected via `calculate_cost(usage, pricing, as_of=...)` — defaults to the latest schedule, no wall clock. Existing single-tier `ModelPricing(tiers=...)` is unchanged.
- Claude Sonnet 5: introductory pricing through 2026-08-31, then standard from 2026-09-01; added to the Vertex regional-premium set.
