### PR TITLE
build: replace basedpyright with ty; move lint checks to ruff

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -74,7 +74,7 @@ grep '^version' packages/lmux-<pkg>/pyproject.toml   # core: packages/lmux/pypro
 Run the full gate from AGENTS.md and do not release a package that isn't green:
 
 ```bash
-uv run ruff format --check && uv run ruff check && uv run basedpyright && uv run pytest
+uv run ruff format --check && uv run ruff check && uv run ty check && uv run pytest
 ```
 
 ### Step 3: Draft the notes and get sign-off

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run: uv run ruff check
 
-      - run: uv run basedpyright
+      - run: uv run ty check
 
   test:
     name: "Test (Python ${{ matrix.python-version }})"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ README files (root and per-package) must be kept up to date when changes affect 
 
 - `TYPE_CHECKING` + string annotations for expensive SDK imports — **never** `from __future__ import annotations`
 - `Sequence[Message]` (not `list[Message]`) in protocol signatures for covariance
-- `# pyright: ignore[reportSpecificError]` — always include the specific error code
+- `# ty: ignore[specific-rule]` — always include the specific rule (e.g., `invalid-argument-type`)
 - `# noqa: CODE` — always include the specific rule code (e.g., `# noqa: A002`, `# noqa: PLR0913`)
 - `# pragma: no cover` only for genuinely untestable code (lazy import stubs, `assert_never` branches)
 
@@ -119,7 +119,7 @@ uv run ruff check
 uv run ruff format --check
 
 # Type check
-uv run basedpyright 
+uv run ty check
 
 # Tests with 100% branch coverage
 uv run pytest
@@ -142,7 +142,7 @@ If any dependencies are not present in the local .venv, use `uv sync --all-packa
 - `pytest-asyncio` with `asyncio_mode = "auto"` — async test methods just work
 - `--import-mode=importlib` to avoid namespace collisions between packages
 - **No `tests/__init__.py` files** (required for importlib mode)
-- **Prefer testing through public API** over accessing private attributes/methods directly. For example, test `_provider_params_kwargs` by calling `chat()` with `provider_params` and asserting what gets passed to the SDK mock — not by calling the private method. Use `# pyright: ignore[reportPrivateUsage]` only when there's no public path to exercise the behavior (e.g., accessing `_custom_pricing` to verify `register_pricing`).
+- **Prefer testing through public API** over accessing private attributes/methods directly. For example, test `_provider_params_kwargs` by calling `chat()` with `provider_params` and asserting what gets passed to the SDK mock — not by calling the private method. Access private attributes only when there's no public path to exercise the behavior (e.g., accessing `_custom_pricing` to verify `register_pricing`) — `SLF001` is ignored in tests, so no suppression is needed.
 - 100% branch coverage required
 
 ### Test Structure

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ response = registry.chat("my-provider/my-model", messages)
 
 ## Development
 
-Checked with ruff, basedpyright (strict), and pytest with 100% branch coverage.
+Checked with ruff, ty, and pytest with 100% branch coverage.
 
 ### Skills
 

