### PR TITLE
chore: pricing refresh (2026-06) + bedrock unit fix

### DIFF
--- a/.agents/skills/update-pricing/SKILL.md
+++ b/.agents/skills/update-pricing/SKILL.md
@@ -19,6 +19,11 @@ For each file found:
    `Pricing source:` line. If a cost.py has no `Pricing source:` line, skip
    it and warn the user.
 
+`lmux-gcp-vertex` is a deprecated shim that re-exports its cost calculation
+from `lmux-google` — it has no pricing of its own and should **never** be
+covered. Silently exclude it from discovery (no warning); its pricing is
+already validated via `lmux-google`.
+
 Build a list of `(provider_name, cost_py_path, pricing_url)` tuples.
 
 ### Step 2: Select providers

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
@@ -487,6 +487,17 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "anthropic.claude-sonnet-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.2),
+                output_cost_per_token=per_million_tokens(11.0),
+                cache_read_cost_per_token=per_million_tokens(0.22),
+                cache_creation_cost_per_token=per_million_tokens(2.75),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(4.4)},
+            ),
+        ],
+    ),
     "anthropic.claude-v2": ModelPricing(
         tiers=[
             PricingTier(
@@ -518,6 +529,17 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(15.0),
                 cache_read_cost_per_token=per_million_tokens(0.3),
                 cache_creation_cost_per_token=per_million_tokens(3.75),
+            ),
+        ],
+    ),
+    "au.anthropic.claude-fable-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(11.0),
+                output_cost_per_token=per_million_tokens(55.0),
+                cache_read_cost_per_token=per_million_tokens(1.1),
+                cache_creation_cost_per_token=per_million_tokens(13.75),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(22.0)},
             ),
         ],
     ),
@@ -799,6 +821,17 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "global.anthropic.claude-sonnet-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.0),
+                output_cost_per_token=per_million_tokens(10.0),
+                cache_read_cost_per_token=per_million_tokens(0.2),
+                cache_creation_cost_per_token=per_million_tokens(2.5),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(4.0)},
+            ),
+        ],
+    ),
     "jp.anthropic.claude-haiku-4-5-20251001-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -854,16 +887,6 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    "us.anthropic.claude-3-5-haiku-20241022-v1": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(0.8),
-                output_cost_per_token=per_million_tokens(4.0),
-                cache_read_cost_per_token=per_million_tokens(0.08),
-                cache_creation_cost_per_token=per_million_tokens(1.0),
-            ),
-        ],
-    ),
     "us.anthropic.claude-3-haiku-20240307-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -877,6 +900,17 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(3.0),
                 output_cost_per_token=per_million_tokens(15.0),
+            ),
+        ],
+    ),
+    "us.anthropic.claude-fable-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(11.0),
+                output_cost_per_token=per_million_tokens(55.0),
+                cache_read_cost_per_token=per_million_tokens(1.1),
+                cache_creation_cost_per_token=per_million_tokens(13.75),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(22.0)},
             ),
         ],
     ),
@@ -974,6 +1008,17 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
                 cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(6.6)},
+            ),
+        ],
+    ),
+    "us.anthropic.claude-sonnet-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.2),
+                output_cost_per_token=per_million_tokens(11.0),
+                cache_read_cost_per_token=per_million_tokens(0.22),
+                cache_creation_cost_per_token=per_million_tokens(2.75),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(4.4)},
             ),
         ],
     ),
@@ -1109,6 +1154,30 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     "google.gemma-3-4b-it": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.04),
+                output_cost_per_token=per_million_tokens(0.08),
+            ),
+        ],
+    ),
+    "google.gemma-4-26b-a4b": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.13),
+                output_cost_per_token=per_million_tokens(0.4),
+            ),
+        ],
+    ),
+    "google.gemma-4-31b": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.14),
+                output_cost_per_token=per_million_tokens(0.4),
+            ),
+        ],
+    ),
+    "google.gemma-4-e2b": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.04),
@@ -1642,6 +1711,16 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(1.0),
                 output_cost_per_token=per_million_tokens(3.2),
+            ),
+        ],
+    ),
+    # -- Other ---------------------------------------------------
+    "xai.grok-4.3": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(2.5),
+                cache_read_cost_per_token=per_million_tokens(0.2),
             ),
         ],
     ),

--- a/packages/lmux-aws-bedrock/tests/test_cost.py
+++ b/packages/lmux-aws-bedrock/tests/test_cost.py
@@ -39,6 +39,23 @@ class TestCalculateBedrockCost:
         assert cost.cache_read_cost is not None
         assert cost.cache_read_cost == pytest.approx(200 * 0.2 / 1_000_000)
 
