### PR TITLE
feat: gpt-5.6 + OpenAI cache-write billing, cross-provider pricing refresh

### DIFF
--- a/.agents/skills/update-pricing/SKILL.md
+++ b/.agents/skills/update-pricing/SKILL.md
@@ -122,6 +122,50 @@ anchors (e.g., `id="partner-models"`, `id="embedding-models"`) first.
 
 ---
 
+## JavaScript-rendered pages (Playwright CLI)
+
+Some pricing pages (notably **Azure**, and the `openai.com/api/pricing` shell)
+render prices client-side, so `WebFetch` and `curl` return an empty shell with
+**no numbers** — the point where a subagent otherwise falls back to unreliable
+third-party aggregators. Such pages also often **hide rows behind UI toggles**
+(e.g. OpenAI's Short/Long-context switch, or Standard/Batch/Priority service-tier
+tabs). When curl/WebFetch yield no prices — or an obviously incomplete subset —
+escalate to a real browser via the **Playwright CLI**, if available.
+
+Check availability first: `playwright-cli --version` (or `npx --no-install
+playwright cli --version`). If neither works, note it in Caveats and treat any
+aggregator figures as low-confidence.
+
+Prefer **structured data over scraping pixels**, in this order:
+
+1. **A first-party pricing API**, if the provider has one — the most reliable
+   source, no browser needed. Azure exposes the unauthenticated **Azure Retail
+   Prices API** (see the `azure-foundry` provider notes).
+2. **The page's own JSON.** Many docs sites embed pricing in a `<script>` blob or
+   fetch it via XHR. With the page open, `playwright-cli requests` lists network
+   calls — capture the pricing JSON directly rather than reading the DOM.
+3. **The rendered DOM, extracted as data.** Open the page, reveal any hidden rows
+   (click context-length / service-tier toggles), then pull whole tables as JSON:
+
+   ```bash
+   playwright-cli open '<pricing_url>'
+   # click any toggle that reveals more columns/rows first, e.g.:
+   #   playwright-cli find "Long context"; playwright-cli click <ref>
+   playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('table')].map(t=>({head:[...t.querySelectorAll('tr:first-child th')].map(c=>c.textContent.trim()),rows:[...t.querySelectorAll('tbody tr')].map(r=>[...r.querySelectorAll('th,td')].map(c=>c.textContent.trim()))})))" > tables.json
+   playwright-cli close
+   ```
+
+   Watch for **multi-level headers** — e.g. OpenAI's `Short context` / `Long
+   context` bands each span their own Input/Cached/Cache-write/Output columns, so
+   one row carries both the base tier and the `>272k` tier. And there are usually
+   **separate Standard / Batch / Priority tables**; only the **Standard on-demand**
+   table maps to `cost.py`.
+
+Note: `playwright-cli --raw eval` may **double-encode** JSON (returns a quoted
+string). If `json.loads(...)` yields a `str`, decode it a second time.
+
+---
+
 ## Provider-specific instructions
 
 ### aws-bedrock
@@ -143,6 +187,35 @@ AWS Pricing API — do NOT scrape pricing pages. Instead:
 
 If updates are approved (Step 5), add any missing `FM_SERVICENAME_MAP`
 entries, then regenerate with `--write` rather than hand-editing `cost.py`.
+
+### azure-foundry
+
+Azure's pricing pages are heavily JavaScript-rendered — `WebFetch`/`curl` return
+an empty shell. Do **NOT** rely on third-party aggregators (they frequently
+transpose input/output or conflate SKU versions). Use Azure's first-party sources:
+
+1. **Azure Retail Prices API** (no auth, authoritative) — the best source for
+   exact per-token meters. Filter by OData; page through with `$top`:
+
+   ```bash
+   curl -s "https://prices.azure.com/api/retail/prices?\$filter=contains(meterName,'embedding')&\$top=1000"
+   ```
+
+   `cost.py` stores the **Global Standard** base rate — the `-glbl` meters (e.g.
+   `text-embedding-3-large-glbl`). The `-regnl` and `-Dzone` meters are the +10%
+   regional / data-zone variants already applied separately via the
+   `REGIONAL_MULTIPLIER` / `DATA_ZONE_MULTIPLIER` constants, so do NOT bake that
+   premium into the base — a base priced at 1.1× the `-glbl` rate is a
+   double-counting bug. (Some models live under a `Managed Model Hosting Service`
+   product rather than `Azure Llama Models`; match by the model name in
+   `meterName`, not the product.)
+2. **Playwright CLI** to render the DeepSeek / Llama / Grok / Mistral Foundry
+   pricing tables when you need the on-page layout — see "JavaScript-rendered
+   pages (Playwright CLI)".
+3. **Microsoft Learn** for lifecycle — check the **Retired Foundry Models** and
+   model-retirement-schedule pages to catch models that should be *removed* from
+   `cost.py`. Absence from the pricing catalog alone is NOT proof of retirement;
+   the retired-models page is.
 
 ### anthropic
 
@@ -179,9 +252,12 @@ You are a pricing validation subagent for the **{provider}** provider.
    - If the page fails to load or returns an error, note this in the Caveats
      section and set the report status to `FETCH_FAILED`. List all models from
      cost.py as "unverifiable".
-   - If the page loads but pricing data is incomplete or hard to parse (e.g.,
-     requires JavaScript rendering), note this in Caveats and set status to
-     `PARTIAL_VERIFICATION`.
+   - If the page is JavaScript-rendered and curl/WebFetch return no prices (or an
+     incomplete subset), do NOT jump to third-party aggregators. First escalate
+     to a first-party pricing API and/or the **Playwright CLI** — see
+     "JavaScript-rendered pages (Playwright CLI)". Only if all first-party routes
+     fail, fall back to aggregators, mark those figures low-confidence in Caveats,
+     and set status to `PARTIAL_VERIFICATION`.
 3. For each model in `_PRICING`:
    - Find the corresponding model on the pricing page
    - Compare: input cost, output cost, cache read cost, cache creation cost

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Thumbs.db
 tmp/
 
 PLANNING.md
+
+# playwright-cli session scratch
+.playwright-cli/

--- a/packages/lmux-aws-bedrock/pyproject.toml
+++ b/packages/lmux-aws-bedrock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-aws-bedrock"
-version = "0.9.0"
+version = "0.9.1"
 description = "AWS Bedrock provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
@@ -393,6 +393,17 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "anthropic.claude-mythos-5-v1": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(11.0),
+                output_cost_per_token=per_million_tokens(55.0),
+                cache_read_cost_per_token=per_million_tokens(1.1),
+                cache_creation_cost_per_token=per_million_tokens(13.75),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(22.0)},
+            ),
+        ],
+    ),
     "anthropic.claude-opus-4-1-20250805-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -548,17 +559,6 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    "au.anthropic.claude-fable-5": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(11.0),
-                output_cost_per_token=per_million_tokens(55.0),
-                cache_read_cost_per_token=per_million_tokens(1.1),
-                cache_creation_cost_per_token=per_million_tokens(13.75),
-                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(22.0)},
-            ),
-        ],
-    ),
     "au.anthropic.claude-haiku-4-5-20251001-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -638,17 +638,6 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(3.0),
                 output_cost_per_token=per_million_tokens(15.0),
-            ),
-        ],
-    ),
-    "eu.anthropic.claude-fable-5": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(11.0),
-                output_cost_per_token=per_million_tokens(55.0),
-                cache_read_cost_per_token=per_million_tokens(1.1),
-                cache_creation_cost_per_token=per_million_tokens(13.75),
-                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(22.0)},
             ),
         ],
     ),
@@ -736,6 +725,31 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.33),
                 cache_creation_cost_per_token=per_million_tokens(4.125),
                 cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(6.6)},
+            ),
+        ],
+    ),
+    "eu.anthropic.claude-sonnet-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.2),
+                output_cost_per_token=per_million_tokens(11.0),
+                cache_read_cost_per_token=per_million_tokens(0.22),
+                cache_creation_cost_per_token=per_million_tokens(2.75),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(4.4)},
+            ),
+        ],
+        schedules=[
+            PricingSchedule(
+                valid_from=date(2026, 9, 1),
+                tiers=[
+                    PricingTier(
+                        input_cost_per_token=per_million_tokens(3.3),
+                        output_cost_per_token=per_million_tokens(16.5),
+                        cache_read_cost_per_token=per_million_tokens(0.33),
+                        cache_creation_cost_per_token=per_million_tokens(4.125),
+                        cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(6.6)},
+                    ),
+                ],
             ),
         ],
     ),
@@ -1448,6 +1462,14 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # -- Mistral (via Bedrock) -----------------------------------
+    "eu.mistral.pixtral-large-2502-v1": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.0),
+                output_cost_per_token=per_million_tokens(6.0),
+            ),
+        ],
+    ),
     "mistral.devstral-2-123b": ModelPricing(
         tiers=[
             PricingTier(
@@ -1528,6 +1550,14 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "mistral.pixtral-large-2502-v1": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.0),
+                output_cost_per_token=per_million_tokens(6.0),
+            ),
+        ],
+    ),
     "mistral.voxtral-mini-3b-2507": ModelPricing(
         tiers=[
             PricingTier(
@@ -1541,6 +1571,14 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.1),
                 output_cost_per_token=per_million_tokens(0.3),
+            ),
+        ],
+    ),
+    "us.mistral.pixtral-large-2502-v1": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.0),
+                output_cost_per_token=per_million_tokens(6.0),
             ),
         ],
     ),

--- a/packages/lmux-azure-foundry/pyproject.toml
+++ b/packages/lmux-azure-foundry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-azure-foundry"
-version = "0.7.0"
+version = "0.7.1"
 description = "Azure AI Foundry provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
@@ -145,6 +145,8 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # --- OpenAI: GPT-4.5 ---
+    # Deprecated: gpt-4.5-preview was retired on Azure 2025-07-14 (replaced by gpt-4.1).
+    # Kept for historical cost lookups.
     "gpt-4.5": ModelPricing(
         tiers=[
             PricingTier(
@@ -362,14 +364,16 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # --- OpenAI: Embedding models ---
+    # Global Standard rates (OpenAI parity); the +10% data-zone/regional premium is
+    # applied via DATA_ZONE_MULTIPLIER / REGIONAL_MULTIPLIER, not baked into the base.
     "text-embedding-3-small": ModelPricing(
-        tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.022), output_cost_per_token=0.0)]
+        tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.02), output_cost_per_token=0.0)]
     ),
     "text-embedding-3-large": ModelPricing(
-        tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.143), output_cost_per_token=0.0)]
+        tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.13), output_cost_per_token=0.0)]
     ),
     "text-embedding-ada-002": ModelPricing(
-        tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.11), output_cost_per_token=0.0)]
+        tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.10), output_cost_per_token=0.0)]
     ),
     # --- DeepSeek ---
     "deepseek-r1": ModelPricing(

--- a/packages/lmux-azure-foundry/tests/test_cost.py
+++ b/packages/lmux-azure-foundry/tests/test_cost.py
@@ -39,7 +39,7 @@ class TestCalculateAzureFoundryCost:
         usage = Usage(input_tokens=100, output_tokens=0)
         cost = calculate_azure_foundry_cost("text-embedding-3-small", usage)
         assert cost is not None
-        assert cost.input_cost == pytest.approx(100 * 0.022 / 1_000_000)
+        assert cost.input_cost == pytest.approx(100 * 0.02 / 1_000_000)
         assert cost.output_cost == 0.0
 
     def test_zero_tokens(self) -> None:

--- a/packages/lmux-google/pyproject.toml
+++ b/packages/lmux-google/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-google"
-version = "0.8.0"
+version = "0.8.1"
 description = "Google (Gemini) provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-google/src/lmux_google/cost.py
+++ b/packages/lmux-google/src/lmux_google/cost.py
@@ -35,6 +35,8 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    # Deprecated: gemini-3-pro-preview was shut down 2026-03-09, superseded by
+    # gemini-3.1-pro-preview above. Kept for historical cost lookups.
     "gemini-3-pro-preview": ModelPricing(
         tiers=[
             PricingTier(
@@ -64,6 +66,15 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.50),
                 output_cost_per_token=per_million_tokens(3.00),
+            ),
+        ],
+    ),
+    # Text I/O rates only; image-output tokens are billed separately and not modeled.
+    "gemini-3.1-flash-lite-image-preview": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.25),
+                output_cost_per_token=per_million_tokens(1.50),
             ),
         ],
     ),

--- a/packages/lmux-openai/README.md
+++ b/packages/lmux-openai/README.md
@@ -107,7 +107,7 @@ OpenAIProvider(
 
 ### Data Residency
 
-OpenAI charges a 10% uplift on the `gpt-5.4` family (`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.4-pro`) when requests go through a [regional processing (data residency) endpoint](https://developers.openai.com/api/docs/guides/your-data).
+OpenAI charges a 10% uplift on the `gpt-5.4`, `gpt-5.5`, and `gpt-5.6` families when requests go through a [regional processing (data residency) endpoint](https://developers.openai.com/api/docs/guides/your-data).
 
 Data residency is selected at the _transport_ layer (regional hostname like `eu.api.openai.com`), not via a per-request parameter. Set `data_residency=True` on the provider so lmux applies the uplift to the reported cost.
 

--- a/packages/lmux-openai/pyproject.toml
+++ b/packages/lmux-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-openai"
-version = "0.6.0"
+version = "0.7.0"
 description = "OpenAI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
   "lmux~=0.9",
-  "openai~=2.20",
+  "openai~=2.45",
 ]
 
 [project.urls]

--- a/packages/lmux-openai/src/lmux_openai/_mappers.py
+++ b/packages/lmux-openai/src/lmux_openai/_mappers.py
@@ -219,6 +219,11 @@ def _map_completion_usage(completion: "ChatCompletion") -> Usage | None:
     if oai_usage.prompt_tokens_details and oai_usage.prompt_tokens_details.cached_tokens:
         cache_read = oai_usage.prompt_tokens_details.cached_tokens
 
+    # gpt-5.6+ bills cache writes; older models report no cache_write_tokens (writes free).
+    cache_write = None
+    if oai_usage.prompt_tokens_details and oai_usage.prompt_tokens_details.cache_write_tokens:
+        cache_write = oai_usage.prompt_tokens_details.cache_write_tokens
+
     reasoning_tokens = None
     if oai_usage.completion_tokens_details and oai_usage.completion_tokens_details.reasoning_tokens:
         reasoning_tokens = oai_usage.completion_tokens_details.reasoning_tokens
@@ -227,6 +232,7 @@ def _map_completion_usage(completion: "ChatCompletion") -> Usage | None:
         input_tokens=oai_usage.prompt_tokens,
         output_tokens=oai_usage.completion_tokens,
         cache_read_tokens=cache_read,
+        cache_creation_tokens=cache_write,
         reasoning_tokens=reasoning_tokens,
     )
 
@@ -265,6 +271,9 @@ def map_chat_chunk(chunk: "ChatCompletionChunk", provider_name: str) -> ChatChun
         cache_read = None
         if chunk.usage.prompt_tokens_details and chunk.usage.prompt_tokens_details.cached_tokens:
             cache_read = chunk.usage.prompt_tokens_details.cached_tokens
+        cache_write = None
+        if chunk.usage.prompt_tokens_details and chunk.usage.prompt_tokens_details.cache_write_tokens:
+            cache_write = chunk.usage.prompt_tokens_details.cache_write_tokens
         reasoning_tokens = None
         if chunk.usage.completion_tokens_details and chunk.usage.completion_tokens_details.reasoning_tokens:
             reasoning_tokens = chunk.usage.completion_tokens_details.reasoning_tokens
@@ -272,6 +281,7 @@ def map_chat_chunk(chunk: "ChatCompletionChunk", provider_name: str) -> ChatChun
             input_tokens=chunk.usage.prompt_tokens,
             output_tokens=chunk.usage.completion_tokens,
             cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_write,
             reasoning_tokens=reasoning_tokens,
         )
 
@@ -319,6 +329,9 @@ def map_responses_response(
         cache_read: int | None = None
         if usage_data.input_tokens_details and usage_data.input_tokens_details.cached_tokens:
             cache_read = usage_data.input_tokens_details.cached_tokens
+        cache_write: int | None = None
+        if usage_data.input_tokens_details and usage_data.input_tokens_details.cache_write_tokens:
+            cache_write = usage_data.input_tokens_details.cache_write_tokens
         reasoning_tokens: int | None = None
         if usage_data.output_tokens_details and usage_data.output_tokens_details.reasoning_tokens:
             reasoning_tokens = usage_data.output_tokens_details.reasoning_tokens
@@ -326,6 +339,7 @@ def map_responses_response(
             input_tokens=usage_data.input_tokens,
             output_tokens=usage_data.output_tokens,
             cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_write,
             reasoning_tokens=reasoning_tokens,
         )
 

--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -8,6 +8,59 @@ from lmux.types import Cost, Usage
 
 _PRICING: dict[str, ModelPricing] = {
     # GPT-5 family
+    # gpt-5.6 family (sol/terra/luna). Cache writes are billed on gpt-5.6+ only,
+    # at a flat 1.25x the input rate (no per-TTL split), via cache_creation_cost_per_token.
+    "gpt-5.6-sol": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(30.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(10.00),
+                output_cost_per_token=per_million_tokens(45.00),
+                cache_read_cost_per_token=per_million_tokens(1.00),
+                cache_creation_cost_per_token=per_million_tokens(12.50),
+                min_input_tokens=272_000,
+            ),
+        ],
+    ),
+    "gpt-5.6-terra": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.50),
+                output_cost_per_token=per_million_tokens(15.00),
+                cache_read_cost_per_token=per_million_tokens(0.25),
+                cache_creation_cost_per_token=per_million_tokens(3.125),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(22.50),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
+                min_input_tokens=272_000,
+            ),
+        ],
+    ),
+    "gpt-5.6-luna": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.00),
+                output_cost_per_token=per_million_tokens(6.00),
+                cache_read_cost_per_token=per_million_tokens(0.10),
+                cache_creation_cost_per_token=per_million_tokens(1.25),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.00),
+                output_cost_per_token=per_million_tokens(9.00),
+                cache_read_cost_per_token=per_million_tokens(0.20),
+                cache_creation_cost_per_token=per_million_tokens(2.50),
+                min_input_tokens=272_000,
+            ),
+        ],
+    ),
     "gpt-5.5-pro": ModelPricing(
         tiers=[
             PricingTier(
@@ -422,10 +475,10 @@ _PRICING: dict[str, ModelPricing] = {
 _PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
 
 # 10% uplift for regional processing (data residency) endpoints. Per OpenAI, this
-# applies to the gpt-5.4 family (gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro)
-# and the gpt-5.5 family (gpt-5.5, gpt-5.5-pro).
+# applies to the gpt-5.4 family (gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro),
+# the gpt-5.5 family (gpt-5.5, gpt-5.5-pro), and the gpt-5.6 family (sol/terra/luna).
 REGIONAL_UPLIFT = 1.1
-_REGIONAL_UPLIFT_PREFIXES = ("gpt-5.4", "gpt-5.5")
+_REGIONAL_UPLIFT_PREFIXES = ("gpt-5.4", "gpt-5.5", "gpt-5.6")
 
 
 def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:

--- a/packages/lmux-openai/tests/test_cost.py
+++ b/packages/lmux-openai/tests/test_cost.py
@@ -73,6 +73,40 @@ class TestCalculateOpenAICost:
         assert cyber.output_cost == pytest.approx(500 * 75.00 / 1_000_000)
         assert cyber.input_cost > base.input_cost
 
+    @pytest.mark.parametrize(
+        ("model", "input_rate", "output_rate", "cache_read_rate", "cache_write_rate"),
+        [
+            ("gpt-5.6-sol", 5.00, 30.00, 0.50, 6.25),
+            ("gpt-5.6-terra", 2.50, 15.00, 0.25, 3.125),
+            ("gpt-5.6-luna", 1.00, 6.00, 0.10, 1.25),
+        ],
+    )
+    def test_gpt_5_6_family_base_pricing(
+        self,
+        model: str,
+        input_rate: float,
+        output_rate: float,
+        cache_read_rate: float,
+        cache_write_rate: float,
+    ) -> None:
+        # gpt-5.6 bills cache writes (1.25x input) on top of the read discount.
+        usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=100, cache_creation_tokens=200)
+        cost = calculate_openai_cost(model, usage)
+        assert cost is not None
+        billable = 1000 - 100 - 200
+        assert cost.input_cost == pytest.approx(billable * input_rate / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * output_rate / 1_000_000)
+        assert cost.cache_read_cost == pytest.approx(100 * cache_read_rate / 1_000_000)
+        assert cost.cache_creation_cost == pytest.approx(200 * cache_write_rate / 1_000_000)
+
+    def test_gpt_5_6_long_context_tier(self) -> None:
+        # Above 272k input tokens gpt-5.6-sol switches to the long-context tier (10.00 / 45.00).
+        usage = Usage(input_tokens=300_000, output_tokens=1000)
+        cost = calculate_openai_cost("gpt-5.6-sol", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(300_000 * 10.00 / 1_000_000)
+        assert cost.output_cost == pytest.approx(1000 * 45.00 / 1_000_000)
+
 
 class TestRegionalUpliftApplies:
     @pytest.mark.parametrize(
@@ -80,6 +114,10 @@ class TestRegionalUpliftApplies:
         ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.4-pro", "gpt-5.4-2025-11-01"],
     )
     def test_applies_to_gpt_5_4_family(self, model: str) -> None:
+        assert regional_uplift_applies(model) is True
+
+    @pytest.mark.parametrize("model", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
+    def test_applies_to_gpt_5_6_family(self, model: str) -> None:
         assert regional_uplift_applies(model) is True
 
     @pytest.mark.parametrize(

--- a/packages/lmux-openai/tests/test_mappers.py
+++ b/packages/lmux-openai/tests/test_mappers.py
@@ -324,6 +324,31 @@ class TestMapChatCompletion:
         assert result.usage is not None
         assert result.usage.cache_read_tokens == 50
 
+    def test_with_cache_write_tokens(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        completion = ChatCompletion(
+            id="chatcmpl-123",
+            choices=[
+                Choice(
+                    finish_reason="stop",
+                    index=0,
+                    message=ChatCompletionMessage(content="Hello!", role="assistant"),
+                )
+            ],
+            created=1234567890,
+            model="gpt-5.6-sol",
+            object="chat.completion",
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=2, cache_write_tokens=6),
+            ),
+        )
+        result = map_chat_completion(completion, "openai", noop_cost_fn)
+        assert result.usage is not None
+        assert result.usage.cache_read_tokens == 2
+        assert result.usage.cache_creation_tokens == 6
+
     def test_with_reasoning_tokens(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         completion = ChatCompletion(
             id="chatcmpl-123",
@@ -479,6 +504,25 @@ class TestMapChatChunk:
         assert result.usage is not None
         assert result.usage.cache_read_tokens == 3
 
+    def test_usage_chunk_with_cache_write(self) -> None:
+        chunk = ChatCompletionChunk(
+            id="chatcmpl-123",
+            choices=[],
+            created=1234567890,
+            model="gpt-5.6-sol",
+            object="chat.completion.chunk",
+            usage=CompletionUsage(
+                prompt_tokens=10,
+                completion_tokens=5,
+                total_tokens=15,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=1, cache_write_tokens=4),
+            ),
+        )
+        result = map_chat_chunk(chunk, "openai")
+        assert result.usage is not None
+        assert result.usage.cache_read_tokens == 1
+        assert result.usage.cache_creation_tokens == 4
+
     def test_usage_chunk_with_reasoning_tokens(self) -> None:
         chunk = ChatCompletionChunk(
             id="chatcmpl-123",
@@ -569,6 +613,21 @@ class TestMapResponsesResponse:
         result = map_responses_response(mock, "openai", noop_cost_fn)
         assert result.usage is not None
         assert result.usage.cache_read_tokens == 50
+
+    def test_with_cache_write_tokens(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        mock = MagicMock()
+        mock.id = "resp_123"
+        mock.output_text = "Hello!"
+        mock.model = "gpt-5.6-sol"
+        mock.usage.input_tokens = 10
+        mock.usage.output_tokens = 5
+        mock.usage.input_tokens_details.cached_tokens = 2
+        mock.usage.input_tokens_details.cache_write_tokens = 6
+        mock.usage.output_tokens_details = None
+        result = map_responses_response(mock, "openai", noop_cost_fn)
+        assert result.usage is not None
+        assert result.usage.cache_read_tokens == 2
+        assert result.usage.cache_creation_tokens == 6
 
     def test_with_reasoning_tokens(self, responses_mock: MagicMock, noop_cost_fn: Any) -> None:  # noqa: ANN401
         responses_mock.usage.output_tokens_details = MagicMock(reasoning_tokens=4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.13"
 
 [tool.uv]
 package = false
-exclude-newer = "7 days"
+exclude-newer = "1 day"
 
 [tool.uv.workspace]
 members = ["packages/*"]

--- a/scripts/update_bedrock_pricing.py
+++ b/scripts/update_bedrock_pricing.py
@@ -45,6 +45,7 @@ LCTX_THRESHOLD = 200_000
 FM_SERVICENAME_MAP: dict[str, str] = {
     # Anthropic Claude
     "Claude Fable 5": "anthropic.claude-fable-5-v1",
+    "Claude Mythos 5": "anthropic.claude-mythos-5-v1",
     "Claude Sonnet 5": "anthropic.claude-sonnet-5-v1",
     "Claude Opus 4.8": "anthropic.claude-opus-4-8-v1",
     "Claude Opus 4.7": "anthropic.claude-opus-4-7-v1",
@@ -121,6 +122,7 @@ NON_MANTLE_MODEL_MAP: dict[str, str] = {
     "Mistral Large": "mistral.mistral-large-2402-v1",
     "Mistral Small": "mistral.mistral-small-2402-v1",
     "Mistral Large 3": "mistral.mistral-large-3-675b-instruct",
+    "Pixtral Large 25.02": "mistral.pixtral-large-2502",
     # Nvidia
     "NVIDIA Nemotron Nano 2 VL": "nvidia.nemotron-nano-12b-v2-vl",
 }

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.13"
 
 [options]
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
+exclude-newer-span = "P1D"
 
 [manifest]
 members = [
@@ -843,7 +843,7 @@ provides-extras = ["vertex"]
 
 [[package]]
 name = "lmux-aws-bedrock"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "packages/lmux-aws-bedrock" }
 dependencies = [
     { name = "boto3" },
@@ -865,7 +865,7 @@ provides-extras = ["async"]
 
 [[package]]
 name = "lmux-azure-foundry"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/lmux-azure-foundry" }
 dependencies = [
     { name = "lmux" },
@@ -898,7 +898,7 @@ requires-dist = [{ name = "lmux-google", editable = "packages/lmux-google" }]
 
 [[package]]
 name = "lmux-google"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/lmux-google" }
 dependencies = [
     { name = "google-genai" },
@@ -928,7 +928,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-openai"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/lmux-openai" }
 dependencies = [
     { name = "lmux" },
@@ -938,7 +938,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "lmux", editable = "packages/lmux" },
-    { name = "openai", specifier = "~=2.20" },
+    { name = "openai", specifier = "~=2.45" },
 ]
 
 [[package]]
@@ -1115,7 +1115,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.30.0"
+version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1127,9 +1127,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Pricing refresh: parallel per-provider validation, then adversarial re-verification against primary/first-party sources only.

- **openai** (minor): `gpt-5.6-sol/terra/luna` + the new cache-write billing (reads `cache_write_tokens` → `cache_creation`), with the token partition verified against the live OpenAI API; openai SDK pin → `~=2.45`.
- **azure-foundry** (patch): embeddings → Global-Standard parity `0.02 / 0.13 / 0.10` (base was double-counting the 1.1× data-zone/regional premium); retired `gpt-4.5` marked deprecated (kept for lookups).
- **google** (patch): add `gemini-3.1-flash-lite-image-preview`; `gemini-3-pro-preview` marked deprecated (kept for lookups).
- **aws-bedrock** (patch): regenerate — add Claude Mythos 5, eu. Sonnet 5, Pixtral Large 25.02; drop stale au./eu. Fable 5.

Workspace: `exclude-newer` 7d→1d (to allow openai 2.45.0); `update-pricing` skill now documents Playwright CLI + the Azure Retail Prices API.