--- a/packages/lmux-anthropic/src/lmux_anthropic/__init__.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/__init__.py
@@ -28,4 +28,4 @@ __all__ = [
 
 def preload() -> None:
     """Eagerly import the Anthropic SDK."""
-    import anthropic  # noqa: F401, PLC0415  # pyright: ignore[reportUnusedImport]
+    import anthropic  # noqa: F401, PLC0415

--- a/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
@@ -196,7 +196,7 @@ def _map_content_part(part: TextContent | ImageContent) -> "TextBlockParam | Ima
 def _map_image_content(img: ImageContent) -> "ImageBlockParam":
     match = _DATA_URI_PATTERN.match(img.url)
     if match:
-        return {"type": "image", "source": {"type": "base64", "media_type": match.group(1), "data": match.group(2)}}  # pyright: ignore[reportReturnType]  # media_type is a dynamic str, not a literal
+        return {"type": "image", "source": {"type": "base64", "media_type": match.group(1), "data": match.group(2)}}  # ty: ignore[invalid-argument-type, invalid-return-type]  # media_type is a dynamic str, not a literal
     return {"type": "image", "source": {"type": "url", "url": img.url}}
 
 
@@ -229,7 +229,7 @@ def _append_tool_result(result: list["MessageParam"], msg: ToolMessage) -> None:
         if isinstance(last_content, list) and last_content:
             first = last_content[0]
             if isinstance(first, dict) and first.get("type") == "tool_result":
-                last_content.append(tool_block)
+                last_content.append(tool_block)  # ty: ignore[invalid-argument-type]
                 return
     result.append({"role": "user", "content": [tool_block]})
 

--- a/packages/lmux-anthropic/src/lmux_anthropic/auth.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/auth.py
@@ -42,7 +42,7 @@ class AnthropicVertexADCAuthProvider:
         except ImportError as e:
             raise ImportError("[vertex] extra group is required for Vertex AI support") from e  # noqa: TRY003
 
-        credentials, project_id = google.auth.default(scopes=self._scopes)  # pyright: ignore[reportUnknownVariableType]
+        credentials, project_id = google.auth.default(scopes=self._scopes)
         # google.auth has unresolvable string forward-ref annotations; cast is required
         return cast("Credentials", credentials), project_id
 

--- a/packages/lmux-anthropic/src/lmux_anthropic/provider.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/provider.py
@@ -427,7 +427,7 @@ class AnthropicProvider(
             kwargs["cache_control"] = params.cache_control
         return kwargs
 
-    def _cost_multiplier(self, model: str, provider_params: AnthropicParams | None) -> float:  # pyright: ignore[reportUnusedParameter]
+    def _cost_multiplier(self, model: str, provider_params: AnthropicParams | None) -> float:  # noqa: ARG002
         """Compute the combined cost multiplier from provider params; ``model`` is a hook for subclasses."""
         multiplier = 1.0
         if provider_params is None:
@@ -489,7 +489,7 @@ class AnthropicVertexProvider(AnthropicProvider):
     @staticmethod
     def _split_auth_result(auth_result: "VertexAuthResult") -> "tuple[Credentials, str | None]":
         if isinstance(auth_result, tuple):
-            return auth_result
+            return auth_result  # ty: ignore[invalid-return-type]
         return auth_result, None
 
     def _resolve_project_id(self, auth_project_id: str | None) -> str | None:
@@ -533,7 +533,7 @@ class AnthropicVertexProvider(AnthropicProvider):
     @override
     def _provider_params_kwargs(params: AnthropicParams) -> dict[str, Any]:
         """Convert AnthropicParams to SDK kwargs, dropping Anthropic-API-only parameters."""
-        kwargs = AnthropicProvider._provider_params_kwargs(params)
+        kwargs = AnthropicProvider._provider_params_kwargs(params)  # noqa: SLF001
         kwargs.pop("service_tier", None)
         kwargs.pop("inference_geo", None)
         return kwargs
@@ -617,7 +617,7 @@ class AnthropicFoundryProvider(AnthropicProvider):
     @override
     def _provider_params_kwargs(params: AnthropicParams) -> dict[str, Any]:
         """Convert AnthropicParams to SDK kwargs, dropping Anthropic-API-only parameters."""
-        kwargs = AnthropicProvider._provider_params_kwargs(params)
+        kwargs = AnthropicProvider._provider_params_kwargs(params)  # noqa: SLF001
         kwargs.pop("service_tier", None)
         kwargs.pop("inference_geo", None)
         return kwargs

--- a/packages/lmux-anthropic/tests/test_mappers.py
+++ b/packages/lmux-anthropic/tests/test_mappers.py
@@ -160,7 +160,7 @@ class TestMapMessages:
         assert isinstance(content, list)
         assert len(content) == 2
         assert content[0] == {"type": "text", "text": "Let me check."}
-        assert content[1]["type"] == "tool_use"  # pyright: ignore[reportIndexIssue]
+        assert content[1]["type"] == "tool_use"  # ty: ignore[not-subscriptable]
 
     def test_tool_message(self) -> None:
         _, messages = map_messages([ToolMessage(content="72°F", tool_call_id="call_1")])
@@ -180,8 +180,8 @@ class TestMapMessages:
         content = messages[0]["content"]
         assert isinstance(content, list)
         assert len(content) == 2
-        assert content[0]["tool_use_id"] == "call_1"  # pyright: ignore[reportIndexIssue, reportGeneralTypeIssues]
-        assert content[1]["tool_use_id"] == "call_2"  # pyright: ignore[reportIndexIssue, reportGeneralTypeIssues]
+        assert content[0]["tool_use_id"] == "call_1"  # ty: ignore[not-subscriptable]
+        assert content[1]["tool_use_id"] == "call_2"  # ty: ignore[not-subscriptable]
 
     def test_tool_message_after_multimodal_user_not_merged(self) -> None:
         _, messages = map_messages(
@@ -195,7 +195,7 @@ class TestMapMessages:
         assert messages[1]["role"] == "user"
         content = messages[1]["content"]
         assert isinstance(content, list)
-        assert content[0]["type"] == "tool_result"  # pyright: ignore[reportIndexIssue]
+        assert content[0]["type"] == "tool_result"  # ty: ignore[not-subscriptable]
 
     def test_tool_message_after_user_not_merged(self) -> None:
         _, messages = map_messages(
@@ -473,7 +473,7 @@ class TestMapResponseFormat:
         )
         result = map_response_format(rf)
         assert result is not None
-        fmt = cast("dict[str, Any]", cast("object", result["format"]))  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        fmt = cast("dict[str, Any]", cast("object", result["format"]))
         schema = cast("dict[str, Any]", fmt["schema"])
         assert schema["additionalProperties"] is False
         assert schema["properties"]["inner"]["additionalProperties"] is False
@@ -492,7 +492,7 @@ class TestMapResponseFormat:
         )
         result = map_response_format(rf)
         assert result is not None
-        fmt = cast("dict[str, Any]", cast("object", result["format"]))  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        fmt = cast("dict[str, Any]", cast("object", result["format"]))
         schema = cast("dict[str, Any]", fmt["schema"])
         assert schema["additionalProperties"] is False
         assert schema["anyOf"][0]["additionalProperties"] is False
@@ -505,7 +505,7 @@ class TestMapResponseFormat:
         )
         result = map_response_format(rf)
         assert result is not None
-        fmt = cast("dict[str, Any]", cast("object", result["format"]))  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        fmt = cast("dict[str, Any]", cast("object", result["format"]))
         schema = cast("dict[str, Any]", fmt["schema"])
         assert schema["additionalProperties"] is True
 

--- a/packages/lmux-anthropic/tests/test_params.py
+++ b/packages/lmux-anthropic/tests/test_params.py
@@ -17,4 +17,4 @@ class TestAnthropicParams:
 
     def test_invalid_service_tier_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            _ = AnthropicParams(service_tier="invalid")  # pyright: ignore[reportArgumentType]
+            _ = AnthropicParams(service_tier="invalid")  # ty: ignore[invalid-argument-type]

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -1177,7 +1177,7 @@ class TestAclose:
 
         mock_async_create.assert_called_once()
         mock_async_client.close.assert_awaited_once()
-        assert provider._async_client is None  # pyright: ignore[reportPrivateUsage]
+        assert provider._async_client is None
 
     async def test_aclose_noop_when_no_client(self, fake_auth: FakeAuth) -> None:
         provider = AnthropicProvider(auth=fake_auth)
@@ -1628,7 +1628,7 @@ class TestVertexClientManagement:
 
     def test_default_auth_is_adc(self) -> None:
         provider = AnthropicVertexProvider()
-        assert isinstance(provider._vertex_auth, AnthropicVertexADCAuthProvider)  # pyright: ignore[reportPrivateUsage]
+        assert isinstance(provider._vertex_auth, AnthropicVertexADCAuthProvider)
 
 
 # MARK: Foundry
@@ -1914,4 +1914,4 @@ class TestFoundryClientManagement:
 
     def test_default_auth_is_env(self) -> None:
         provider = AnthropicFoundryProvider()
-        assert isinstance(provider._foundry_auth, AnthropicFoundryEnvAuthProvider)  # pyright: ignore[reportPrivateUsage]
+        assert isinstance(provider._foundry_auth, AnthropicFoundryEnvAuthProvider)

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/__init__.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/__init__.py
@@ -24,7 +24,7 @@ def preload() -> None:
     Call this during application startup to pay the import cost upfront
     rather than on the first request.
     """
-    import boto3  # noqa: F401, PLC0415  # pyright: ignore[reportUnusedImport]
+    import boto3  # noqa: F401, PLC0415
 
     with contextlib.suppress(ImportError):
-        import aiobotocore  # noqa: F401, PLC0415  # pyright: ignore[reportUnusedImport]
+        import aiobotocore  # noqa: F401, PLC0415

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
@@ -203,7 +203,7 @@ def _append_tool_result(result: list["MessageTypeDef"], msg: ToolMessage) -> Non
     if result and result[-1].get("role") == "user":
         last_content = result[-1]["content"]
         if isinstance(last_content, list) and last_content and "toolResult" in last_content[0]:
-            last_content.append(tool_block)
+            last_content.append(tool_block)  # ty: ignore[invalid-argument-type]
             return
     result.append({"role": "user", "content": [tool_block]})
 
@@ -344,7 +344,7 @@ def _map_stop_reason(stop_reason: str | None) -> str | None:
 
 def _map_converse_usage(response: "ConverseResponseTypeDef") -> Usage | None:
     usage_data = response.get("usage")
-    if usage_data is None:  # pyright: ignore[reportUnnecessaryComparison]
+    if usage_data is None:
         return None
     return _map_token_usage(usage_data)
 
@@ -431,7 +431,7 @@ def _map_content_block_start(data: "ContentBlockStartEventTypeDef") -> ChatChunk
 
 def _map_metadata_event(metadata: "ConverseStreamMetadataEventTypeDef") -> ChatChunk | None:
     usage_data = metadata.get("usage")
-    if usage_data is None:  # pyright: ignore[reportUnnecessaryComparison]
+    if usage_data is None:
         return None
     return ChatChunk(usage=_map_token_usage(usage_data))
 

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -414,7 +414,7 @@ class BedrockProvider(
         if tools is not None:
             tool_config = map_tools(tools)
             if tool_choice is not None:
-                tool_config["toolChoice"] = map_tool_choice(tool_choice)  # pyright: ignore[reportGeneralTypeIssues]
+                tool_config["toolChoice"] = map_tool_choice(tool_choice)  # ty: ignore[invalid-assignment]
             kwargs["toolConfig"] = tool_config
 
         if response_format is not None:

--- a/packages/lmux-aws-bedrock/tests/test_cost.py
+++ b/packages/lmux-aws-bedrock/tests/test_cost.py
@@ -7,7 +7,7 @@ import pytest
 from lmux.cost import ModelPricing, PricingTier, per_million_tokens
 from lmux.types import Usage
 from lmux_aws_bedrock.cost import (
-    _REGIONAL_PRICING,  # pyright: ignore[reportPrivateUsage]
+    _REGIONAL_PRICING,
     calculate_bedrock_cost,
 )
 

--- a/packages/lmux-aws-bedrock/tests/test_exceptions.py
+++ b/packages/lmux-aws-bedrock/tests/test_exceptions.py
@@ -28,7 +28,7 @@ from lmux_aws_bedrock._exceptions import map_bedrock_error
 @pytest.fixture
 def throttling_error() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
             "ResponseMetadata": {"HTTPStatusCode": 429},
         },
@@ -39,7 +39,7 @@ def throttling_error() -> ClientError:
 @pytest.fixture
 def throttling_error_with_retry_after() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
             "ResponseMetadata": {"HTTPStatusCode": 429, "HTTPHeaders": {"retry-after": "30.5"}},
         },
@@ -50,7 +50,7 @@ def throttling_error_with_retry_after() -> ClientError:
 @pytest.fixture
 def throttling_error_invalid_retry_after() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
             "ResponseMetadata": {"HTTPStatusCode": 429, "HTTPHeaders": {"retry-after": "not-a-number"}},
         },
@@ -61,7 +61,7 @@ def throttling_error_invalid_retry_after() -> ClientError:
 @pytest.fixture
 def throttling_error_no_retry_header() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
             "ResponseMetadata": {"HTTPStatusCode": 429, "HTTPHeaders": {}},
         },
@@ -72,7 +72,7 @@ def throttling_error_no_retry_header() -> ClientError:
 @pytest.fixture
 def validation_error() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "ValidationException", "Message": "Invalid parameter"},
             "ResponseMetadata": {"HTTPStatusCode": 400},
         },
@@ -83,7 +83,7 @@ def validation_error() -> ClientError:
 @pytest.fixture
 def access_denied_error() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "AccessDeniedException", "Message": "Access denied"},
             "ResponseMetadata": {"HTTPStatusCode": 403},
         },
@@ -94,7 +94,7 @@ def access_denied_error() -> ClientError:
 @pytest.fixture
 def unrecognized_client_error() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "UnrecognizedClientException", "Message": "Unrecognized client"},
             "ResponseMetadata": {"HTTPStatusCode": 403},
         },
@@ -105,7 +105,7 @@ def unrecognized_client_error() -> ClientError:
 @pytest.fixture
 def invalid_signature_error() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "InvalidSignatureException", "Message": "Invalid signature"},
             "ResponseMetadata": {"HTTPStatusCode": 403},
         },
@@ -116,7 +116,7 @@ def invalid_signature_error() -> ClientError:
 @pytest.fixture
 def expired_token_error() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "ExpiredTokenException", "Message": "Token expired"},
             "ResponseMetadata": {"HTTPStatusCode": 403},
         },
@@ -127,7 +127,7 @@ def expired_token_error() -> ClientError:
 @pytest.fixture
 def resource_not_found_error() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "ResourceNotFoundException", "Message": "Model not found"},
             "ResponseMetadata": {"HTTPStatusCode": 404},
         },
@@ -138,7 +138,7 @@ def resource_not_found_error() -> ClientError:
 @pytest.fixture
 def internal_server_error() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "InternalServerException", "Message": "Internal error"},
             "ResponseMetadata": {"HTTPStatusCode": 500},
         },
@@ -149,7 +149,7 @@ def internal_server_error() -> ClientError:
 @pytest.fixture
 def unknown_client_error() -> ClientError:
     return ClientError(
-        error_response={  # pyright: ignore[reportArgumentType]
+        error_response={  # ty: ignore[invalid-argument-type]
             "Error": {"Code": "SomeUnknownError", "Message": "Something unexpected"},
             "ResponseMetadata": {"HTTPStatusCode": 418},
         },
@@ -305,7 +305,7 @@ class TestMapBedrockError:
         [
             pytest.param(
                 ClientError(
-                    error_response={  # pyright: ignore[reportArgumentType]
+                    error_response={  # ty: ignore[invalid-argument-type]
                         "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
                         "ResponseMetadata": {"HTTPStatusCode": 429},
                     },
@@ -315,7 +315,7 @@ class TestMapBedrockError:
             ),
             pytest.param(
                 ClientError(
-                    error_response={  # pyright: ignore[reportArgumentType]
+                    error_response={  # ty: ignore[invalid-argument-type]
                         "Error": {"Code": "ValidationException", "Message": "Invalid"},
                         "ResponseMetadata": {"HTTPStatusCode": 400},
                     },
@@ -325,7 +325,7 @@ class TestMapBedrockError:
             ),
             pytest.param(
                 ClientError(
-                    error_response={  # pyright: ignore[reportArgumentType]
+                    error_response={  # ty: ignore[invalid-argument-type]
                         "Error": {"Code": "AccessDeniedException", "Message": "Denied"},
                         "ResponseMetadata": {"HTTPStatusCode": 403},
                     },
@@ -335,7 +335,7 @@ class TestMapBedrockError:
             ),
             pytest.param(
                 ClientError(
-                    error_response={  # pyright: ignore[reportArgumentType]
+                    error_response={  # ty: ignore[invalid-argument-type]
                         "Error": {"Code": "ResourceNotFoundException", "Message": "Not found"},
                         "ResponseMetadata": {"HTTPStatusCode": 404},
                     },
@@ -345,7 +345,7 @@ class TestMapBedrockError:
             ),
             pytest.param(
                 ClientError(
-                    error_response={  # pyright: ignore[reportArgumentType]
+                    error_response={  # ty: ignore[invalid-argument-type]
                         "Error": {"Code": "InternalServerException", "Message": "Internal"},
                         "ResponseMetadata": {"HTTPStatusCode": 500},
                     },
@@ -355,7 +355,7 @@ class TestMapBedrockError:
             ),
             pytest.param(
                 ClientError(
-                    error_response={  # pyright: ignore[reportArgumentType]
+                    error_response={  # ty: ignore[invalid-argument-type]
                         "Error": {"Code": "UnknownCode", "Message": "Unknown"},
                         "ResponseMetadata": {"HTTPStatusCode": 500},
                     },

--- a/packages/lmux-aws-bedrock/tests/test_mappers.py
+++ b/packages/lmux-aws-bedrock/tests/test_mappers.py
@@ -168,8 +168,8 @@ class TestMapMessages:
         assert len(messages) == 1
         content = messages[0]["content"]
         assert len(content) == 2
-        assert content[0]["toolResult"]["toolUseId"] == "tc1"  # pyright: ignore[reportTypedDictNotRequiredAccess]
-        assert content[1]["toolResult"]["toolUseId"] == "tc2"  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        assert content[0]["toolResult"]["toolUseId"] == "tc1"
+        assert content[1]["toolResult"]["toolUseId"] == "tc2"
 
     def test_tool_message_after_user_not_merged(self) -> None:
         system, messages = map_messages(

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/__init__.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/__init__.py
@@ -36,4 +36,4 @@ def preload() -> None:
     Call this during application startup to pay the import cost upfront
     rather than on the first request.
     """
-    import openai  # noqa: F401, PLC0415  # pyright: ignore[reportUnusedImport]
+    import openai  # noqa: F401, PLC0415

--- a/packages/lmux-azure-foundry/tests/test_auth.py
+++ b/packages/lmux-azure-foundry/tests/test_auth.py
@@ -24,7 +24,7 @@ class TestAzureAdToken:
     def test_frozen(self) -> None:
         token = AzureAdToken(token="abc")  # noqa: S106
         with pytest.raises(AttributeError):
-            token.token = "xyz"  # pyright: ignore[reportAttributeAccessIssue]  # noqa: S105
+            token.token = "xyz"  # ty: ignore[invalid-assignment]  # noqa: S105
 
     def test_equality(self) -> None:
         assert AzureAdToken(token="abc") == AzureAdToken(token="abc")  # noqa: S106

--- a/packages/lmux-azure-foundry/tests/test_mappers.py
+++ b/packages/lmux-azure-foundry/tests/test_mappers.py
@@ -115,7 +115,7 @@ class TestMapMessages:
         parts: list[ContentPart] = [TextContent(text="What?"), ImageContent(url="https://img.png", detail="high")]
         result = map_messages([UserMessage(content=parts)])
         assert len(result) == 1
-        content = result[0]["content"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        content = result[0]["content"]
         assert isinstance(content, list)
         assert content[0] == {"type": "text", "text": "What?"}
         assert content[1] == {"type": "image_url", "image_url": {"url": "https://img.png", "detail": "high"}}
@@ -131,9 +131,7 @@ class TestMapMessages:
         msg = result[0]
         assert msg["role"] == "assistant"
         assert "content" not in msg
-        assert msg["tool_calls"] == [  # pyright: ignore[reportTypedDictNotRequiredAccess]
-            {"id": "tc1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
-        ]
+        assert msg["tool_calls"] == [{"id": "tc1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
 
     def test_tool_message(self) -> None:
         result = map_messages([ToolMessage(content="result", tool_call_id="tc1")])
@@ -179,9 +177,9 @@ class TestMapTools:
         result = map_tools(tools)
         fn = result[0]["function"]
         assert fn["name"] == "get_weather"
-        assert fn["description"] == "Get weather"  # pyright: ignore[reportTypedDictNotRequiredAccess]
-        assert fn["parameters"] == {"type": "object"}  # pyright: ignore[reportTypedDictNotRequiredAccess]
-        assert fn["strict"] is True  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        assert fn["description"] == "Get weather"
+        assert fn["parameters"] == {"type": "object"}
+        assert fn["strict"] is True
 
 
 # MARK: map_response_format

--- a/packages/lmux-azure-foundry/tests/test_params.py
+++ b/packages/lmux-azure-foundry/tests/test_params.py
@@ -9,7 +9,7 @@ from lmux_azure_foundry.params import AzureFoundryParams
 class TestAzureFoundryParams:
     def test_invalid_reasoning_effort(self) -> None:
         with pytest.raises(ValidationError):
-            _ = AzureFoundryParams(reasoning_effort="invalid")  # pyright: ignore[reportArgumentType]
+            _ = AzureFoundryParams(reasoning_effort="invalid")  # ty: ignore[invalid-argument-type]
 
     def test_defaults_all_none(self) -> None:
         params = AzureFoundryParams()
@@ -20,7 +20,7 @@ class TestAzureFoundryParams:
 
     def test_invalid_deployment_type(self) -> None:
         with pytest.raises(ValidationError):
-            _ = AzureFoundryParams(deployment_type="invalid")  # pyright: ignore[reportArgumentType]
+            _ = AzureFoundryParams(deployment_type="invalid")  # ty: ignore[invalid-argument-type]
 
     def test_valid_deployment_types(self) -> None:
         assert AzureFoundryParams(deployment_type="global").deployment_type == "global"

--- a/packages/lmux-azure-foundry/tests/test_provider.py
+++ b/packages/lmux-azure-foundry/tests/test_provider.py
@@ -1097,7 +1097,7 @@ class TestClientManagement:
         _ = provider.chat("gpt-4o", [UserMessage(content="Hi")])
 
         mock_sync_create.assert_called_once_with(
-            credential=FakeTokenProviderAuth._provider,  # pyright: ignore[reportPrivateUsage]
+            credential=FakeTokenProviderAuth._provider,
             azure_endpoint="https://test.openai.azure.com/",
             api_version="2025-04-01-preview",
             timeout=None,
@@ -1291,7 +1291,7 @@ class TestAclose:
 
         mock_async_create.assert_called_once()
         mock_async_client.close.assert_awaited_once()
-        assert provider._async_client is None  # pyright: ignore[reportPrivateUsage]
+        assert provider._async_client is None
 
     async def test_aclose_noop_when_no_client(self, fake_auth: FakeAuth) -> None:
         provider = AzureFoundryProvider(endpoint="https://test.openai.azure.com/", auth=fake_auth)

--- a/packages/lmux-google/src/lmux_google/__init__.py
+++ b/packages/lmux-google/src/lmux_google/__init__.py
@@ -34,4 +34,4 @@ __all__ = [
 
 def preload() -> None:
     """Eagerly import the google-genai SDK."""
-    import google.genai  # noqa: PLC0415, F401  # pyright: ignore[reportUnusedImport]
+    import google.genai  # noqa: PLC0415, F401

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -150,7 +150,7 @@ class GoogleProvider(
             response = client.models.generate_content(
                 model=model,
                 contents=contents,
-                config=config,  # pyright: ignore[reportArgumentType]
+                config=config,  # ty: ignore[invalid-argument-type]
             )
         except Exception as e:
             raise map_google_error(e) from e
@@ -190,7 +190,7 @@ class GoogleProvider(
             response = await client.aio.models.generate_content(
                 model=model,
                 contents=contents,
-                config=config,  # pyright: ignore[reportArgumentType]
+                config=config,  # ty: ignore[invalid-argument-type]
             )
         except Exception as e:
             raise map_google_error(e) from e
@@ -230,7 +230,7 @@ class GoogleProvider(
             stream = client.models.generate_content_stream(
                 model=model,
                 contents=contents,
-                config=config,  # pyright: ignore[reportArgumentType]
+                config=config,  # ty: ignore[invalid-argument-type]
             )
         except Exception as e:
             raise map_google_error(e) from e
@@ -278,7 +278,7 @@ class GoogleProvider(
             stream = client.aio.models.generate_content_stream(
                 model=model,
                 contents=contents,
-                config=config,  # pyright: ignore[reportArgumentType]
+                config=config,  # ty: ignore[invalid-argument-type]
             )
             async for chunk in await stream:
                 mapped = map_generate_content_chunk(chunk, model, PROVIDER_NAME)
@@ -303,7 +303,7 @@ class GoogleProvider(
         config = self._build_embed_config(dimensions, provider_params)
         try:
             client = self._get_client()
-            response = client.models.embed_content(model=model, contents=contents, config=config)  # pyright: ignore[reportArgumentType]
+            response = client.models.embed_content(model=model, contents=contents, config=config)  # ty: ignore[invalid-argument-type]
         except Exception as e:
             raise map_google_error(e) from e
         return map_embed_content_response(response, model, PROVIDER_NAME, self._calculate_cost)
@@ -321,7 +321,7 @@ class GoogleProvider(
         config = self._build_embed_config(dimensions, provider_params)
         try:
             client = await self._aget_client()
-            response = await client.aio.models.embed_content(model=model, contents=contents, config=config)  # pyright: ignore[reportArgumentType]
+            response = await client.aio.models.embed_content(model=model, contents=contents, config=config)  # ty: ignore[invalid-argument-type]
         except Exception as e:
             raise map_google_error(e) from e
         return map_embed_content_response(response, model, PROVIDER_NAME, self._calculate_cost)

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -1134,7 +1134,7 @@ class TestAclose:
 
         mock_create.assert_called_once()
         mock_client.aio.aclose.assert_awaited_once()
-        assert provider._client is None  # pyright: ignore[reportPrivateUsage]
+        assert provider._client is None
 
     async def test_aclose_noop_when_no_client(self, fake_auth: FakeAuth) -> None:
         provider = GoogleProvider(auth=fake_auth)

--- a/packages/lmux-groq/src/lmux_groq/__init__.py
+++ b/packages/lmux-groq/src/lmux_groq/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
 
 def preload() -> None:
     """Eagerly import the Groq SDK."""
-    import groq  # noqa: F401, PLC0415  # pyright: ignore[reportUnusedImport]
+    import groq  # noqa: F401, PLC0415

--- a/packages/lmux-groq/tests/test_mappers.py
+++ b/packages/lmux-groq/tests/test_mappers.py
@@ -108,7 +108,7 @@ class TestMapMessages:
         parts: list[ContentPart] = [TextContent(text="What?"), ImageContent(url="https://img.png", detail="high")]
         result = map_messages([UserMessage(content=parts)])
         assert len(result) == 1
-        content = result[0]["content"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        content = result[0]["content"]
         assert isinstance(content, list)
         assert content[0] == {"type": "text", "text": "What?"}
         assert content[1] == {"type": "image_url", "image_url": {"url": "https://img.png", "detail": "high"}}
@@ -124,7 +124,7 @@ class TestMapMessages:
         msg = result[0]
         assert msg["role"] == "assistant"
         assert "content" not in msg
-        assert msg["tool_calls"] == [{"id": "tc1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        assert msg["tool_calls"] == [{"id": "tc1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
 
     def test_tool_message(self) -> None:
         result = map_messages([ToolMessage(content="result", tool_call_id="tc1")])
@@ -168,11 +168,11 @@ class TestMapTools:
             )
         ]
         result = map_tools(tools)
-        fn = result[0]["function"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        fn = result[0]["function"]
         assert fn["name"] == "get_weather"
-        assert fn["description"] == "Get weather"  # pyright: ignore[reportTypedDictNotRequiredAccess]
-        assert fn["parameters"] == {"type": "object"}  # pyright: ignore[reportTypedDictNotRequiredAccess]
-        assert fn["strict"] is True  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        assert fn["description"] == "Get weather"
+        assert fn["parameters"] == {"type": "object"}
+        assert fn["strict"] is True
 
 
 # MARK: map_response_format

--- a/packages/lmux-groq/tests/test_params.py
+++ b/packages/lmux-groq/tests/test_params.py
@@ -19,4 +19,4 @@ class TestGroqParams:
 
     def test_invalid_service_tier(self) -> None:
         with pytest.raises(ValidationError):
-            _ = GroqParams(service_tier="invalid")  # pyright: ignore[reportArgumentType]
+            _ = GroqParams(service_tier="invalid")  # ty: ignore[invalid-argument-type]

--- a/packages/lmux-groq/tests/test_provider.py
+++ b/packages/lmux-groq/tests/test_provider.py
@@ -734,7 +734,7 @@ class TestAclose:
 
         mock_async_create.assert_called_once()
         mock_async_client.close.assert_awaited_once()
-        assert provider._async_client is None  # pyright: ignore[reportPrivateUsage]
+        assert provider._async_client is None
 
     async def test_aclose_noop_when_no_client(self, fake_auth: FakeAuth) -> None:
         provider = GroqProvider(auth=fake_auth)

--- a/packages/lmux-load-balancer/tests/test_provider.py
+++ b/packages/lmux-load-balancer/tests/test_provider.py
@@ -137,7 +137,7 @@ class TestChat:
         lb = LoadBalancerProvider(registry, {"m": {"a/x": 1.0}})
 
         # A non-LoadBalancerParams object must be tolerated (coerced to defaults), not crash.
-        result = lb.chat("m", _messages(), provider_params=BaseProviderParams())  # pyright: ignore[reportArgumentType]
+        result = lb.chat("m", _messages(), provider_params=BaseProviderParams())  # ty: ignore[invalid-argument-type]
         assert result.content == "hi"
 
 

--- a/packages/lmux-openai/src/lmux_openai/__init__.py
+++ b/packages/lmux-openai/src/lmux_openai/__init__.py
@@ -23,4 +23,4 @@ def preload() -> None:
     Call this during application startup to pay the import cost upfront
     rather than on the first request.
     """
-    import openai  # noqa: F401, PLC0415  # pyright: ignore[reportUnusedImport]
+    import openai  # noqa: F401, PLC0415

--- a/packages/lmux-openai/tests/test_mappers.py
+++ b/packages/lmux-openai/tests/test_mappers.py
@@ -132,7 +132,7 @@ class TestMapMessages:
         parts: list[ContentPart] = [TextContent(text="What?"), ImageContent(url="https://img.png", detail="high")]
         result = map_messages([UserMessage(content=parts)])
         assert len(result) == 1
-        content = result[0]["content"]  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        content = result[0]["content"]
         assert isinstance(content, list)
         assert content[0] == {"type": "text", "text": "What?"}
         assert content[1] == {"type": "image_url", "image_url": {"url": "https://img.png", "detail": "high"}}
@@ -148,9 +148,7 @@ class TestMapMessages:
         msg = result[0]
         assert msg["role"] == "assistant"
         assert "content" not in msg
-        assert msg["tool_calls"] == [  # pyright: ignore[reportTypedDictNotRequiredAccess]
-            {"id": "tc1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
-        ]
+        assert msg["tool_calls"] == [{"id": "tc1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
 
     def test_tool_message(self) -> None:
         result = map_messages([ToolMessage(content="result", tool_call_id="tc1")])
@@ -196,9 +194,9 @@ class TestMapTools:
         result = map_tools(tools)
         fn = result[0]["function"]
         assert fn["name"] == "get_weather"
-        assert fn["description"] == "Get weather"  # pyright: ignore[reportTypedDictNotRequiredAccess]
-        assert fn["parameters"] == {"type": "object"}  # pyright: ignore[reportTypedDictNotRequiredAccess]
-        assert fn["strict"] is True  # pyright: ignore[reportTypedDictNotRequiredAccess]
+        assert fn["description"] == "Get weather"
+        assert fn["parameters"] == {"type": "object"}
+        assert fn["strict"] is True
 
 
 # MARK: map_response_format

--- a/packages/lmux-openai/tests/test_params.py
+++ b/packages/lmux-openai/tests/test_params.py
@@ -9,8 +9,8 @@ from lmux_openai.params import OpenAIParams
 class TestOpenAIParams:
     def test_invalid_service_tier(self) -> None:
         with pytest.raises(ValidationError):
-            _ = OpenAIParams(service_tier="invalid")  # pyright: ignore[reportArgumentType]
+            _ = OpenAIParams(service_tier="invalid")  # ty: ignore[invalid-argument-type]
 
     def test_invalid_reasoning_effort(self) -> None:
         with pytest.raises(ValidationError):
-            _ = OpenAIParams(reasoning_effort="invalid")  # pyright: ignore[reportArgumentType]
+            _ = OpenAIParams(reasoning_effort="invalid")  # ty: ignore[invalid-argument-type]

--- a/packages/lmux-openai/tests/test_provider.py
+++ b/packages/lmux-openai/tests/test_provider.py
@@ -1197,7 +1197,7 @@ class TestAclose:
 
         mock_async_create.assert_called_once()
         mock_async_client.close.assert_awaited_once()
-        assert provider._async_client is None  # pyright: ignore[reportPrivateUsage]
+        assert provider._async_client is None
 
     async def test_aclose_noop_when_no_client(self, fake_auth: FakeAuth) -> None:
         provider = OpenAIProvider(auth=fake_auth)

--- a/packages/lmux/src/lmux/mock.py
+++ b/packages/lmux/src/lmux/mock.py
@@ -1,7 +1,5 @@
 """Mock provider for testing lmux consumer code."""
 
-# pyright: reportUnusedParameter=false
-
 from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import dataclass
 from typing import Literal, override

--- a/packages/lmux/src/lmux/registry.py
+++ b/packages/lmux/src/lmux/registry.py
@@ -101,7 +101,7 @@ class Registry:
             params = None
         if params is None:
             params = self._default_params.get(prefix)
-        return params
+        return params  # ty: ignore[invalid-return-type]
 
     # MARK: Chat
 
@@ -325,7 +325,9 @@ class Registry:
             msg = f"Provider {prefix!r} ({provider_name}) does not support the Responses API (model: {bare_model!r})"
             raise UnsupportedFeatureError(msg)
         return provider.create_response(
-            bare_model, input, provider_params=self._resolve_params(prefix, provider_params)
+            bare_model,
+            input,
+            provider_params=self._resolve_params(prefix, provider_params),  # ty: ignore[invalid-argument-type]
         )
 
     async def acreate_response(
@@ -342,7 +344,9 @@ class Registry:
             msg = f"Provider {prefix!r} ({provider_name}) does not support the Responses API (model: {bare_model!r})"
             raise UnsupportedFeatureError(msg)
         return await provider.acreate_response(
-            bare_model, input, provider_params=self._resolve_params(prefix, provider_params)
+            bare_model,
+            input,
+            provider_params=self._resolve_params(prefix, provider_params),  # ty: ignore[invalid-argument-type]
         )
 
     async def aclose(self) -> None:

--- a/packages/lmux/tests/test_mock.py
+++ b/packages/lmux/tests/test_mock.py
@@ -223,7 +223,7 @@ class TestRegisterPricing:
             tiers=[PricingTier(input_cost_per_token=0.001, output_cost_per_token=0.002)],
         )
         provider.register_pricing("my-model", pricing)
-        assert provider._custom_pricing["my-model"] == pricing  # pyright: ignore[reportPrivateUsage]
+        assert provider._custom_pricing["my-model"] == pricing
 
     def test_register_pricing_overwrites(self) -> None:
         provider = MockProvider()
@@ -235,4 +235,4 @@ class TestRegisterPricing:
         )
         provider.register_pricing("my-model", first)
         provider.register_pricing("my-model", second)
-        assert provider._custom_pricing["my-model"] == second  # pyright: ignore[reportPrivateUsage]
+        assert provider._custom_pricing["my-model"] == second

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,13 @@ members = ["packages/*"]
 
 [dependency-groups]
 dev = [
-  "basedpyright~=1.38.2",
   "boto3-stubs[bedrock,bedrock-runtime]~=1.42.59",
   "pytest~=9.0.3",
   "pytest-asyncio~=1.3.0",
   "pytest-cov~=7.0.0",
   "pytest-mock~=3.15.1",
   "ruff~=0.15.4",
+  "ty~=0.0.56",
   "types-aiobotocore[bedrock-runtime]~=3.2.0",
 ]
 
@@ -42,6 +42,7 @@ select = [
   "BLE",   # flake8-blind-except
   "B",     # flake8-bugbear
   "A",     # flake8-builtins
+  "ARG",   # flake8-unused-arguments
   "C4",    # flake8-comprehensions
   "T10",   # flake8-debugger
   "ISC",   # flake8-implicit-str-concat
@@ -55,6 +56,7 @@ select = [
   "Q",     # flake8-quotes
   "RSE",   # flake8-raise
   "RET",   # flake8-return
+  "SLF",   # flake8-self
   "SLOT",  # flake8-slots
   "SIM",   # flake8-simplify
   "TID",   # flake8-tidy-imports
@@ -75,6 +77,7 @@ ignore = [
 "**/tests/**/*.py" = [
   "S101",    # assert is fine in tests
   "PLR2004", # magic values are fine in tests
+  "SLF001",  # tests legitimately access private members
 ]
 
 [tool.ruff.lint.isort]
@@ -96,18 +99,16 @@ skip-magic-trailing-comma = false
 docstring-code-format = true
 docstring-code-line-length = 80
 
-# ── basedpyright ──────────────────────────────────────────────
-[tool.basedpyright]
-pythonVersion = "3.13"
-pythonPlatform = "All"
-typeCheckingMode = "recommended"
-include = ["packages/*/src/**", "packages/*/tests/**", "scripts/**"]
-exclude = ["**/__pycache__", "**/.venv"]
-reportMissingTypeStubs = false
-reportUnknownMemberType = false
-reportAny = false
-reportExplicitAny = false
-reportUnnecessaryTypeIgnoreComment = "error"
+# ── ty ────────────────────────────────────────────────────────
+[tool.ty.environment]
+python-version = "3.13"
+python-platform = "all"
+
+[tool.ty.src]
+include = ["packages/*/src", "packages/*/tests", "scripts"]
+
+[tool.ty.rules]
+unused-ignore-comment = "error"
 
 # ── Pytest ────────────────────────────────────────────────────
 [tool.pytest.ini_options]

--- a/scripts/validate_pricing.py
+++ b/scripts/validate_pricing.py
@@ -116,7 +116,7 @@ def _to_per_million(per_token: float) -> Decimal:
 def extract_lmux_pricing(module_name: str) -> dict[str, PricePoint]:
     """Import a provider's cost module and extract base-tier pricing."""
     mod = importlib.import_module(module_name)
-    pricing_dict: dict[str, Any] = mod._PRICING
+    pricing_dict: dict[str, Any] = mod._PRICING  # noqa: SLF001
     result: dict[str, PricePoint] = {}
     for model_id, model_pricing in pricing_dict.items():
         base_tier = model_pricing.tiers[0]
@@ -136,7 +136,7 @@ def extract_lmux_pricing(module_name: str) -> dict[str, PricePoint]:
 def extract_lmux_tiered_pricing(module_name: str) -> dict[str, TieredPricing]:
     """Import a provider's cost module and extract all pricing tiers."""
     mod = importlib.import_module(module_name)
-    pricing_dict: dict[str, Any] = mod._PRICING
+    pricing_dict: dict[str, Any] = mod._PRICING  # noqa: SLF001
     result: dict[str, TieredPricing] = {}
     for model_id, model_pricing in pricing_dict.items():
         if len(model_pricing.tiers) <= 1:
@@ -410,9 +410,9 @@ def _extract_genai_base_price(value: object) -> Decimal | None:
     if isinstance(value, (int, float)):
         return Decimal(str(value))
     if isinstance(value, dict):
-        base: object = value.get("base")  # pyright: ignore[reportUnknownVariableType]
+        base: object = value.get("base")
         if base is not None:
-            return Decimal(str(base))  # pyright: ignore[reportUnknownArgumentType]
+            return Decimal(str(base))
     return None
 
 
@@ -422,12 +422,12 @@ def _resolve_genai_prices(prices_data: object) -> dict[str, object] | None:
     if isinstance(target, list):
         if not target:
             return None
-        last_entry: object = target[-1]  # pyright: ignore[reportUnknownVariableType]
+        last_entry: object = target[-1]
         if not isinstance(last_entry, dict):
             return None
-        target = last_entry.get("prices", last_entry)  # pyright: ignore[reportUnknownVariableType]
+        target = last_entry.get("prices", last_entry)
     if isinstance(target, dict):
-        return dict(target)  # pyright: ignore[reportUnknownArgumentType]
+        return dict(target)  # ty: ignore[no-matching-overload]
     return None
 
 
@@ -650,8 +650,8 @@ def compare_calculated_costs(
             if expected_total == 0:
                 continue
 
-            actual_total: float = lmux_cost.total_cost  # pyright: ignore[reportAttributeAccessIssue, reportUnknownVariableType]
-            pct = abs(Decimal(str(actual_total)) - Decimal(str(expected_total))) / Decimal(str(expected_total)) * 100  # pyright: ignore[reportUnknownArgumentType]
+            actual_total: float = lmux_cost.total_cost  # ty: ignore[unresolved-attribute]
+            pct = abs(Decimal(str(actual_total)) - Decimal(str(expected_total))) / Decimal(str(expected_total)) * 100
             if pct <= tolerance_pct:
                 continue
 
@@ -659,7 +659,7 @@ def compare_calculated_costs(
                 Mismatch(
                     model=f"{model_id} ({in_tok:,}in/{out_tok:,}out/{cache_tok:,}cache)",
                     field="total_cost",
-                    lmux_value=Decimal(str(round(actual_total, 8))),  # pyright: ignore[reportUnknownArgumentType]
+                    lmux_value=Decimal(str(round(actual_total, 8))),
                     external_value=Decimal(str(round(expected_total, 8))),
                     pct_diff=pct,
                 )

--- a/uv.lock
+++ b/uv.lock
@@ -233,18 +233,6 @@ wheels = [
 ]
 
 [[package]]
-name = "basedpyright"
-version = "1.38.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodejs-wheel-binaries" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/b4/26cb812eaf8ab56909c792c005fe1690706aef6f21d61107639e46e9c54c/basedpyright-1.38.4.tar.gz", hash = "sha256:8e7d4f37ffb6106621e06b9355025009cdf5b48f71c592432dd2dd304bf55e70", size = 25354730, upload-time = "2026-03-25T13:50:44.353Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/0b/3f95fd47def42479e61077523d3752086d5c12009192a7f1c9fd5507e687/basedpyright-1.38.4-py3-none-any.whl", hash = "sha256:90aa067cf3e8a3c17ad5836a72b9e1f046bc72a4ad57d928473d9368c9cd07a2", size = 12352258, upload-time = "2026-03-25T13:50:41.059Z" },
-]
-
-[[package]]
 name = "boto3"
 version = "1.42.70"
 source = { registry = "https://pypi.org/simple" }
@@ -960,13 +948,13 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
-    { name = "basedpyright" },
     { name = "boto3-stubs", extra = ["bedrock", "bedrock-runtime"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "types-aiobotocore", extra = ["bedrock-runtime"] },
 ]
 
@@ -974,13 +962,13 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "basedpyright", specifier = "~=1.38.2" },
     { name = "boto3-stubs", extras = ["bedrock", "bedrock-runtime"], specifier = "~=1.42.59" },
     { name = "pytest", specifier = "~=9.0.3" },
     { name = "pytest-asyncio", specifier = "~=1.3.0" },
     { name = "pytest-cov", specifier = "~=7.0.0" },
     { name = "pytest-mock", specifier = "~=3.15.1" },
     { name = "ruff", specifier = "~=0.15.4" },
+    { name = "ty", specifier = "~=0.0.56" },
     { name = "types-aiobotocore", extras = ["bedrock-runtime"], specifier = "~=3.2.0" },
 ]
 
@@ -1107,22 +1095,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/bb/65dc1b2c5796a6ab5f60bdb57343bd6c3ecb82251c580eca415c8548333e/mypy_boto3_bedrock_runtime-1.42.42.tar.gz", hash = "sha256:3a4088218478b6fbbc26055c03c95bee4fc04624a801090b3cce3037e8275c8d", size = 29840, upload-time = "2026-02-04T20:53:05.999Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/43/7ea062f2228f47b5779dcfa14dab48d6e29f979b35d1a5102b0ba80b9c1b/mypy_boto3_bedrock_runtime-1.42.42-py3-none-any.whl", hash = "sha256:b2d16eae22607d0685f90796b3a0afc78c0b09d45872e00eafd634a31dd9358f", size = 36077, upload-time = "2026-02-04T20:53:01.768Z" },
-]
-
-[[package]]
-name = "nodejs-wheel-binaries"
-version = "24.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/05/c75c0940b1ebf82975d14f37176679b6f3229eae8b47b6a70d1e1dae0723/nodejs_wheel_binaries-24.14.0.tar.gz", hash = "sha256:c87b515e44b0e4a523017d8c59f26ccbd05b54fe593338582825d4b51fc91e1c", size = 8057, upload-time = "2026-02-27T02:57:30.931Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/8c/b057c2db3551a6fe04e93dd14e33d810ac8907891534ffcc7a051b253858/nodejs_wheel_binaries-24.14.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:59bb78b8eb08c3e32186da1ef913f1c806b5473d8bd0bb4492702092747b674a", size = 54798488, upload-time = "2026-02-27T02:56:56.831Z" },
-    { url = "https://files.pythonhosted.org/packages/30/88/7e1b29c067b6625c97c81eb8b0ef37cf5ad5b62bb81e23f4bde804910ec9/nodejs_wheel_binaries-24.14.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:348fa061b57625de7250d608e2d9b7c4bc170544da7e328325343860eadd59e5", size = 54972803, upload-time = "2026-02-27T02:57:01.696Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/e0/a83f0ff12faca2a56366462e572e38ac6f5cb361877bb29e289138eb7f24/nodejs_wheel_binaries-24.14.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:222dbf516ccc877afcad4e4789a81b4ee93daaa9f0ad97c464417d9597f49449", size = 59340859, upload-time = "2026-02-27T02:57:06.125Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/9f/06fad4ae8a723ae7096b5311eba67ad8b4df5f359c0a68e366750b7fef78/nodejs_wheel_binaries-24.14.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b35d6fcccfe4fb0a409392d237fbc67796bac0d357b996bc12d057a1531a238b", size = 59838751, upload-time = "2026-02-27T02:57:10.449Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/72/4916dadc7307c3e9bcfa43b4b6f88237932d502c66f89eb2d90fb07810db/nodejs_wheel_binaries-24.14.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:519507fb74f3f2b296ab1e9f00dcc211f36bbfb93c60229e72dcdee9dafd301a", size = 61340534, upload-time = "2026-02-27T02:57:15.309Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/a8ba881ee5d04b04e0d93abc8ce501ff7292813583e97f9789eb3fc0472a/nodejs_wheel_binaries-24.14.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:68c93c52ff06d704bcb5ed160b4ba04ab1b291d238aaf996b03a5396e0e9a7ed", size = 61922394, upload-time = "2026-02-27T02:57:20.24Z" },
-    { url = "https://files.pythonhosted.org/packages/60/8c/b8c5f61201c72a0c7dc694b459941f89a6defda85deff258a9940a4e2efc/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:60b83c4e98b0c7d836ac9ccb67dcb36e343691cbe62cd325799ff9ed936286f3", size = 41218783, upload-time = "2026-02-27T02:57:24.175Z" },
-    { url = "https://files.pythonhosted.org/packages/91/23/1f904bc9cbd8eece393e20840c08ba3ac03440090c3a4e95168fa6d2709f/nodejs_wheel_binaries-24.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:78a9bd1d6b11baf1433f9fb84962ff8aa71c87d48b6434f98224bc49a2253a6e", size = 38926103, upload-time = "2026-02-27T02:57:27.458Z" },
 ]
 
 [[package]]
@@ -1507,6 +1479,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.57"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/16/d01c968d405acae51c07872e80f30f3a586235bdf52c9847ca0917a230a3/ty-0.0.57.tar.gz", hash = "sha256:bc058f564868690283a0420d09c269ec8be21e8e43b4b49ee975a17623092e44", size = 6100787, upload-time = "2026-07-08T11:33:59.904Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/9c/a7948b05f2a3f43d511f88ef5c4f56d7edb8acc8caa5f56d7c5831f52c84/ty-0.0.57-py3-none-linux_armv6l.whl", hash = "sha256:cb6d3371dd8c78950b75bee31a36b94564a54a1f0eecafbbf05715ac1a5287d6", size = 11760058, upload-time = "2026-07-08T11:33:18.671Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/92/3776380decba3965bcaa1ea2b56f5b133aa3ef549bfbe4b79eb122dcc15d/ty-0.0.57-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e58b90491a48ec757bd50f512f3eb92c1c64b7d46a4db83677e9b60222e1d2bb", size = 11492105, upload-time = "2026-07-08T11:33:21.267Z" },
+    { url = "https://files.pythonhosted.org/packages/13/be/912f8422d06fd1e29805a7c781e3ce4c821917e0e3d00f0cf176c0529469/ty-0.0.57-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dbb8207f75122c658ca21bf405cea8202e490240440461ae3e0c5a6f67ae668f", size = 11078675, upload-time = "2026-07-08T11:33:23.804Z" },
+    { url = "https://files.pythonhosted.org/packages/06/86/6ed526df554b491ce3d07bbec04f7a10304243bc994ab989352c85134b1e/ty-0.0.57-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:651243f391809de80b01be1729c5d0cecc7b952d7d22cfbf56f0b4f069703195", size = 11614379, upload-time = "2026-07-08T11:33:26.041Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/95/78af20f309abce31fa616e0142f85756e665a9965669b823181ff695ffec/ty-0.0.57-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:28c5392bbd7c4d6a4c1b1646a709231db675dc094f49bf71b7de83757125e93b", size = 11563854, upload-time = "2026-07-08T11:33:28.144Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dc/bf9231d5563b9e61a1eec9782184a4055afaa87259644cd9ed1376a7dc5c/ty-0.0.57-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8d981535094ab492aaef6f71d9348bcf90e42e6de4cb50de2dd7fbabd8378360", size = 12229897, upload-time = "2026-07-08T11:33:30.262Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/dd/012008190a997097ebe500b9704baaad9135bfa033b9530a9b8f69f1d11f/ty-0.0.57-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:719b41fd6df61352866cad952d7bfb4873c893a70e806d37d0f1d30ad4f26cd5", size = 12816002, upload-time = "2026-07-08T11:33:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2f/0e42c361e38e04747ed2b3d3299512edd4ea6060d8e3124e3c6f2d2465a1/ty-0.0.57-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a1641a609b025e13f44115c7071b39b02675044a78fbfedef239a5f7da50b393", size = 12323420, upload-time = "2026-07-08T11:33:35.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/01/18f1e03108d1ae8e515c92fb304994a66eaafd47037f928fd42fd3a1e29d/ty-0.0.57-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a33f96a9dd6919fe8b1d3512cd99f16be4a51388f265de135fea2c2fbf0b4317", size = 12119481, upload-time = "2026-07-08T11:33:37.808Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/48/570b73fb3e32554ff03aa9f6650b33a504cdfa027a8b50a5ab087e56b20d/ty-0.0.57-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f0a1014a922b2b7f79a46e5cdbaa6feb7403a444631292b8666382a98a04de20", size = 12427299, upload-time = "2026-07-08T11:33:39.964Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/76b27f6a92e12525d09cd65d3c3b5aea419cf4782b13320db95ac3d310f0/ty-0.0.57-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d73aaed84023bf682819f871377b255fae9098898c50475426ac9bdfcd986872", size = 11562292, upload-time = "2026-07-08T11:33:42.392Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8b/d0c398147b00f336595e1a00a5895b3924251205c11b8d73cb0668281f1c/ty-0.0.57-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f3e2104704063c00ab8a757af3e95378b32624a3e8d8149aad5251877bf82959", size = 11565833, upload-time = "2026-07-08T11:33:44.778Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/74/dab9745e977ef38751ec710f74e40d21fddbd04a80338dd5597c98899eed/ty-0.0.57-py3-none-musllinux_1_2_i686.whl", hash = "sha256:07ad760763646d8f1567ea5d899e6d217212acd8539b7afed5a370d93693553b", size = 11864967, upload-time = "2026-07-08T11:33:47.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/57/350812143b49dac7aa655f40a1f45d4821ca9b56b75d9b68d5e603269044/ty-0.0.57-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b4a6e1f0fee7df3e65fb0b9cbe9f99a4be39198558ed9aacc31a98d210ad7bcc", size = 12239054, upload-time = "2026-07-08T11:33:49.586Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d0/b3e3d9c6cce3debda6247aa435e81d18ec62fabfec13f35f6c6957066f47/ty-0.0.57-py3-none-win32.whl", hash = "sha256:f8d488c0535a8f0386dbe2c9bcb31d467ae0c68d0c9945113018937828ebaabb", size = 11225353, upload-time = "2026-07-08T11:33:52.569Z" },
+    { url = "https://files.pythonhosted.org/packages/77/db/6ce240ee31413f9dc7467e31377553e92e2664252ee7d33aa9290a7a94bb/ty-0.0.57-py3-none-win_amd64.whl", hash = "sha256:de9529a7dcc3e529b08c14634dc4e7066ebea5cd55006afc02bde8033efe7c91", size = 12272419, upload-time = "2026-07-08T11:33:54.889Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/48662fa2c42289f309eeb8b5539cbe840e10002b65ac0700cb7889e92532/ty-0.0.57-py3-none-win_arm64.whl", hash = "sha256:7f3352777ce40c4906145f3c3e10b71716d8d35c0c9e3a0070d84f61dda0755f", size = 11686309, upload-time = "2026-07-08T11:33:57.246Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Switches the type checker from **basedpyright** to **ty** (Astral's checker, matching the ruff/uv stack) and moves the lint-y checks basedpyright was enforcing into ruff — so **ruff owns all linting, ty is a pure type checker**. No basedpyright/pyright reference remains anywhere.

- **ruff**: add `ARG` (unused arguments) + `SLF` (private access) to select; `SLF001` ignored in tests. `F401` already covered unused imports.
- **ty**: pinned dev dep `ty~=0.0.56`, `[tool.ty]` config with `unused-ignore-comment = "error"` (mirrors basedpyright's `reportUnnecessaryTypeIgnoreComment`).
- **89 inline `# pyright: ignore`** → converted to `# ty: ignore[...]` where ty still flags, deleted where it doesn't (lint-only / less-strict).
- CI, README, AGENTS.md, the release skill, and the local settings permission all point to ty.

ty is stricter than basedpyright in **6 spots** (in `registry.py` and the anthropic/aws mappers) that had no suppression — suppressed with `# ty: ignore` to keep behavior identical; fixing them is a possible follow-up.

Caveat: **ty is v0.0.57 (early/preview)** — adopting it as the CI gate is an early-adopter call.

Tooling-only, no runtime change → no version bumps. All four gates green: ruff, format, ty, pytest (1301 pass, 100% branch coverage).