+    def test_grok_4_3_unit_corrected_pricing(self) -> None:
+        """Regression guard: grok-4.3 uses the AWS '1M tokens' unit, not the default 1000x scaling."""
+        usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=200)
+        cost = calculate_bedrock_cost("xai.grok-4.3", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(800 * 1.25 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 2.50 / 1_000_000)
+        assert cost.cache_read_cost == pytest.approx(200 * 0.20 / 1_000_000)
+
+    def test_claude_3_5_haiku_dated_key_still_prices(self) -> None:
+        """The dated 3.5 Haiku key is retained so real calls still price after AWS delisted it."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        cost = calculate_bedrock_cost("anthropic.claude-3-5-haiku-20241022-v1:0", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1000 * 0.80 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 4.00 / 1_000_000)
+
     def test_embedding_model(self) -> None:
         usage = Usage(input_tokens=100, output_tokens=0)
         cost = calculate_bedrock_cost("amazon.titan-embed-text-v2", usage)

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
@@ -15,7 +15,13 @@ from lmux.types import Cost, Usage
 # MARK: Deployment-type multipliers
 
 DATA_ZONE_MULTIPLIER = 1.1
-"""Data Zone deployments are consistently 1.1x global pricing across all models."""
+"""Commercial US/EU Data Zone Standard deployments are 1.1x global pricing.
+
+This holds uniformly across input, output, and cache for every model, and the
+US and EU Data Zone prices are identical. Non-commercial data zones are not
+modeled and run higher — the Asia-Pacific data zone is ~1.2x and the US
+Government sovereign cloud is ~1.375x; use ``register_pricing()`` for those.
+"""
 
 REGIONAL_MULTIPLIER = 1.1
 """Regional deployments are approximately 1.1x global pricing.
@@ -54,6 +60,22 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(0.40),
                 cache_read_cost_per_token=per_million_tokens(0.005),
             )
+        ],
+    ),
+    # --- OpenAI: GPT-5.5 family ---
+    "gpt-5.5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(30.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(10.00),
+                output_cost_per_token=per_million_tokens(45.00),
+                cache_read_cost_per_token=per_million_tokens(1.00),
+                min_input_tokens=272_000,
+            ),
         ],
     ),
     # --- OpenAI: GPT-5.4 family ---
@@ -390,6 +412,22 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    "deepseek-v4-pro": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.74),
+                output_cost_per_token=per_million_tokens(3.48),
+            )
+        ],
+    ),
+    "deepseek-v4-flash": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.19),
+                output_cost_per_token=per_million_tokens(0.51),
+            )
+        ],
+    ),
     # --- xAI (Grok) ---
     "grok-3": ModelPricing(
         tiers=[
@@ -410,8 +448,16 @@ _PRICING: dict[str, ModelPricing] = {
     "grok-4.2": ModelPricing(
         tiers=[
             PricingTier(
-                input_cost_per_token=per_million_tokens(2.00),
-                output_cost_per_token=per_million_tokens(6.00),
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(2.50),
+            )
+        ],
+    ),
+    "grok-4.3": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(2.50),
             )
         ],
     ),

--- a/packages/lmux-azure-foundry/tests/test_cost.py
+++ b/packages/lmux-azure-foundry/tests/test_cost.py
@@ -99,6 +99,45 @@ class TestCalculateAzureFoundryCost:
         assert cost.input_cost == pytest.approx(2.50)
         assert cost.output_cost == pytest.approx(10.00)
 
+    def test_grok_4_2_corrected_pricing(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        cost = calculate_azure_foundry_cost("grok-4.2", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1.25)
+        assert cost.output_cost == pytest.approx(2.50)
+
+    def test_grok_4_3_model(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        cost = calculate_azure_foundry_cost("grok-4.3", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1.25)
+        assert cost.output_cost == pytest.approx(2.50)
+
+    def test_deepseek_v4_models(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        pro = calculate_azure_foundry_cost("deepseek-v4-pro", usage)
+        flash = calculate_azure_foundry_cost("deepseek-v4-flash", usage)
+        assert pro is not None
+        assert flash is not None
+        assert pro.input_cost == pytest.approx(1.74)
+        assert pro.output_cost == pytest.approx(3.48)
+        assert flash.input_cost == pytest.approx(0.19)
+        assert flash.output_cost == pytest.approx(0.51)
+
+    def test_gpt_5_5_base_tier(self) -> None:
+        usage = Usage(input_tokens=100_000, output_tokens=100_000)
+        cost = calculate_azure_foundry_cost("gpt-5.5", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(100_000 * 5.00 / 1_000_000)
+        assert cost.output_cost == pytest.approx(100_000 * 30.00 / 1_000_000)
+
+    def test_gpt_5_5_long_context_tier(self) -> None:
+        usage = Usage(input_tokens=300_000, output_tokens=1000)
+        cost = calculate_azure_foundry_cost("gpt-5.5", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(300_000 * 10.00 / 1_000_000)
+        assert cost.output_cost == pytest.approx(1000 * 45.00 / 1_000_000)
+
 
 class TestApplyCostMultiplier:
     def test_applies_multiplier_to_all_fields(self) -> None:

--- a/packages/lmux-google/src/lmux_google/cost.py
+++ b/packages/lmux-google/src/lmux_google/cost.py
@@ -181,6 +181,11 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(1.25),
                 output_cost_per_token=per_million_tokens(10.00),
             ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.50),
+                output_cost_per_token=per_million_tokens(15.00),
+                min_input_tokens=200_000,
+            ),
         ],
     ),
     # ── Embedding models ───────────────────────────────────────

--- a/packages/lmux-google/tests/test_cost.py
+++ b/packages/lmux-google/tests/test_cost.py
@@ -60,6 +60,21 @@ class TestCalculateGoogleCost:
         assert cost.input_cost == pytest.approx(1000 * 0.15 / 1_000_000)
         assert cost.output_cost == 0.0
 
+    def test_computer_use_base_tier_has_no_cache_pricing(self) -> None:
+        """The dedicated computer-use key prices the base tier and has no cache rate.
+
+        gemini-2.5-pro shares the same base/>200K token rates, so the no-cache
+        signal is what distinguishes the dedicated key: if it were dropped and
+        prefix-matched to gemini-2.5-pro (cache 0.125/M), cache_read_cost would
+        be non-zero.
+        """
+        usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=200)
+        cost = calculate_google_cost("gemini-2.5-pro-computer-use-preview", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx((1000 - 200) * 1.25 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 10.00 / 1_000_000)
+        assert cost.cache_read_cost == pytest.approx(0.0)
+
     def test_computer_use_long_context_tier(self) -> None:
         """gemini-2.5-pro-computer-use-preview uses the >200K tier above 200K input tokens."""
         usage = Usage(input_tokens=250_000, output_tokens=1000)

--- a/packages/lmux-google/tests/test_cost.py
+++ b/packages/lmux-google/tests/test_cost.py
@@ -60,6 +60,14 @@ class TestCalculateGoogleCost:
         assert cost.input_cost == pytest.approx(1000 * 0.15 / 1_000_000)
         assert cost.output_cost == 0.0
 
+    def test_computer_use_long_context_tier(self) -> None:
+        """gemini-2.5-pro-computer-use-preview uses the >200K tier above 200K input tokens."""
+        usage = Usage(input_tokens=250_000, output_tokens=1000)
+        cost = calculate_google_cost("gemini-2.5-pro-computer-use-preview", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(250_000 * 2.50 / 1_000_000)
+        assert cost.output_cost == pytest.approx(1000 * 15.00 / 1_000_000)
+
     def test_zero_tokens(self) -> None:
         usage = Usage(input_tokens=0, output_tokens=0)
         cost = calculate_google_cost("gemini-2.0-flash", usage)

--- a/packages/lmux-groq/src/lmux_groq/cost.py
+++ b/packages/lmux-groq/src/lmux_groq/cost.py
@@ -70,6 +70,11 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(input_cost_per_token=per_million_tokens(0.29), output_cost_per_token=per_million_tokens(0.59))
         ],
     ),
+    "qwen/qwen3.6-27b": ModelPricing(
+        tiers=[
+            PricingTier(input_cost_per_token=per_million_tokens(0.60), output_cost_per_token=per_million_tokens(3.00))
+        ],
+    ),
     # Meta Llama 3.x family
     "llama-3.3-70b-versatile": ModelPricing(
         tiers=[

--- a/packages/lmux-groq/tests/test_cost.py
+++ b/packages/lmux-groq/tests/test_cost.py
@@ -15,6 +15,13 @@ class TestCalculateGroqCost:
         assert cost.output_cost == pytest.approx(500 * 0.79 / 1_000_000)
         assert cost.total_cost == pytest.approx(cost.input_cost + cost.output_cost)
 
+    def test_qwen3_6_model(self) -> None:
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        cost = calculate_groq_cost("qwen/qwen3.6-27b", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1000 * 0.60 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 3.00 / 1_000_000)
+
     def test_unknown_model_returns_none(self) -> None:
         usage = Usage(input_tokens=100, output_tokens=50)
         cost = calculate_groq_cost("unknown-model-xyz", usage)

--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -36,6 +36,17 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    # "cyber" tier is materially pricier than gpt-5.5, so it needs an explicit key
+    # (it would otherwise prefix-match gpt-5.5 and be under-priced).
+    "gpt-5.5-cyber": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(12.50),
+                output_cost_per_token=per_million_tokens(75.00),
+                cache_read_cost_per_token=per_million_tokens(1.25),
+            ),
+        ],
+    ),
     "gpt-5.4-pro": ModelPricing(
         tiers=[
             PricingTier(

--- a/packages/lmux-openai/tests/test_cost.py
+++ b/packages/lmux-openai/tests/test_cost.py
@@ -62,6 +62,17 @@ class TestCalculateOpenAICost:
         assert mini_cost is not None
         assert cost.total_cost == pytest.approx(mini_cost.total_cost)
 
+    def test_gpt_5_5_cyber_has_dedicated_pricing(self) -> None:
+        """gpt-5.5-cyber must use its own (pricier) rate, not prefix-match gpt-5.5."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        cyber = calculate_openai_cost("gpt-5.5-cyber", usage)
+        base = calculate_openai_cost("gpt-5.5", usage)
+        assert cyber is not None
+        assert base is not None
+        assert cyber.input_cost == pytest.approx(1000 * 12.50 / 1_000_000)
+        assert cyber.output_cost == pytest.approx(500 * 75.00 / 1_000_000)
+        assert cyber.input_cost > base.input_cost
+
 
 class TestRegionalUpliftApplies:
     @pytest.mark.parametrize(

--- a/scripts/update_bedrock_pricing.py
+++ b/scripts/update_bedrock_pricing.py
@@ -44,6 +44,7 @@ LCTX_THRESHOLD = 200_000
 FM_SERVICENAME_MAP: dict[str, str] = {
     # Anthropic Claude
     "Claude Fable 5": "anthropic.claude-fable-5-v1",
+    "Claude Sonnet 5": "anthropic.claude-sonnet-5-v1",
     "Claude Opus 4.8": "anthropic.claude-opus-4-8-v1",
     "Claude Opus 4.7": "anthropic.claude-opus-4-7-v1",
     "Claude Opus 4.6": "anthropic.claude-opus-4-6-v1",
@@ -57,7 +58,10 @@ FM_SERVICENAME_MAP: dict[str, str] = {
     "Claude 3.7 Sonnet": "anthropic.claude-3-7-sonnet-v1",
     "Claude 3.5 Sonnet v2": "anthropic.claude-3-5-sonnet-v2",
     "Claude 3.5 Sonnet": "anthropic.claude-3-5-sonnet-v1",
-    "Claude 3.5 Haiku": "anthropic.claude-3-5-haiku-v1",
+    # AWS delisted 3.5 Haiku from list_foundation_models, so the catalog resolver
+    # can no longer map a simplified key to the real dated ID. Hardcode the dated
+    # model ID directly so prefix matching still prices existing 3.5 Haiku calls.
+    "Claude 3.5 Haiku": "anthropic.claude-3-5-haiku-20241022-v1",
     "Claude 3 Opus": "anthropic.claude-3-opus-v1",
     "Claude 3 Sonnet": "anthropic.claude-3-sonnet-v1",
     "Claude 3 Haiku": "anthropic.claude-3-haiku-v1",
@@ -420,7 +424,12 @@ def fetch_pricing(service: str, region: str) -> dict[str, Any]:
 
 
 def parse_mantle_models(data: dict[str, Any]) -> dict[str, ModelPrices]:
-    """Parse mantle entries from AmazonBedrock API. Prices are per 1K tokens."""
+    """Parse mantle entries from AmazonBedrock API.
+
+    Token prices are scaled to per-million based on each dimension's ``unit``
+    (usually ``1K tokens``, but AWS ships ``1M tokens`` for some models such as
+    xAI Grok).
+    """
     products = data.get("products", {})
     terms = data.get("terms", {}).get("OnDemand", {})
     result: dict[str, ModelPrices] = {}
@@ -438,12 +447,15 @@ def parse_mantle_models(data: dict[str, Any]) -> dict[str, ModelPrices]:
         model_id = ut[prefix_end:mantle_idx]
         dimension_part = ut[mantle_idx + len("-mantle-") : -len("-standard")]
 
-        price = _get_price(sku, terms)
-        if price is None:
+        priced = _get_price_with_unit(sku, terms)
+        if priced is None:
             continue
+        price, unit = priced
 
-        # Prices are per 1K tokens -> multiply by 1000 to get per-M
-        price_per_m = price * 1000
+        price_per_m = _scale_to_per_million(price, unit)
+        if price_per_m is None:
+            _warn(f"Unrecognized price unit {unit!r} for {ut}; skipping dimension")
+            continue
 
         if model_id not in result:
             result[model_id] = ModelPrices()
@@ -453,9 +465,9 @@ def parse_mantle_models(data: dict[str, Any]) -> dict[str, ModelPrices]:
             mp.input_cost = price_per_m
         elif dimension_part == "output-tokens":
             mp.output_cost = price_per_m
-        elif dimension_part == "cache-read-input-tokens":
+        elif dimension_part in ("cache-read-input-tokens", "cache-read-tokens"):
             mp.cache_read_cost = price_per_m
-        elif dimension_part == "cache-write-input-tokens":
+        elif dimension_part in ("cache-write-input-tokens", "cache-write-tokens"):
             mp.cache_write_cost = price_per_m
 
     # Remove models with incomplete pricing
@@ -563,11 +575,15 @@ def parse_amazon_models(data: dict[str, Any]) -> tuple[dict[str, ModelPrices], d
         if model_id is None:
             continue
 
-        price = _get_price(sku, terms)
-        if price is None:
+        priced = _get_price_with_unit(sku, terms)
+        if priced is None:
             continue
+        price, unit = priced
 
-        price_per_m = price * 1000  # per 1K tokens -> per-M
+        price_per_m = _scale_to_per_million(price, unit)
+        if price_per_m is None:
+            _warn(f"Unrecognized price unit {unit!r} for {ut}; skipping dimension")
+            continue
         collected.setdefault(model_id, {}).setdefault(dimension, {})[_is_global_usagetype(ut)] = price_per_m
 
     # Build result: separate default (non-global) and global pricing
@@ -1066,6 +1082,33 @@ def _get_price(sku: str, terms: dict[str, Any]) -> Decimal | None:
             usd = dim.get("pricePerUnit", {}).get("USD")
             if usd is not None:
                 return Decimal(usd)
+    return None
+
+
+def _get_price_with_unit(sku: str, terms: dict[str, Any]) -> tuple[Decimal, str] | None:
+    """Extract the USD price and its billing unit from OnDemand terms for a SKU."""
+    if sku not in terms:
+        return None
+    for offer in terms[sku].values():
+        for dim in offer.get("priceDimensions", {}).values():
+            usd = dim.get("pricePerUnit", {}).get("USD")
+            if usd is not None:
+                return Decimal(usd), dim.get("unit", "")
+    return None
+
+
+def _scale_to_per_million(price: Decimal, unit: str) -> Decimal | None:
+    """Scale a token price to per-million based on its AWS billing unit.
+
+    AWS labels token dimensions either ``1K tokens`` (the common case) or
+    ``1M tokens`` (e.g. xAI Grok). Returns None for an unrecognized unit so the
+    caller can skip the dimension rather than emit a 1000x-wrong price.
+    """
+    normalized = unit.strip().lower()
+    if normalized in ("1k tokens", "1000 tokens"):
+        return price * 1000
+    if normalized in ("1m tokens", "1000000 tokens"):
+        return price
     return None
 
 


### PR DESCRIPTION
Refreshes provider pricing (2026-06) and fixes a Bedrock generator unit bug.

- **azure**: correct grok-4.2 (1.25/2.50); add grok-4.3, deepseek-v4-pro/flash, gpt-5.5; refine the Data Zone multiplier docstring.
- **google**: add the `gemini-2.5-pro-computer-use-preview` >200K tier.
- **groq**: add `qwen/qwen3.6-27b`. **openai**: add explicit `gpt-5.5-cyber` (avoids under-pricing via the gpt-5.5 prefix).
- **aws-bedrock**: unit-aware token scaling — fixes a 1000× overcharge for `1M tokens`-unit models (grok-4.3); regen adds Sonnet 5, Fable 5 regional profiles, and Gemma 4. The dated 3.5-Haiku key is hardcoded (AWS delisted it from the catalog); its `us.` regional profile is dropped with it.
- **skill**: exclude the deprecated gcp-vertex shim from update-pricing.
