### PR TITLE
feat(anthropic): SDK-lite httpx transport with Pydantic wire models

### DIFF
--- a/packages/lmux-anthropic/README.md
+++ b/packages/lmux-anthropic/README.md
@@ -1,6 +1,6 @@
 # lmux-anthropic
 
-Anthropic provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [anthropic](https://pypi.org/project/anthropic/) SDK.
+Anthropic provider for [lmux](https://github.com/cluebbehusen/lmux). Talks to the Anthropic Messages API directly over [httpx](https://pypi.org/project/httpx/).
 
 Supports chat completions and streaming.
 
@@ -94,7 +94,7 @@ Cache reads/writes are reported on `response.usage` (`cache_read_tokens`, `cache
 
 ## Claude on Vertex AI
 
-Requires the `vertex` extra, which pulls in `google-auth` via `anthropic[vertex]`:
+Requires the `vertex` extra, which pulls in `google-auth`:
 
 ```bash
 uv add "lmux-anthropic[vertex]"

--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "lmux~=0.9",
+  "lmux~=0.10",
   "httpx~=0.28",
 ]
 

--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -15,11 +15,11 @@ classifiers = [
 ]
 dependencies = [
   "lmux~=0.9",
-  "anthropic~=0.83",
+  "httpx~=0.28",
 ]
 
 [project.optional-dependencies]
-vertex = ["anthropic[vertex]~=0.83"]
+vertex = ["google-auth~=2.0"]
 
 [project.urls]
 Homepage = "https://github.com/cluebbehusen/lmux"

--- a/packages/lmux-anthropic/src/lmux_anthropic/__init__.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/__init__.py
@@ -27,5 +27,5 @@ __all__ = [
 
 
 def preload() -> None:
-    """Eagerly import the Anthropic SDK."""
-    import anthropic  # noqa: F401, PLC0415
+    """Eagerly import the HTTP client."""
+    import httpx  # noqa: F401, PLC0415

--- a/packages/lmux-anthropic/src/lmux_anthropic/_exceptions.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_exceptions.py
@@ -2,6 +2,8 @@
 
 from typing import TYPE_CHECKING, Any
 
+from pydantic import ValidationError
+
 from lmux.exceptions import (
     AuthenticationError,
     InvalidRequestError,
@@ -12,6 +14,7 @@ from lmux.exceptions import (
     RateLimitError,
     TimeoutError,  # noqa: A004
 )
+from lmux_anthropic._wire import WireMessage
 
 if TYPE_CHECKING:
     import httpx
@@ -31,17 +34,13 @@ def raise_for_status(response: "httpx.Response", provider: str = PROVIDER) -> No
         raise error_from_response(response, provider)
 
 
-def parse_json(response: "httpx.Response", provider: str = PROVIDER) -> dict[str, Any]:
-    """Return the JSON object body of a success response, mapping a malformed or non-object body to a ProviderError."""
+def parse_message(response: "httpx.Response", provider: str = PROVIDER) -> WireMessage:
+    """Validate a success body into a WireMessage, mapping a malformed or mis-shaped body to a ProviderError."""
     try:
-        data = response.json()
-    except ValueError as e:
+        return WireMessage.model_validate_json(response.content)
+    except ValidationError as e:
         msg = "malformed response body"
         raise ProviderError(msg, provider=provider, status_code=response.status_code) from e
-    if not isinstance(data, dict):
-        msg = "expected a JSON object response body"
-        raise ProviderError(msg, provider=provider, status_code=response.status_code)
-    return data
 
 
 def error_from_stream(payload: dict[str, Any], provider: str = PROVIDER) -> LmuxError:

--- a/packages/lmux-anthropic/src/lmux_anthropic/_exceptions.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_exceptions.py
@@ -7,6 +7,7 @@ from lmux.exceptions import (
     InvalidRequestError,
     LmuxError,
     NotFoundError,
+    PermissionDeniedError,
     ProviderError,
     RateLimitError,
     TimeoutError,  # noqa: A004
@@ -54,8 +55,10 @@ def error_from_response(response: "httpx.Response", provider: str = PROVIDER) ->
     """Map an HTTP error response to an lmux exception (body must be readable)."""
     code = response.status_code
     msg = _message(response)
-    if code in (_AUTH, _FORBIDDEN):
+    if code == _AUTH:
         return AuthenticationError(msg, provider=provider, status_code=code)
+    if code == _FORBIDDEN:
+        return PermissionDeniedError(msg, provider=provider, status_code=code)
     if code == _RATE_LIMIT:
         return RateLimitError(msg, provider=provider, status_code=code, retry_after=_retry_after(response))
     if code == _BAD_REQUEST:

--- a/packages/lmux-anthropic/src/lmux_anthropic/_exceptions.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_exceptions.py
@@ -1,4 +1,6 @@
-"""Map Anthropic SDK exceptions to lmux exception hierarchy."""
+"""Map HTTP responses and transport errors to the lmux exception hierarchy."""
+
+from typing import TYPE_CHECKING
 
 from lmux.exceptions import (
     AuthenticationError,
@@ -10,53 +12,65 @@ from lmux.exceptions import (
     TimeoutError,  # noqa: A004
 )
 
+if TYPE_CHECKING:
+    import httpx
+
 PROVIDER = "anthropic"
 
+_AUTH = 401
+_FORBIDDEN = 403
+_BAD_REQUEST = 400
+_NOT_FOUND = 404
+_RATE_LIMIT = 429
 
-def map_anthropic_error(error: Exception, provider: str = PROVIDER) -> LmuxError:  # noqa: PLR0911
-    """Convert an Anthropic SDK exception to the corresponding lmux exception."""
-    import anthropic  # noqa: PLC0415
 
-    if isinstance(error, anthropic.AuthenticationError):
-        return AuthenticationError(str(error), provider=provider, status_code=401)
+def raise_for_status(response: "httpx.Response", provider: str = PROVIDER) -> None:
+    """Raise the mapped lmux error for a non-streamed error response."""
+    if response.status_code >= _BAD_REQUEST:
+        raise error_from_response(response, provider)
 
-    if isinstance(error, anthropic.PermissionDeniedError):
-        return AuthenticationError(str(error), provider=provider, status_code=403)
 
-    if isinstance(error, anthropic.RateLimitError):
-        retry_after = _extract_retry_after(error)
-        return RateLimitError(str(error), provider=provider, status_code=429, retry_after=retry_after)
+def error_from_response(response: "httpx.Response", provider: str = PROVIDER) -> LmuxError:
+    """Map an HTTP error response to an lmux exception (body must be readable)."""
+    code = response.status_code
+    msg = _message(response)
+    if code in (_AUTH, _FORBIDDEN):
+        return AuthenticationError(msg, provider=provider, status_code=code)
+    if code == _RATE_LIMIT:
+        return RateLimitError(msg, provider=provider, status_code=code, retry_after=_retry_after(response))
+    if code == _BAD_REQUEST:
+        return InvalidRequestError(msg, provider=provider, status_code=code)
+    if code == _NOT_FOUND:
+        return NotFoundError(msg, provider=provider, status_code=code)
+    return ProviderError(msg, provider=provider, status_code=code)
 
-    if isinstance(error, anthropic.BadRequestError):
-        return InvalidRequestError(str(error), provider=provider, status_code=400)
 
-    if isinstance(error, anthropic.NotFoundError):
-        return NotFoundError(str(error), provider=provider, status_code=404)
+def map_transport_error(error: Exception, provider: str = PROVIDER) -> LmuxError:
+    """Map an httpx transport error (or client-creation failure) to an lmux error."""
+    import httpx  # noqa: PLC0415
 
-    if isinstance(error, anthropic.InternalServerError):
-        return ProviderError(str(error), provider=provider, status_code=error.status_code)
-
-    if isinstance(error, anthropic.APITimeoutError):
+    if isinstance(error, LmuxError):
+        return error
+    if isinstance(error, httpx.TimeoutException):
         return TimeoutError(str(error), provider=provider)
-
-    if isinstance(error, anthropic.APIStatusError):
-        return ProviderError(str(error), provider=provider, status_code=error.status_code)
-
-    if isinstance(error, anthropic.APIError):
-        return ProviderError(str(error), provider=provider)
-
     return ProviderError(str(error), provider=provider)
 
 
-def _extract_retry_after(error: Exception) -> float | None:
-    """Extract Retry-After header value from an Anthropic error response."""
-    response = getattr(error, "response", None)
-    if response is None:
-        return None
-    retry_header = response.headers.get("retry-after")
-    if retry_header is None:
+def _message(response: "httpx.Response") -> str:
+    try:
+        data = response.json()
+    except ValueError:
+        return response.text
+    if isinstance(data, dict) and isinstance(data.get("error"), dict):
+        return str(data["error"].get("message") or response.text)
+    return response.text
+
+
+def _retry_after(response: "httpx.Response") -> float | None:
+    header = response.headers.get("retry-after")
+    if header is None:
         return None
     try:
-        return float(retry_header)
-    except (ValueError, TypeError):
+        return float(header)
+    except ValueError:
         return None

--- a/packages/lmux-anthropic/src/lmux_anthropic/_exceptions.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_exceptions.py
@@ -1,6 +1,6 @@
 """Map HTTP responses and transport errors to the lmux exception hierarchy."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lmux.exceptions import (
     AuthenticationError,
@@ -28,6 +28,26 @@ def raise_for_status(response: "httpx.Response", provider: str = PROVIDER) -> No
     """Raise the mapped lmux error for a non-streamed error response."""
     if response.status_code >= _BAD_REQUEST:
         raise error_from_response(response, provider)
+
+
+def parse_json(response: "httpx.Response", provider: str = PROVIDER) -> dict[str, Any]:
+    """Return the JSON object body of a success response, mapping a malformed or non-object body to a ProviderError."""
+    try:
+        data = response.json()
+    except ValueError as e:
+        msg = "malformed response body"
+        raise ProviderError(msg, provider=provider, status_code=response.status_code) from e
+    if not isinstance(data, dict):
+        msg = "expected a JSON object response body"
+        raise ProviderError(msg, provider=provider, status_code=response.status_code)
+    return data
+
+
+def error_from_stream(payload: dict[str, Any], provider: str = PROVIDER) -> LmuxError:
+    """Map a streamed Anthropic ``error`` event to an lmux error."""
+    error = payload.get("error")
+    message = error.get("message") if isinstance(error, dict) else error
+    return ProviderError(str(message), provider=provider)
 
 
 def error_from_response(response: "httpx.Response", provider: str = PROVIDER) -> LmuxError:

--- a/packages/lmux-anthropic/src/lmux_anthropic/_lazy.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_lazy.py
@@ -1,5 +1,6 @@
 """HTTP client factories for the Anthropic, Vertex, and Foundry transports."""
 
+import os
 from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING
 
@@ -102,9 +103,15 @@ class HttpxTransportRequest:
 
 
 def vertex_base_url(region: str) -> str:
-    """Return the Vertex AI base URL for a region (``global`` has no region prefix)."""
+    """Return the Vertex AI base URL for a region.
+
+    ``global`` has no region prefix; the ``us`` and ``eu`` multi-regions use their
+    dedicated ``rep`` endpoints; anything else is a standard regional host.
+    """
     if region == "global":
         return "https://aiplatform.googleapis.com/v1"
+    if region in ("us", "eu"):
+        return f"https://aiplatform.{region}.rep.googleapis.com/v1"
     return f"https://{region}-aiplatform.googleapis.com/v1"
 
 
@@ -117,22 +124,22 @@ def resolve_vertex_token(credentials: "Credentials") -> str:
     return credentials.token
 
 
-def _vertex_headers(token: str) -> Mapping[str, str]:
-    return {"Authorization": f"Bearer {token}", "content-type": _JSON}
+def vertex_auth_headers(credentials: "Credentials") -> dict[str, str]:
+    """Per-request Vertex auth header, refreshing the (short-lived) access token if needed."""
+    return {"Authorization": f"Bearer {resolve_vertex_token(credentials)}"}
 
 
 def create_sync_vertex_client(
     *,
-    credentials: "Credentials",
     region: str,
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
 ) -> "httpx.Client":
-    """Create an httpx client for the Vertex AI ``rawPredict`` endpoint."""
+    """Create an httpx client for the Vertex AI ``rawPredict`` endpoint (auth is applied per request)."""
     return _create_sync(
         base_url=base_url or vertex_base_url(region),
-        headers=_vertex_headers(resolve_vertex_token(credentials)),
+        headers={"content-type": _JSON},
         timeout=timeout,
         max_retries=max_retries,
     )
@@ -140,16 +147,15 @@ def create_sync_vertex_client(
 
 def create_async_vertex_client(
     *,
-    credentials: "Credentials",
     region: str,
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
 ) -> "httpx.AsyncClient":
-    """Create an async httpx client for the Vertex AI ``rawPredict`` endpoint."""
+    """Create an async httpx client for the Vertex AI ``rawPredict`` endpoint (auth is applied per request)."""
     return _create_async(
         base_url=base_url or vertex_base_url(region),
-        headers=_vertex_headers(resolve_vertex_token(credentials)),
+        headers={"content-type": _JSON},
         timeout=timeout,
         max_retries=max_retries,
     )
@@ -163,56 +169,61 @@ def foundry_base_url(resource: str) -> str:
     return f"https://{resource}.services.ai.azure.com/anthropic"
 
 
-def _foundry_headers(api_key: str | None, azure_ad_token_provider: "Callable[[], str] | None") -> Mapping[str, str]:
-    headers: dict[str, str] = {"anthropic-version": ANTHROPIC_VERSION, "content-type": _JSON}
+def foundry_auth_headers(api_key: str | None, azure_ad_token_provider: "Callable[[], str] | None") -> dict[str, str]:
+    """Per-request Foundry auth headers.
+
+    An Entra ID token provider is invoked on every call for a fresh bearer token. For
+    API-key auth the endpoint authenticates with ``x-api-key``; ``api-key`` is also sent
+    for backwards compatibility.
+    """
     if azure_ad_token_provider is not None:
-        headers["Authorization"] = f"Bearer {azure_ad_token_provider()}"
-    elif api_key is not None:
-        headers["api-key"] = api_key
-    else:
-        raise ValueError("Foundry requires either an api_key or an azure_ad_token_provider")  # noqa: TRY003
-    return headers
+        return {"Authorization": f"Bearer {azure_ad_token_provider()}"}
+    if api_key is not None:
+        return {"x-api-key": api_key, "api-key": api_key}
+    raise ValueError("Foundry requires either an api_key or an azure_ad_token_provider")  # noqa: TRY003
 
 
 def _resolve_foundry_base_url(base_url: str | None, resource: str | None) -> str:
+    base_url = base_url or os.environ.get("ANTHROPIC_FOUNDRY_BASE_URL")
     if base_url is not None:
         return base_url
+    resource = resource or os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE")
     if resource is not None:
         return foundry_base_url(resource)
-    raise ValueError("Foundry requires either a base_url or a resource")  # noqa: TRY003
+    msg = (
+        "Foundry requires a base_url or resource "
+        "(or the ANTHROPIC_FOUNDRY_BASE_URL / ANTHROPIC_FOUNDRY_RESOURCE env var)"
+    )
+    raise ValueError(msg)
 
 
-def create_sync_foundry_client(  # noqa: PLR0913
+def create_sync_foundry_client(
     *,
-    api_key: str | None = None,
-    azure_ad_token_provider: "Callable[[], str] | None" = None,
     resource: str | None = None,
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
 ) -> "httpx.Client":
-    """Create an httpx client for the Microsoft Foundry Anthropic endpoint."""
+    """Create an httpx client for the Microsoft Foundry Anthropic endpoint (auth is applied per request)."""
     return _create_sync(
         base_url=_resolve_foundry_base_url(base_url, resource),
-        headers=_foundry_headers(api_key, azure_ad_token_provider),
+        headers={"anthropic-version": ANTHROPIC_VERSION, "content-type": _JSON},
         timeout=timeout,
         max_retries=max_retries,
     )
 
 
-def create_async_foundry_client(  # noqa: PLR0913
+def create_async_foundry_client(
     *,
-    api_key: str | None = None,
-    azure_ad_token_provider: "Callable[[], str] | None" = None,
     resource: str | None = None,
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
 ) -> "httpx.AsyncClient":
-    """Create an async httpx client for the Microsoft Foundry Anthropic endpoint."""
+    """Create an async httpx client for the Microsoft Foundry Anthropic endpoint (auth is applied per request)."""
     return _create_async(
         base_url=_resolve_foundry_base_url(base_url, resource),
-        headers=_foundry_headers(api_key, azure_ad_token_provider),
+        headers={"anthropic-version": ANTHROPIC_VERSION, "content-type": _JSON},
         timeout=timeout,
         max_retries=max_retries,
     )

--- a/packages/lmux-anthropic/src/lmux_anthropic/_lazy.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_lazy.py
@@ -1,11 +1,28 @@
-"""Lazy Anthropic SDK loading internals."""
+"""HTTP client factories for the Anthropic, Vertex, and Foundry transports."""
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING
+
+from lmux._http import create_async_client as _create_async
+from lmux._http import create_sync_client as _create_sync
 
 if TYPE_CHECKING:
-    import anthropic
+    import httpx
     from google.auth.credentials import Credentials
+
+DEFAULT_BASE_URL = "https://api.anthropic.com"
+ANTHROPIC_VERSION = "2023-06-01"
+VERTEX_ANTHROPIC_VERSION = "vertex-2023-10-16"
+
+_JSON = "application/json"
+_REFRESH_TIMEOUT = 120.0
+
+
+# MARK: Direct Anthropic API
+
+
+def _api_headers(api_key: str) -> Mapping[str, str]:
+    return {"x-api-key": api_key, "anthropic-version": ANTHROPIC_VERSION, "content-type": _JSON}
 
 
 def create_sync_client(
@@ -14,18 +31,11 @@ def create_sync_client(
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
-) -> "anthropic.Anthropic":
-    """Create an anthropic.Anthropic client, lazily importing the SDK."""
-    import anthropic  # noqa: PLC0415
-
-    kwargs: dict[str, Any] = {"api_key": api_key}
-    if base_url is not None:
-        kwargs["base_url"] = base_url
-    if timeout is not None:
-        kwargs["timeout"] = timeout
-    if max_retries is not None:
-        kwargs["max_retries"] = max_retries
-    return anthropic.Anthropic(**kwargs)
+) -> "httpx.Client":
+    """Create an httpx client for the Anthropic Messages API."""
+    return _create_sync(
+        base_url=base_url or DEFAULT_BASE_URL, headers=_api_headers(api_key), timeout=timeout, max_retries=max_retries
+    )
 
 
 def create_async_client(
@@ -34,166 +44,175 @@ def create_async_client(
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
-) -> "anthropic.AsyncAnthropic":
-    """Create an anthropic.AsyncAnthropic client, lazily importing the SDK."""
-    import anthropic  # noqa: PLC0415
-
-    kwargs: dict[str, Any] = {"api_key": api_key}
-    if base_url is not None:
-        kwargs["base_url"] = base_url
-    if timeout is not None:
-        kwargs["timeout"] = timeout
-    if max_retries is not None:
-        kwargs["max_retries"] = max_retries
-    return anthropic.AsyncAnthropic(**kwargs)
+) -> "httpx.AsyncClient":
+    """Create an async httpx client for the Anthropic Messages API."""
+    return _create_async(
+        base_url=base_url or DEFAULT_BASE_URL, headers=_api_headers(api_key), timeout=timeout, max_retries=max_retries
+    )
 
 
-def _vertex_client_kwargs(  # noqa: PLR0913
-    *,
-    credentials: "Credentials",
-    project_id: str | None,
-    region: str | None,
-    base_url: str | None,
-    timeout: float | None,
-    max_retries: int | None,
-) -> dict[str, Any]:
-    """Build AnthropicVertex constructor kwargs, omitting None values.
+# MARK: Vertex AI
 
-    Omitted region/project_id fall back to the SDK's CLOUD_ML_REGION and
-    ANTHROPIC_VERTEX_PROJECT_ID environment variables.
+
+class _HttpxTransportResponse:
+    """Adapt an httpx response to the ``google.auth.transport.Response`` interface."""
+
+    def __init__(self, response: "httpx.Response") -> None:
+        self._response = response
+
+    @property
+    def status(self) -> int:
+        return self._response.status_code
+
+    @property
+    def headers(self) -> "httpx.Headers":
+        return self._response.headers
+
+    @property
+    def data(self) -> bytes:
+        return self._response.content
+
+
+class HttpxTransportRequest:
+    """Minimal ``google.auth.transport.Request`` backed by httpx.
+
+    Lets Vertex credential refresh reuse httpx instead of pulling in the
+    ``requests`` library that ``google.auth.transport.requests`` needs.
     """
-    kwargs: dict[str, Any] = {"credentials": credentials}
-    if project_id is not None:
-        kwargs["project_id"] = project_id
-    if region is not None:
-        kwargs["region"] = region
-    if base_url is not None:
-        kwargs["base_url"] = base_url
-    if timeout is not None:
-        kwargs["timeout"] = timeout
-    if max_retries is not None:
-        kwargs["max_retries"] = max_retries
-    return kwargs
+
+    def __call__(
+        self,
+        url: str,
+        method: str = "GET",
+        body: bytes | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        **kwargs: object,  # noqa: ARG002
+    ) -> _HttpxTransportResponse:
+        import httpx  # noqa: PLC0415
+
+        response = httpx.request(
+            method,
+            url,
+            content=body,
+            headers=dict(headers) if headers else None,
+            timeout=timeout if timeout is not None else _REFRESH_TIMEOUT,
+        )
+        return _HttpxTransportResponse(response)
 
 
-def create_sync_vertex_client(  # noqa: PLR0913
+def vertex_base_url(region: str) -> str:
+    """Return the Vertex AI base URL for a region (``global`` has no region prefix)."""
+    if region == "global":
+        return "https://aiplatform.googleapis.com/v1"
+    return f"https://{region}-aiplatform.googleapis.com/v1"
+
+
+def resolve_vertex_token(credentials: "Credentials") -> str:
+    """Resolve a bearer token from Google credentials, refreshing them if needed."""
+    if not credentials.token or credentials.expired:
+        credentials.refresh(HttpxTransportRequest())
+    if not credentials.token:
+        raise RuntimeError("Could not resolve a Vertex access token from the credentials")  # noqa: TRY003
+    return credentials.token
+
+
+def _vertex_headers(token: str) -> Mapping[str, str]:
+    return {"Authorization": f"Bearer {token}", "content-type": _JSON}
+
+
+def create_sync_vertex_client(
     *,
     credentials: "Credentials",
-    project_id: str | None = None,
-    region: str | None = None,
+    region: str,
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
-) -> "anthropic.AnthropicVertex":
-    """Create an anthropic.AnthropicVertex client, lazily importing the SDK."""
-    import anthropic  # noqa: PLC0415
-
-    kwargs = _vertex_client_kwargs(
-        credentials=credentials,
-        project_id=project_id,
-        region=region,
-        base_url=base_url,
+) -> "httpx.Client":
+    """Create an httpx client for the Vertex AI ``rawPredict`` endpoint."""
+    return _create_sync(
+        base_url=base_url or vertex_base_url(region),
+        headers=_vertex_headers(resolve_vertex_token(credentials)),
         timeout=timeout,
         max_retries=max_retries,
     )
-    return anthropic.AnthropicVertex(**kwargs)
 
 
-def create_async_vertex_client(  # noqa: PLR0913
+def create_async_vertex_client(
     *,
     credentials: "Credentials",
-    project_id: str | None = None,
-    region: str | None = None,
+    region: str,
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
-) -> "anthropic.AsyncAnthropicVertex":
-    """Create an anthropic.AsyncAnthropicVertex client, lazily importing the SDK."""
-    import anthropic  # noqa: PLC0415
-
-    kwargs = _vertex_client_kwargs(
-        credentials=credentials,
-        project_id=project_id,
-        region=region,
-        base_url=base_url,
+) -> "httpx.AsyncClient":
+    """Create an async httpx client for the Vertex AI ``rawPredict`` endpoint."""
+    return _create_async(
+        base_url=base_url or vertex_base_url(region),
+        headers=_vertex_headers(resolve_vertex_token(credentials)),
         timeout=timeout,
         max_retries=max_retries,
     )
-    return anthropic.AsyncAnthropicVertex(**kwargs)
 
 
-def _foundry_client_kwargs(  # noqa: PLR0913
-    *,
-    api_key: str | None,
-    azure_ad_token_provider: Callable[[], str] | None,
-    resource: str | None,
-    base_url: str | None,
-    timeout: float | None,
-    max_retries: int | None,
-) -> dict[str, Any]:
-    """Build AnthropicFoundry constructor kwargs, omitting None values.
+# MARK: Microsoft Foundry
 
-    Omitted api_key/resource/base_url fall back to the SDK's
-    ANTHROPIC_FOUNDRY_API_KEY, ANTHROPIC_FOUNDRY_RESOURCE, and
-    ANTHROPIC_FOUNDRY_BASE_URL environment variables.
-    """
-    kwargs: dict[str, Any] = {}
-    if api_key is not None:
-        kwargs["api_key"] = api_key
+
+def foundry_base_url(resource: str) -> str:
+    """Return the Foundry base URL for a resource name."""
+    return f"https://{resource}.services.ai.azure.com/anthropic"
+
+
+def _foundry_headers(api_key: str | None, azure_ad_token_provider: "Callable[[], str] | None") -> Mapping[str, str]:
+    headers: dict[str, str] = {"anthropic-version": ANTHROPIC_VERSION, "content-type": _JSON}
     if azure_ad_token_provider is not None:
-        kwargs["azure_ad_token_provider"] = azure_ad_token_provider
-    if resource is not None:
-        kwargs["resource"] = resource
+        headers["Authorization"] = f"Bearer {azure_ad_token_provider()}"
+    elif api_key is not None:
+        headers["api-key"] = api_key
+    else:
+        raise ValueError("Foundry requires either an api_key or an azure_ad_token_provider")  # noqa: TRY003
+    return headers
+
+
+def _resolve_foundry_base_url(base_url: str | None, resource: str | None) -> str:
     if base_url is not None:
-        kwargs["base_url"] = base_url
-    if timeout is not None:
-        kwargs["timeout"] = timeout
-    if max_retries is not None:
-        kwargs["max_retries"] = max_retries
-    return kwargs
+        return base_url
+    if resource is not None:
+        return foundry_base_url(resource)
+    raise ValueError("Foundry requires either a base_url or a resource")  # noqa: TRY003
 
 
 def create_sync_foundry_client(  # noqa: PLR0913
     *,
     api_key: str | None = None,
-    azure_ad_token_provider: Callable[[], str] | None = None,
+    azure_ad_token_provider: "Callable[[], str] | None" = None,
     resource: str | None = None,
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
-) -> "anthropic.AnthropicFoundry":
-    """Create an anthropic.AnthropicFoundry client, lazily importing the SDK."""
-    import anthropic  # noqa: PLC0415
-
-    kwargs = _foundry_client_kwargs(
-        api_key=api_key,
-        azure_ad_token_provider=azure_ad_token_provider,
-        resource=resource,
-        base_url=base_url,
+) -> "httpx.Client":
+    """Create an httpx client for the Microsoft Foundry Anthropic endpoint."""
+    return _create_sync(
+        base_url=_resolve_foundry_base_url(base_url, resource),
+        headers=_foundry_headers(api_key, azure_ad_token_provider),
         timeout=timeout,
         max_retries=max_retries,
     )
-    return anthropic.AnthropicFoundry(**kwargs)
 
 
 def create_async_foundry_client(  # noqa: PLR0913
     *,
     api_key: str | None = None,
-    azure_ad_token_provider: Callable[[], str] | None = None,
+    azure_ad_token_provider: "Callable[[], str] | None" = None,
     resource: str | None = None,
     base_url: str | None = None,
     timeout: float | None = None,
     max_retries: int | None = None,
-) -> "anthropic.AsyncAnthropicFoundry":
-    """Create an anthropic.AsyncAnthropicFoundry client, lazily importing the SDK."""
-    import anthropic  # noqa: PLC0415
-
-    kwargs = _foundry_client_kwargs(
-        api_key=api_key,
-        azure_ad_token_provider=azure_ad_token_provider,
-        resource=resource,
-        base_url=base_url,
+) -> "httpx.AsyncClient":
+    """Create an async httpx client for the Microsoft Foundry Anthropic endpoint."""
+    return _create_async(
+        base_url=_resolve_foundry_base_url(base_url, resource),
+        headers=_foundry_headers(api_key, azure_ad_token_provider),
         timeout=timeout,
         max_retries=max_retries,
     )
-    return anthropic.AsyncAnthropicFoundry(**kwargs)

--- a/packages/lmux-anthropic/src/lmux_anthropic/_lazy.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_lazy.py
@@ -184,10 +184,15 @@ def foundry_auth_headers(api_key: str | None, azure_ad_token_provider: "Callable
 
 
 def _resolve_foundry_base_url(base_url: str | None, resource: str | None) -> str:
+    # base_url and resource are mutually exclusive; resolve both (explicit or env) so a stale
+    # ANTHROPIC_FOUNDRY_BASE_URL can't silently override an explicitly selected resource.
     base_url = base_url or os.environ.get("ANTHROPIC_FOUNDRY_BASE_URL")
-    if base_url is not None:
-        return base_url
     resource = resource or os.environ.get("ANTHROPIC_FOUNDRY_RESOURCE")
+    if base_url is not None:
+        if resource is not None:
+            msg = "Foundry base_url and resource are mutually exclusive"
+            raise ValueError(msg)
+        return base_url
     if resource is not None:
         return foundry_base_url(resource)
     msg = (

--- a/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
@@ -34,6 +34,22 @@ from lmux.types import (
     Usage,
     UserMessage,
 )
+from lmux_anthropic._wire import (
+    WireCacheCreation,
+    WireContentBlockDeltaEvent,
+    WireContentBlockStartEvent,
+    WireDeltaUsage,
+    WireInputJsonDelta,
+    WireMessage,
+    WireMessageDeltaEvent,
+    WireMessageStartEvent,
+    WireTextBlock,
+    WireTextDelta,
+    WireThinkingBlock,
+    WireThinkingDelta,
+    WireToolUseBlock,
+    WireUsage,
+)
 
 type CostCalculator = Callable[[str, Usage], Cost | None]
 type Json = dict[str, Any]
@@ -262,34 +278,32 @@ def map_response_format(rf: ResponseFormat) -> Json | None:
     return {"format": {"type": "json_schema", "schema": patched}}
 
 
-# MARK: Output Mappers (Anthropic Messages API JSON -> lmux)
+# MARK: Output Mappers (Anthropic wire models -> lmux)
 
 
-def map_message_response(message: Json, provider_name: str, cost_fn: CostCalculator) -> ChatResponse:
-    """Convert an Anthropic Messages API response body to an lmux ChatResponse."""
+def map_message_response(message: WireMessage, provider_name: str, cost_fn: CostCalculator) -> ChatResponse:
+    """Convert a validated Anthropic Messages API response to an lmux ChatResponse."""
     text_parts: list[str] = []
     thinking_parts: list[str] = []
     tool_calls: list[ToolCall] = []
 
-    for block in message["content"]:
-        block_type = block["type"]
-        if block_type == "thinking":
-            thinking_parts.append(block["thinking"])
-        elif block_type == "text":
-            text_parts.append(block["text"])
-        elif block_type == "tool_use":
+    for block in message.content:
+        if isinstance(block, WireThinkingBlock):
+            thinking_parts.append(block.thinking)
+        elif isinstance(block, WireTextBlock):
+            text_parts.append(block.text)
+        elif isinstance(block, WireToolUseBlock):
             tool_calls.append(
                 ToolCall(
-                    id=block["id"],
-                    function=FunctionCallResult(name=block["name"], arguments=json.dumps(block["input"])),
+                    id=block.id,
+                    function=FunctionCallResult(name=block.name, arguments=json.dumps(block.input)),
                 )
             )
 
     content = "\n".join(text_parts) if text_parts else None
     reasoning = "\n".join(thinking_parts) if thinking_parts else None
-    model = message["model"]
-    usage = _map_usage(message["usage"])
-    cost = cost_fn(model, usage)
+    usage = _map_usage(message.usage)
+    cost = cost_fn(message.model, usage)
 
     return ChatResponse(
         content=content,
@@ -297,100 +311,96 @@ def map_message_response(message: Json, provider_name: str, cost_fn: CostCalcula
         tool_calls=tool_calls or None,
         usage=usage,
         cost=cost,
-        model=model,
+        model=message.model,
         provider=provider_name,
-        finish_reason=_map_stop_reason(message.get("stop_reason")),
+        finish_reason=_map_stop_reason(message.stop_reason),
     )
 
 
-def _map_usage(usage: Json) -> Usage:
-    cache_read: int = usage.get("cache_read_input_tokens") or 0
-    cache_creation: int = usage.get("cache_creation_input_tokens") or 0
+def _map_usage(usage: WireUsage) -> Usage:
+    cache_read = usage.cache_read_input_tokens or 0
+    cache_creation = usage.cache_creation_input_tokens or 0
     return Usage(
         # Anthropic reports input_tokens exclusive of cached tokens; lmux's
         # Usage convention is the inclusive total (see lmux.types.Usage).
-        input_tokens=usage["input_tokens"] + cache_read + cache_creation,
-        output_tokens=usage["output_tokens"],
+        input_tokens=usage.input_tokens + cache_read + cache_creation,
+        output_tokens=usage.output_tokens,
         cache_read_tokens=cache_read or None,
         cache_creation_tokens=cache_creation or None,
-        cache_creation_tokens_by_ttl=_map_cache_creation_breakdown(usage.get("cache_creation")),
+        cache_creation_tokens_by_ttl=_map_cache_creation_breakdown(usage.cache_creation),
     )
 
 
-def _map_cache_creation_breakdown(cache_creation: Json | None) -> dict[str, int] | None:
+def _map_cache_creation_breakdown(cache_creation: WireCacheCreation | None) -> dict[str, int] | None:
     """Map the per-TTL cache-write breakdown (``usage.cache_creation``) if reported."""
     if cache_creation is None:
         return None
     breakdown: dict[str, int] = {}
-    five_minute = cache_creation.get("ephemeral_5m_input_tokens")
-    one_hour = cache_creation.get("ephemeral_1h_input_tokens")
-    if five_minute:
-        breakdown["5m"] = five_minute
-    if one_hour:
-        breakdown["1h"] = one_hour
+    if cache_creation.ephemeral_5m_input_tokens:
+        breakdown["5m"] = cache_creation.ephemeral_5m_input_tokens
+    if cache_creation.ephemeral_1h_input_tokens:
+        breakdown["1h"] = cache_creation.ephemeral_1h_input_tokens
     return breakdown or None
 
 
 # MARK: Streaming Mappers
 
 
-def map_message_start(event: Json) -> tuple[str, Usage]:
+def map_message_start(event: WireMessageStartEvent) -> tuple[str, Usage]:
     """Extract the resolved model id and input token usage from the message_start event."""
-    message = event["message"]
-    return message["model"], _map_usage(message["usage"])
+    return event.message.model, _map_usage(event.message.usage)
 
 
-def map_content_block_start(event: Json) -> ChatChunk | None:
+def map_content_block_start(event: WireContentBlockStartEvent) -> ChatChunk | None:
     """Map a content_block_start event. Returns a chunk for tool_use blocks only."""
-    block = event["content_block"]
-    if block["type"] == "tool_use":
+    block = event.content_block
+    if isinstance(block, WireToolUseBlock):
         return ChatChunk(
             tool_call_deltas=[
                 ToolCallDelta(
-                    index=event["index"],
-                    id=block["id"],
+                    index=event.index,
+                    id=block.id,
                     type="function",
-                    function=FunctionCallDelta(name=block["name"]),
+                    function=FunctionCallDelta(name=block.name),
                 )
             ],
         )
     return None
 
 
-def map_content_block_delta(event: Json) -> ChatChunk | None:
+def map_content_block_delta(event: WireContentBlockDeltaEvent) -> ChatChunk | None:
     """Map a content_block_delta event to a ChatChunk."""
-    delta = event["delta"]
-    delta_type = delta["type"]
-    if delta_type == "text_delta":
-        return ChatChunk(delta=delta["text"])
-    if delta_type == "input_json_delta":
+    delta = event.delta
+    if isinstance(delta, WireTextDelta):
+        return ChatChunk(delta=delta.text)
+    if isinstance(delta, WireInputJsonDelta):
         return ChatChunk(
             tool_call_deltas=[
                 ToolCallDelta(
-                    index=event["index"],
-                    function=FunctionCallDelta(arguments=delta["partial_json"]),
+                    index=event.index,
+                    function=FunctionCallDelta(arguments=delta.partial_json),
                 )
             ],
         )
-    if delta_type == "thinking_delta":
-        return ChatChunk(reasoning_delta=delta["thinking"])
+    if isinstance(delta, WireThinkingDelta):
+        return ChatChunk(reasoning_delta=delta.thinking)
     return None
 
 
-def map_message_delta(event: Json, start_usage: Usage) -> ChatChunk:
+def map_message_delta(event: WireMessageDeltaEvent, start_usage: Usage) -> ChatChunk:
     """Map the message_delta event (final event with output usage)."""
-    usage = _map_delta_usage(event["usage"], start_usage)
+    usage = _map_delta_usage(event.usage, start_usage)
     return ChatChunk(
-        finish_reason=_map_stop_reason(event["delta"].get("stop_reason")),
+        finish_reason=_map_stop_reason(event.delta.stop_reason),
         usage=usage,
     )
 
 
-def _map_delta_usage(delta_usage: Json, start_usage: Usage) -> Usage:
+def _map_delta_usage(delta_usage: WireDeltaUsage, start_usage: Usage) -> Usage:
     """Combine input tokens from message_start with output tokens from message_delta."""
     return Usage(
         input_tokens=start_usage.input_tokens,
-        output_tokens=delta_usage["output_tokens"],
+        output_tokens=delta_usage.output_tokens,
         cache_read_tokens=start_usage.cache_read_tokens,
         cache_creation_tokens=start_usage.cache_creation_tokens,
         cache_creation_tokens_by_ttl=start_usage.cache_creation_tokens_by_ttl,

--- a/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
@@ -1,10 +1,10 @@
-"""Internal mappers between lmux types and Anthropic SDK types."""
+"""Internal mappers between lmux types and Anthropic Messages API JSON."""
 
 import copy
 import json
 import re
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Literal, cast
+from typing import Any
 
 from lmux.exceptions import UnsupportedFeatureError
 from lmux.schema import add_additional_properties_false
@@ -35,31 +35,8 @@ from lmux.types import (
     UserMessage,
 )
 
-if TYPE_CHECKING:
-    from anthropic.types import (
-        CacheControlEphemeralParam,
-        ImageBlockParam,
-        JSONOutputFormatParam,
-        MessageDeltaUsage,
-        MessageParam,
-        OutputConfigParam,
-        TextBlockParam,
-        ToolParam,
-        ToolResultBlockParam,
-        ToolUseBlockParam,
-    )
-    from anthropic.types import (
-        Message as AnthropicMessage,
-    )
-    from anthropic.types import (
-        Usage as AnthropicUsage,
-    )
-    from anthropic.types.raw_content_block_delta_event import RawContentBlockDeltaEvent
-    from anthropic.types.raw_content_block_start_event import RawContentBlockStartEvent
-    from anthropic.types.raw_message_delta_event import RawMessageDeltaEvent
-    from anthropic.types.raw_message_start_event import RawMessageStartEvent
-
 type CostCalculator = Callable[[str, Usage], Cost | None]
+type Json = dict[str, Any]
 
 _DATA_URI_PATTERN = re.compile(r"^data:(image/[^;]+);base64,(.+)$", re.DOTALL)
 
@@ -79,10 +56,10 @@ def _map_stop_reason(stop_reason: str | None) -> str | None:
     return _STOP_REASON_MAP.get(stop_reason, stop_reason)
 
 
-# MARK: Input Mappers (lmux -> Anthropic SDK params)
+# MARK: Input Mappers (lmux -> Anthropic Messages API JSON)
 
 
-def map_messages(messages: Sequence[Message]) -> tuple[str | list["TextBlockParam"] | None, list["MessageParam"]]:
+def map_messages(messages: Sequence[Message]) -> tuple[str | list[Json] | None, list[Json]]:
     """Convert lmux Messages to Anthropic format.
 
     Returns ``(system, messages_list)`` where ``system`` is extracted from any
@@ -93,7 +70,7 @@ def map_messages(messages: Sequence[Message]) -> tuple[str | list["TextBlockPara
     """
     system_parts: list[str] = []
     system_cache_split: tuple[int, CachePointContent] | None = None
-    result: list[MessageParam] = []
+    result: list[Json] = []
 
     for msg in messages:
         if isinstance(msg, (SystemMessage, DeveloperMessage)):
@@ -118,9 +95,7 @@ def map_messages(messages: Sequence[Message]) -> tuple[str | list["TextBlockPara
     return system, result
 
 
-def _map_system(
-    system_parts: list[str], cache_split: "tuple[int, CachePointContent] | None"
-) -> str | list["TextBlockParam"] | None:
+def _map_system(system_parts: list[str], cache_split: tuple[int, CachePointContent] | None) -> str | list[Json] | None:
     if not system_parts:
         return None
     if cache_split is None:
@@ -128,7 +103,7 @@ def _map_system(
     # Split at the marker position so system text appearing after the cache
     # point stays outside the cached prefix.
     split, cache_point = cache_split
-    blocks: list[TextBlockParam] = [
+    blocks: list[Json] = [
         {"type": "text", "text": "\n".join(system_parts[:split]), "cache_control": _map_cache_control(cache_point)}
     ]
     if len(system_parts) > split:
@@ -136,9 +111,7 @@ def _map_system(
     return blocks
 
 
-def _map_user_content(
-    content: str | list[ContentPart],
-) -> tuple[str | list["TextBlockParam | ImageBlockParam"], CachePointContent | None]:
+def _map_user_content(content: str | list[ContentPart]) -> tuple[str | list[Json], CachePointContent | None]:
     """Map user content, attaching cache points to the preceding block.
 
     Returns ``(blocks, leading_cache_point)`` — a cache point with no
@@ -147,7 +120,7 @@ def _map_user_content(
     """
     if isinstance(content, str):
         return content, None
-    blocks: list[TextBlockParam | ImageBlockParam] = []
+    blocks: list[Json] = []
     leading_cache_point: CachePointContent | None = None
     for part in content:
         if isinstance(part, CachePointContent):
@@ -161,7 +134,7 @@ def _map_user_content(
     return blocks, leading_cache_point
 
 
-def _attach_cache_point(message: "MessageParam", cache_point: CachePointContent) -> None:
+def _attach_cache_point(message: Json, cache_point: CachePointContent) -> None:
     """Attach ``cache_control`` to the last content block of ``message``.
 
     No-ops when the message has nothing cacheable (empty content) or the
@@ -171,37 +144,36 @@ def _attach_cache_point(message: "MessageParam", cache_point: CachePointContent)
     if isinstance(content, str):
         if not content:
             return
-        text_block: TextBlockParam = {"type": "text", "text": content, "cache_control": _map_cache_control(cache_point)}
-        message["content"] = [text_block]
+        message["content"] = [{"type": "text", "text": content, "cache_control": _map_cache_control(cache_point)}]
         return
-    blocks = cast("list[dict[str, object]]", content)
+    blocks: list[Json] = content
     if blocks and "cache_control" not in blocks[-1]:
         blocks[-1]["cache_control"] = _map_cache_control(cache_point)
 
 
-def _map_cache_control(cache_point: CachePointContent) -> "CacheControlEphemeralParam":
-    cache_control: CacheControlEphemeralParam = {"type": "ephemeral"}
+def _map_cache_control(cache_point: CachePointContent) -> Json:
+    cache_control: Json = {"type": "ephemeral"}
     if cache_point.ttl is not None:
         # ttl is a deliberate passthrough — the API validates the value
-        cache_control["ttl"] = cast('Literal["5m", "1h"]', cache_point.ttl)
+        cache_control["ttl"] = cache_point.ttl
     return cache_control
 
 
-def _map_content_part(part: TextContent | ImageContent) -> "TextBlockParam | ImageBlockParam":
+def _map_content_part(part: TextContent | ImageContent) -> Json:
     if isinstance(part, TextContent):
         return {"type": "text", "text": part.text}
     return _map_image_content(part)
 
 
-def _map_image_content(img: ImageContent) -> "ImageBlockParam":
+def _map_image_content(img: ImageContent) -> Json:
     match = _DATA_URI_PATTERN.match(img.url)
     if match:
-        return {"type": "image", "source": {"type": "base64", "media_type": match.group(1), "data": match.group(2)}}  # ty: ignore[invalid-argument-type, invalid-return-type]  # media_type is a dynamic str, not a literal
+        return {"type": "image", "source": {"type": "base64", "media_type": match.group(1), "data": match.group(2)}}
     return {"type": "image", "source": {"type": "url", "url": img.url}}
 
 
-def _map_assistant_message(msg: AssistantMessage) -> "MessageParam":
-    content: list[TextBlockParam | ToolUseBlockParam] = []
+def _map_assistant_message(msg: AssistantMessage) -> Json:
+    content: list[Json] = []
     if msg.content is not None:
         content.append({"type": "text", "text": msg.content})
     if msg.tool_calls:
@@ -217,9 +189,9 @@ def _map_assistant_message(msg: AssistantMessage) -> "MessageParam":
     return {"role": "assistant", "content": content}
 
 
-def _append_tool_result(result: list["MessageParam"], msg: ToolMessage) -> None:
+def _append_tool_result(result: list[Json], msg: ToolMessage) -> None:
     """Append a tool_result block, merging consecutive tool results into one user message."""
-    tool_block: ToolResultBlockParam = {
+    tool_block: Json = {
         "type": "tool_result",
         "tool_use_id": msg.tool_call_id,
         "content": msg.content,
@@ -229,16 +201,16 @@ def _append_tool_result(result: list["MessageParam"], msg: ToolMessage) -> None:
         if isinstance(last_content, list) and last_content:
             first = last_content[0]
             if isinstance(first, dict) and first.get("type") == "tool_result":
-                last_content.append(tool_block)  # ty: ignore[invalid-argument-type]
+                last_content.append(tool_block)
                 return
     result.append({"role": "user", "content": [tool_block]})
 
 
-def map_tools(tools: list[Tool]) -> list["ToolParam"]:
+def map_tools(tools: list[Tool]) -> list[Json]:
     """Convert lmux Tools to Anthropic tool param dicts."""
-    result: list[ToolParam] = []
+    result: list[Json] = []
     for tool in tools:
-        t: ToolParam = {
+        t: Json = {
             "name": tool.function.name,
             "input_schema": tool.function.parameters or {"type": "object"},
         }
@@ -278,7 +250,7 @@ def model_uses_adaptive_thinking(model: str) -> bool:
     return (major, minor) >= _ADAPTIVE_MIN
 
 
-def map_response_format(rf: ResponseFormat) -> "OutputConfigParam | None":
+def map_response_format(rf: ResponseFormat) -> Json | None:
     """Convert lmux ResponseFormat to Anthropic output_config dict, or None for text."""
     if isinstance(rf, TextResponseFormat):
         return None
@@ -287,40 +259,37 @@ def map_response_format(rf: ResponseFormat) -> "OutputConfigParam | None":
         raise UnsupportedFeatureError(msg, provider="anthropic")
     patched = copy.deepcopy(rf.json_schema)
     add_additional_properties_false(patched)
-    schema_dict: JSONOutputFormatParam = {"type": "json_schema", "schema": patched}
-    return {"format": schema_dict}
+    return {"format": {"type": "json_schema", "schema": patched}}
 
 
-# MARK: Output Mappers (Anthropic SDK responses -> lmux)
+# MARK: Output Mappers (Anthropic Messages API JSON -> lmux)
 
 
-def map_message_response(
-    message: "AnthropicMessage",
-    provider_name: str,
-    cost_fn: CostCalculator,
-) -> ChatResponse:
-    """Convert Anthropic Message to lmux ChatResponse."""
+def map_message_response(message: Json, provider_name: str, cost_fn: CostCalculator) -> ChatResponse:
+    """Convert an Anthropic Messages API response body to an lmux ChatResponse."""
     text_parts: list[str] = []
     thinking_parts: list[str] = []
     tool_calls: list[ToolCall] = []
 
-    for block in message.content:
-        if block.type == "thinking":
-            thinking_parts.append(block.thinking)
-        elif block.type == "text":
-            text_parts.append(block.text)
-        elif block.type == "tool_use":
+    for block in message["content"]:
+        block_type = block["type"]
+        if block_type == "thinking":
+            thinking_parts.append(block["thinking"])
+        elif block_type == "text":
+            text_parts.append(block["text"])
+        elif block_type == "tool_use":
             tool_calls.append(
                 ToolCall(
-                    id=block.id,
-                    function=FunctionCallResult(name=block.name, arguments=json.dumps(block.input)),
+                    id=block["id"],
+                    function=FunctionCallResult(name=block["name"], arguments=json.dumps(block["input"])),
                 )
             )
 
     content = "\n".join(text_parts) if text_parts else None
     reasoning = "\n".join(thinking_parts) if thinking_parts else None
-    usage = _map_usage(message.usage)
-    cost = cost_fn(message.model, usage)
+    model = message["model"]
+    usage = _map_usage(message["usage"])
+    cost = cost_fn(model, usage)
 
     return ChatResponse(
         content=content,
@@ -328,34 +297,33 @@ def map_message_response(
         tool_calls=tool_calls or None,
         usage=usage,
         cost=cost,
-        model=message.model,
+        model=model,
         provider=provider_name,
-        finish_reason=_map_stop_reason(message.stop_reason),
+        finish_reason=_map_stop_reason(message.get("stop_reason")),
     )
 
 
-def _map_usage(usage: "AnthropicUsage") -> Usage:
-    cache_read: int = getattr(usage, "cache_read_input_tokens", None) or 0
-    cache_creation: int = getattr(usage, "cache_creation_input_tokens", None) or 0
+def _map_usage(usage: Json) -> Usage:
+    cache_read: int = usage.get("cache_read_input_tokens") or 0
+    cache_creation: int = usage.get("cache_creation_input_tokens") or 0
     return Usage(
         # Anthropic reports input_tokens exclusive of cached tokens; lmux's
         # Usage convention is the inclusive total (see lmux.types.Usage).
-        input_tokens=usage.input_tokens + cache_read + cache_creation,
-        output_tokens=usage.output_tokens,
+        input_tokens=usage["input_tokens"] + cache_read + cache_creation,
+        output_tokens=usage["output_tokens"],
         cache_read_tokens=cache_read or None,
         cache_creation_tokens=cache_creation or None,
-        cache_creation_tokens_by_ttl=_map_cache_creation_breakdown(usage),
+        cache_creation_tokens_by_ttl=_map_cache_creation_breakdown(usage.get("cache_creation")),
     )
 
 
-def _map_cache_creation_breakdown(usage: "AnthropicUsage") -> dict[str, int] | None:
+def _map_cache_creation_breakdown(cache_creation: Json | None) -> dict[str, int] | None:
     """Map the per-TTL cache-write breakdown (``usage.cache_creation``) if reported."""
-    cache_creation = getattr(usage, "cache_creation", None)
     if cache_creation is None:
         return None
     breakdown: dict[str, int] = {}
-    five_minute = getattr(cache_creation, "ephemeral_5m_input_tokens", None)
-    one_hour = getattr(cache_creation, "ephemeral_1h_input_tokens", None)
+    five_minute = cache_creation.get("ephemeral_5m_input_tokens")
+    one_hour = cache_creation.get("ephemeral_1h_input_tokens")
     if five_minute:
         breakdown["5m"] = five_minute
     if one_hour:
@@ -366,61 +334,63 @@ def _map_cache_creation_breakdown(usage: "AnthropicUsage") -> dict[str, int] | N
 # MARK: Streaming Mappers
 
 
-def map_message_start(event: "RawMessageStartEvent") -> tuple[str, Usage]:
+def map_message_start(event: Json) -> tuple[str, Usage]:
     """Extract the resolved model id and input token usage from the message_start event."""
-    return event.message.model, _map_usage(event.message.usage)
+    message = event["message"]
+    return message["model"], _map_usage(message["usage"])
 
 
-def map_content_block_start(event: "RawContentBlockStartEvent") -> ChatChunk | None:
+def map_content_block_start(event: Json) -> ChatChunk | None:
     """Map a content_block_start event. Returns a chunk for tool_use blocks only."""
-    block = event.content_block
-    if block.type == "tool_use":
+    block = event["content_block"]
+    if block["type"] == "tool_use":
         return ChatChunk(
             tool_call_deltas=[
                 ToolCallDelta(
-                    index=event.index,
-                    id=block.id,
+                    index=event["index"],
+                    id=block["id"],
                     type="function",
-                    function=FunctionCallDelta(name=block.name),
+                    function=FunctionCallDelta(name=block["name"]),
                 )
             ],
         )
     return None
 
 
-def map_content_block_delta(event: "RawContentBlockDeltaEvent") -> ChatChunk | None:
+def map_content_block_delta(event: Json) -> ChatChunk | None:
     """Map a content_block_delta event to a ChatChunk."""
-    delta = event.delta
-    if delta.type == "text_delta":
-        return ChatChunk(delta=delta.text)
-    if delta.type == "input_json_delta":
+    delta = event["delta"]
+    delta_type = delta["type"]
+    if delta_type == "text_delta":
+        return ChatChunk(delta=delta["text"])
+    if delta_type == "input_json_delta":
         return ChatChunk(
             tool_call_deltas=[
                 ToolCallDelta(
-                    index=event.index,
-                    function=FunctionCallDelta(arguments=delta.partial_json),
+                    index=event["index"],
+                    function=FunctionCallDelta(arguments=delta["partial_json"]),
                 )
             ],
         )
-    if delta.type == "thinking_delta":
-        return ChatChunk(reasoning_delta=delta.thinking)
+    if delta_type == "thinking_delta":
+        return ChatChunk(reasoning_delta=delta["thinking"])
     return None
 
 
-def map_message_delta(event: "RawMessageDeltaEvent", start_usage: Usage) -> ChatChunk:
+def map_message_delta(event: Json, start_usage: Usage) -> ChatChunk:
     """Map the message_delta event (final event with output usage)."""
-    usage = _map_delta_usage(event.usage, start_usage)
+    usage = _map_delta_usage(event["usage"], start_usage)
     return ChatChunk(
-        finish_reason=_map_stop_reason(event.delta.stop_reason),
+        finish_reason=_map_stop_reason(event["delta"].get("stop_reason")),
         usage=usage,
     )
 
 
-def _map_delta_usage(delta_usage: "MessageDeltaUsage", start_usage: Usage) -> Usage:
+def _map_delta_usage(delta_usage: Json, start_usage: Usage) -> Usage:
     """Combine input tokens from message_start with output tokens from message_delta."""
     return Usage(
         input_tokens=start_usage.input_tokens,
-        output_tokens=delta_usage.output_tokens,
+        output_tokens=delta_usage["output_tokens"],
         cache_read_tokens=start_usage.cache_read_tokens,
         cache_creation_tokens=start_usage.cache_creation_tokens,
         cache_creation_tokens_by_ttl=start_usage.cache_creation_tokens_by_ttl,

--- a/packages/lmux-anthropic/src/lmux_anthropic/_wire.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_wire.py
@@ -1,0 +1,155 @@
+"""Pydantic wire models for the Anthropic Messages API response and stream events.
+
+Only the fields lmux consumes are declared; unknown fields are ignored (Pydantic's default), so
+new server fields do not break parsing. Content blocks and streaming deltas are discriminated
+unions with an explicit unknown-tag fallback, so an unrecognized ``type`` validates into the
+fallback variant instead of raising.
+"""
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Discriminator, Tag
+
+# MARK: Usage (shared by the response, message_start, and message_delta)
+
+
+class WireCacheCreation(BaseModel):
+    ephemeral_5m_input_tokens: int | None = None
+    ephemeral_1h_input_tokens: int | None = None
+
+
+class WireUsage(BaseModel):
+    input_tokens: int
+    output_tokens: int
+    cache_read_input_tokens: int | None = None
+    cache_creation_input_tokens: int | None = None
+    cache_creation: WireCacheCreation | None = None
+
+
+class WireDeltaUsage(BaseModel):
+    """The message_delta ``usage`` object carries only output tokens; input usage came in message_start."""
+
+    output_tokens: int
+
+
+# MARK: Content blocks (response ``content[]`` and content_block_start)
+
+_KNOWN_BLOCKS = frozenset({"text", "thinking", "tool_use"})
+
+
+class WireTextBlock(BaseModel):
+    type: Literal["text"]
+    text: str
+
+
+class WireThinkingBlock(BaseModel):
+    type: Literal["thinking"]
+    thinking: str
+
+
+class WireToolUseBlock(BaseModel):
+    type: Literal["tool_use"]
+    id: str
+    name: str
+    input: dict[str, Any]
+
+
+class WireUnknownBlock(BaseModel):
+    """Fallback for block types lmux does not consume (e.g. ``redacted_thinking``)."""
+
+    type: str
+
+
+def _content_block_tag(value: Any) -> str:  # noqa: ANN401 — pydantic passes the raw input
+    tag = value.get("type") if isinstance(value, dict) else getattr(value, "type", None)
+    return tag if tag in _KNOWN_BLOCKS else "unknown"
+
+
+WireContentBlock = Annotated[
+    Annotated[WireTextBlock, Tag("text")]
+    | Annotated[WireThinkingBlock, Tag("thinking")]
+    | Annotated[WireToolUseBlock, Tag("tool_use")]
+    | Annotated[WireUnknownBlock, Tag("unknown")],
+    Discriminator(_content_block_tag),
+]
+
+
+# MARK: Streaming content_block_delta payloads
+
+_KNOWN_DELTAS = frozenset({"text_delta", "input_json_delta", "thinking_delta"})
+
+
+class WireTextDelta(BaseModel):
+    type: Literal["text_delta"]
+    text: str
+
+
+class WireInputJsonDelta(BaseModel):
+    type: Literal["input_json_delta"]
+    partial_json: str
+
+
+class WireThinkingDelta(BaseModel):
+    type: Literal["thinking_delta"]
+    thinking: str
+
+
+class WireUnknownDelta(BaseModel):
+    """Fallback for delta types lmux does not consume (e.g. ``signature_delta``)."""
+
+    type: str
+
+
+def _stream_delta_tag(value: Any) -> str:  # noqa: ANN401 — pydantic passes the raw input
+    tag = value.get("type") if isinstance(value, dict) else getattr(value, "type", None)
+    return tag if tag in _KNOWN_DELTAS else "unknown"
+
+
+WireStreamDelta = Annotated[
+    Annotated[WireTextDelta, Tag("text_delta")]
+    | Annotated[WireInputJsonDelta, Tag("input_json_delta")]
+    | Annotated[WireThinkingDelta, Tag("thinking_delta")]
+    | Annotated[WireUnknownDelta, Tag("unknown")],
+    Discriminator(_stream_delta_tag),
+]
+
+
+# MARK: Non-streamed response
+
+
+class WireMessage(BaseModel):
+    model: str
+    content: list[WireContentBlock]
+    usage: WireUsage
+    stop_reason: str | None = None
+
+
+# MARK: Stream events
+
+
+class WireStartMessage(BaseModel):
+    model: str
+    usage: WireUsage
+
+
+class WireMessageStartEvent(BaseModel):
+    message: WireStartMessage
+
+
+class WireContentBlockStartEvent(BaseModel):
+    index: int
+    content_block: WireContentBlock
+
+
+class WireContentBlockDeltaEvent(BaseModel):
+    index: int
+    delta: WireStreamDelta
+
+
+class WireMessageDeltaBody(BaseModel):
+    stop_reason: str | None = None
+
+
+class WireMessageDeltaEvent(BaseModel):
+    delta: WireMessageDeltaBody
+    usage: WireDeltaUsage

--- a/packages/lmux-anthropic/src/lmux_anthropic/provider.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/provider.py
@@ -1,20 +1,24 @@
-"""Anthropic provider implementation."""
+"""Anthropic provider implementation (SDK-lite, httpx transport)."""
 
 import asyncio
+import json
 import os
 from collections.abc import AsyncIterator, Callable, Iterator, Sequence
 from datetime import date
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, override
 
 if TYPE_CHECKING:
-    import anthropic
+    import httpx
     from google.auth.credentials import Credentials
 
+from lmux._http import aiter_sse, iter_sse
 from lmux.cost import ModelPricing, calculate_cost
+from lmux.exceptions import LmuxError, ProviderError
 from lmux.protocols import AuthProvider, CompletionProvider, PricingProvider
 from lmux.types import ChatChunk, ChatResponse, Cost, Message, ResponseFormat, Tool, ToolChoice, Usage
-from lmux_anthropic._exceptions import map_anthropic_error
+from lmux_anthropic._exceptions import error_from_response, map_transport_error, raise_for_status
 from lmux_anthropic._lazy import (
+    VERTEX_ANTHROPIC_VERSION,
     create_async_client,
     create_async_foundry_client,
     create_async_vertex_client,
@@ -52,18 +56,15 @@ PROVIDER_NAME = "anthropic"
 VERTEX_PROVIDER_NAME = "anthropic-vertex"
 FOUNDRY_PROVIDER_NAME = "anthropic-foundry"
 DEFAULT_MAX_TOKENS = 4096
-
-type SyncAnthropicClient = "anthropic.Anthropic | anthropic.AnthropicVertex | anthropic.AnthropicFoundry"
-type AsyncAnthropicClient = (
-    "anthropic.AsyncAnthropic | anthropic.AsyncAnthropicVertex | anthropic.AsyncAnthropicFoundry"
-)
+_MESSAGES_PATH = "v1/messages"
+_HTTP_ERROR = 400
 
 # Vertex auth providers may return bare credentials, or credentials together
 # with the project ID they resolved (e.g. from ADC or a service account file).
 type VertexAuthResult = "Credentials | tuple[Credentials, str | None]"
 
 # Foundry auth providers return an API key, or a Microsoft Entra ID bearer
-# token provider that the SDK invokes on every request.
+# token provider that the client invokes when building the request.
 type FoundryAuthResult = "str | Callable[[], str]"
 
 
@@ -76,7 +77,7 @@ class AnthropicProvider(
     CompletionProvider[AnthropicParams],
     PricingProvider,
 ):
-    """Anthropic API provider."""
+    """Anthropic API provider over httpx."""
 
     _provider_name: ClassVar[str] = PROVIDER_NAME
 
@@ -94,8 +95,8 @@ class AnthropicProvider(
         self._timeout: float | None = timeout
         self._max_retries: int | None = max_retries
         self._default_max_tokens: int = default_max_tokens
-        self._sync_client: SyncAnthropicClient | None = None
-        self._async_client: AsyncAnthropicClient | None = None
+        self._sync_client: httpx.Client | None = None
+        self._async_client: httpx.AsyncClient | None = None
         self._async_loop: asyncio.AbstractEventLoop | None = None
         self._custom_pricing: dict[str, ModelPricing] = {}
 
@@ -118,7 +119,9 @@ class AnthropicProvider(
             return calculate_cost(usage, pricing, as_of)
         return calculate_anthropic_cost(model, usage, as_of)
 
-    def _create_sync_client(self) -> SyncAnthropicClient:
+    # MARK: Client Management
+
+    def _create_sync_client(self) -> "httpx.Client":
         return create_sync_client(
             api_key=self._auth.get_credentials(),
             base_url=self._base_url,
@@ -126,7 +129,7 @@ class AnthropicProvider(
             max_retries=self._max_retries,
         )
 
-    async def _create_async_client(self) -> AsyncAnthropicClient:
+    async def _create_async_client(self) -> "httpx.AsyncClient":
         return create_async_client(
             api_key=await self._auth.aget_credentials(),
             base_url=self._base_url,
@@ -134,12 +137,12 @@ class AnthropicProvider(
             max_retries=self._max_retries,
         )
 
-    def _get_sync_client(self) -> SyncAnthropicClient:
+    def _get_sync_client(self) -> "httpx.Client":
         if self._sync_client is None:
             self._sync_client = self._create_sync_client()
         return self._sync_client
 
-    async def _get_async_client(self) -> AsyncAnthropicClient:
+    async def _get_async_client(self) -> "httpx.AsyncClient":
         loop = asyncio.get_running_loop()
         if self._async_client is None or self._async_loop is not loop:
             self._async_client = await self._create_async_client()
@@ -149,9 +152,19 @@ class AnthropicProvider(
     async def aclose(self) -> None:
         """Close the underlying async HTTP client."""
         if self._async_client is not None:
-            await self._async_client.close()
+            await self._async_client.aclose()
             self._async_client = None
             self._async_loop = None
+
+    # MARK: Request shaping hooks (overridden by Vertex)
+
+    def _request_path(self, model: str, *, stream: bool) -> str:  # noqa: ARG002
+        """Path for the Messages request; ``model``/``stream`` matter only on Vertex."""
+        return _MESSAGES_PATH
+
+    def _transform_body(self, body: dict[str, Any], model: str) -> dict[str, Any]:  # noqa: ARG002
+        """Adjust the request body per-transport; identity for the Anthropic API."""
+        return body
 
     # MARK: Chat
 
@@ -171,27 +184,17 @@ class AnthropicProvider(
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         provider_params: AnthropicParams | None = None,
     ) -> ChatResponse:
-        kwargs = self._build_chat_kwargs(
-            model,
-            messages,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+        body = self._build_body(
+            model, messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params, stream=False,
+        )  # fmt: skip
         try:
             client = self._get_sync_client()
-            message = client.messages.create(**kwargs, stream=False)
+            response = client.post(self._request_path(model, stream=False), json=self._transform_body(body, model))
         except Exception as e:
-            raise map_anthropic_error(e, self._provider_name) from e
-        as_of = self._resolve_pricing_as_of(provider_params)
-        response = map_message_response(message, self._provider_name, lambda m, u: self._calculate_cost(m, u, as_of))
-        return self._apply_multipliers(response, provider_params)
+            raise map_transport_error(e, self._provider_name) from e
+        raise_for_status(response, self._provider_name)
+        return self._map_response(response.json(), provider_params)
 
     @override
     async def achat(
@@ -209,27 +212,19 @@ class AnthropicProvider(
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         provider_params: AnthropicParams | None = None,
     ) -> ChatResponse:
-        kwargs = self._build_chat_kwargs(
-            model,
-            messages,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+        body = self._build_body(
+            model, messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params, stream=False,
+        )  # fmt: skip
         try:
             client = await self._get_async_client()
-            message = await client.messages.create(**kwargs, stream=False)
+            response = await client.post(
+                self._request_path(model, stream=False), json=self._transform_body(body, model)
+            )
         except Exception as e:
-            raise map_anthropic_error(e, self._provider_name) from e
-        as_of = self._resolve_pricing_as_of(provider_params)
-        response = map_message_response(message, self._provider_name, lambda m, u: self._calculate_cost(m, u, as_of))
-        return self._apply_multipliers(response, provider_params)
+            raise map_transport_error(e, self._provider_name) from e
+        raise_for_status(response, self._provider_name)
+        return self._map_response(response.json(), provider_params)
 
     @override
     def chat_stream(
@@ -247,51 +242,32 @@ class AnthropicProvider(
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         provider_params: AnthropicParams | None = None,
     ) -> Iterator[ChatChunk]:
-        kwargs = self._build_chat_kwargs(
-            model,
-            messages,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+        body = self._build_body(
+            model, messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params, stream=True,
+        )  # fmt: skip
         try:
             client = self._get_sync_client()
-            stream = client.messages.create(**kwargs, stream=True)
+            path = self._request_path(model, stream=True)
+            body = self._transform_body(body, model)
         except Exception as e:
-            raise map_anthropic_error(e, self._provider_name) from e
+            raise map_transport_error(e, self._provider_name) from e
 
         as_of = self._resolve_pricing_as_of(provider_params)
-        start_usage: Usage | None = None
-        start_model: str = model
+        stream = _StreamState(model)
         try:
-            for event in stream:
-                if event.type == "message_start":
-                    start_model, start_usage = map_message_start(event)
-                    continue
-                if event.type == "content_block_start":
-                    chunk = map_content_block_start(event)
+            with client.stream("POST", path, json=body) as response:
+                if response.status_code >= _HTTP_ERROR:
+                    response.read()
+                    raise error_from_response(response, self._provider_name)  # noqa: TRY301
+                for _event, data in iter_sse(response):
+                    chunk = stream.feed(json.loads(data))
                     if chunk is not None:
-                        yield chunk
-                    continue
-                if event.type == "content_block_delta":
-                    chunk = map_content_block_delta(event)
-                    if chunk is not None:
-                        yield chunk
-                    continue
-                if event.type == "message_delta" and start_usage is not None:
-                    chunk = map_message_delta(event, start_usage)
-                    cost = self._calculate_cost(start_model, chunk.usage, as_of) if chunk.usage else None
-                    cost = self._apply_cost_multipliers(cost, start_model, provider_params)
-                    yield chunk.model_copy(update={"cost": cost, "model": start_model, "provider": self._provider_name})
-                    continue
+                        yield self._finalize_chunk(chunk, stream, provider_params, as_of)
+        except LmuxError:
+            raise
         except Exception as e:
-            raise map_anthropic_error(e, self._provider_name) from e
+            raise map_transport_error(e, self._provider_name) from e
 
     @override
     async def achat_stream(
@@ -309,55 +285,55 @@ class AnthropicProvider(
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         provider_params: AnthropicParams | None = None,
     ) -> AsyncIterator[ChatChunk]:
-        kwargs = self._build_chat_kwargs(
-            model,
-            messages,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+        body = self._build_body(
+            model, messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params, stream=True,
+        )  # fmt: skip
         try:
             client = await self._get_async_client()
-            stream = await client.messages.create(**kwargs, stream=True)
+            path = self._request_path(model, stream=True)
+            body = self._transform_body(body, model)
         except Exception as e:
-            raise map_anthropic_error(e, self._provider_name) from e
+            raise map_transport_error(e, self._provider_name) from e
 
         as_of = self._resolve_pricing_as_of(provider_params)
-        start_usage: Usage | None = None
-        start_model: str = model
+        stream = _StreamState(model)
         try:
-            async for event in stream:
-                if event.type == "message_start":
-                    start_model, start_usage = map_message_start(event)
-                    continue
-                if event.type == "content_block_start":
-                    chunk = map_content_block_start(event)
+            async with client.stream("POST", path, json=body) as response:
+                if response.status_code >= _HTTP_ERROR:
+                    await response.aread()
+                    raise error_from_response(response, self._provider_name)  # noqa: TRY301
+                async for _event, data in aiter_sse(response):
+                    chunk = stream.feed(json.loads(data))
                     if chunk is not None:
-                        yield chunk
-                    continue
-                if event.type == "content_block_delta":
-                    chunk = map_content_block_delta(event)
-                    if chunk is not None:
-                        yield chunk
-                    continue
-                if event.type == "message_delta" and start_usage is not None:
-                    chunk = map_message_delta(event, start_usage)
-                    cost = self._calculate_cost(start_model, chunk.usage, as_of) if chunk.usage else None
-                    cost = self._apply_cost_multipliers(cost, start_model, provider_params)
-                    yield chunk.model_copy(update={"cost": cost, "model": start_model, "provider": self._provider_name})
-                    continue
+                        yield self._finalize_chunk(chunk, stream, provider_params, as_of)
+        except LmuxError:
+            raise
         except Exception as e:
-            raise map_anthropic_error(e, self._provider_name) from e
+            raise map_transport_error(e, self._provider_name) from e
 
     # MARK: Internal Helpers
 
-    def _build_chat_kwargs(  # noqa: PLR0913
+    def _map_response(self, body: dict[str, Any], provider_params: AnthropicParams | None) -> ChatResponse:
+        as_of = self._resolve_pricing_as_of(provider_params)
+        response = map_message_response(body, self._provider_name, lambda m, u: self._calculate_cost(m, u, as_of))
+        return self._apply_multipliers(response, provider_params)
+
+    def _finalize_chunk(
+        self,
+        chunk: ChatChunk,
+        stream: "_StreamState",
+        provider_params: AnthropicParams | None,
+        as_of: date,
+    ) -> ChatChunk:
+        """Attach model/provider/cost to a message_delta chunk; pass others through."""
+        if chunk.usage is None:
+            return chunk
+        cost = self._calculate_cost(stream.model, chunk.usage, as_of)
+        cost = self._apply_cost_multipliers(cost, stream.model, provider_params)
+        return chunk.model_copy(update={"cost": cost, "model": stream.model, "provider": self._provider_name})
+
+    def _build_body(  # noqa: PLR0913
         self,
         model: str,
         messages: Sequence[Message],
@@ -370,48 +346,51 @@ class AnthropicProvider(
         response_format: ResponseFormat | None,
         reasoning_effort: Literal["low", "medium", "high"] | None,
         provider_params: AnthropicParams | None,
+        *,
+        stream: bool,
     ) -> dict[str, Any]:
         system, mapped_messages = map_messages(messages)
-        kwargs: dict[str, Any] = {
+        body: dict[str, Any] = {
             "model": model,
             "messages": mapped_messages,
             "max_tokens": max_tokens if max_tokens is not None else self._default_max_tokens,
+            "stream": stream,
         }
         if system is not None:
-            kwargs["system"] = system
+            body["system"] = system
         if temperature is not None:
-            kwargs["temperature"] = temperature
+            body["temperature"] = temperature
         if top_p is not None:
-            kwargs["top_p"] = top_p
+            body["top_p"] = top_p
         if stop is not None:
-            kwargs["stop_sequences"] = [stop] if isinstance(stop, str) else stop
+            body["stop_sequences"] = [stop] if isinstance(stop, str) else stop
         if tools is not None:
-            kwargs["tools"] = map_tools(tools)
+            body["tools"] = map_tools(tools)
         if tool_choice is not None:
-            kwargs["tool_choice"] = map_tool_choice(tool_choice)
+            body["tool_choice"] = map_tool_choice(tool_choice)
         if response_format is not None:
             output_config = map_response_format(response_format)
             if output_config is not None:
-                kwargs["output_config"] = output_config
+                body["output_config"] = output_config
         # provider_params.thinking takes precedence over reasoning_effort, so skip the
         # reasoning_effort mapping entirely when it is set (otherwise a stray
         # output_config.effort would linger after the provider_params update below).
         provider_sets_thinking = provider_params is not None and provider_params.thinking is not None
         if reasoning_effort is not None and not provider_sets_thinking:
             if model_uses_adaptive_thinking(model):
-                kwargs["thinking"] = {"type": "adaptive"}
-                kwargs["output_config"] = {**kwargs.get("output_config", {}), "effort": reasoning_effort}
+                body["thinking"] = {"type": "adaptive"}
+                body["output_config"] = {**body.get("output_config", {}), "effort": reasoning_effort}
             else:
                 budget = {"low": 1024, "medium": 8192, "high": 32768}[reasoning_effort]
-                budget = min(budget, kwargs["max_tokens"] - 1)
-                kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
+                budget = min(budget, body["max_tokens"] - 1)
+                body["thinking"] = {"type": "enabled", "budget_tokens": budget}
         if provider_params is not None:
-            kwargs.update(self._provider_params_kwargs(provider_params))
-        return kwargs
+            body.update(self._provider_params_kwargs(provider_params))
+        return body
 
     @staticmethod
     def _provider_params_kwargs(params: AnthropicParams) -> dict[str, Any]:
-        """Convert AnthropicParams to kwargs for the Anthropic SDK."""
+        """Convert AnthropicParams to request-body kwargs."""
         kwargs: dict[str, Any] = {}
         if params.thinking is not None:
             kwargs["thinking"] = params.thinking
@@ -454,13 +433,36 @@ class AnthropicProvider(
         return response.model_copy(update={"cost": adjusted})
 
 
+class _StreamState:
+    """Accumulates message_start context and maps each streamed event to a chunk."""
+
+    def __init__(self, model: str) -> None:
+        self.model: str = model
+        self._start_usage: Usage | None = None
+
+    def feed(self, event: dict[str, Any]) -> ChatChunk | None:
+        """Map one streamed event to a ChatChunk, or None if it carries no delta."""
+        event_type = event.get("type")
+        if event_type == "message_start":
+            self.model, self._start_usage = map_message_start(event)
+            return None
+        if event_type == "content_block_start":
+            return map_content_block_start(event)
+        if event_type == "content_block_delta":
+            return map_content_block_delta(event)
+        if event_type == "message_delta" and self._start_usage is not None:
+            return map_message_delta(event, self._start_usage)
+        return None
+
+
 class AnthropicVertexProvider(AnthropicProvider):
     """Claude on Vertex AI provider.
 
-    Requires the ``[vertex]`` extra. Reuses the Anthropic API request/response
-    handling unchanged; only client creation and auth differ. ``service_tier``
-    and ``inference_geo`` are Anthropic-API-only parameters and are dropped
-    from outgoing requests; the US-inference cost multiplier never applies.
+    Requires the ``[vertex]`` extra. Reuses the Anthropic Messages API
+    request/response handling; only client creation, endpoint URL, and auth
+    differ. ``service_tier`` and ``inference_geo`` are Anthropic-API-only
+    parameters and are dropped from outgoing requests; the US-inference cost
+    multiplier never applies.
     """
 
     _provider_name: ClassVar[str] = VERTEX_PROVIDER_NAME
@@ -485,6 +487,8 @@ class AnthropicVertexProvider(AnthropicProvider):
         self._vertex_auth: AuthProvider[VertexAuthResult] = auth or AnthropicVertexADCAuthProvider()
         self._project_id: str | None = project_id
         self._region: str | None = region
+        self._resolved_project_id: str | None = None
+        self._resolved_region: str | None = None
 
     @staticmethod
     def _split_auth_result(auth_result: "VertexAuthResult") -> "tuple[Credentials, str | None]":
@@ -492,47 +496,73 @@ class AnthropicVertexProvider(AnthropicProvider):
             return auth_result  # ty: ignore[invalid-return-type]
         return auth_result, None
 
-    def _resolve_project_id(self, auth_project_id: str | None) -> str | None:
+    def _resolve_project_id(self, auth_project_id: str | None) -> str:
         """Resolve the project ID: explicit argument, then env var, then auth-derived.
 
         Matches the SDK's own precedence — the env var wins over a project
         inferred from credentials.
         """
-        if self._project_id is not None:
-            return self._project_id
-        env_project_id = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID")
-        if env_project_id:
-            return env_project_id
-        return auth_project_id
+        project_id = self._project_id or os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID") or auth_project_id
+        if not project_id:
+            raise ProviderError(  # noqa: TRY003
+                "No project_id was given and it could not be resolved from credentials; pass project_id= "
+                "or set ANTHROPIC_VERTEX_PROJECT_ID",
+                provider=self._provider_name,
+            )
+        return project_id
+
+    def _resolve_region(self) -> str:
+        region = self._region or os.environ.get("CLOUD_ML_REGION")
+        if not region:
+            raise ProviderError(  # noqa: TRY003
+                "No region was given; pass region= or set CLOUD_ML_REGION", provider=self._provider_name
+            )
+        return region
 
     @override
-    def _create_sync_client(self) -> "anthropic.AnthropicVertex":
+    def _create_sync_client(self) -> "httpx.Client":
         credentials, auth_project_id = self._split_auth_result(self._vertex_auth.get_credentials())
+        self._resolved_region = self._resolve_region()
+        self._resolved_project_id = self._resolve_project_id(auth_project_id)
         return create_sync_vertex_client(
             credentials=credentials,
-            project_id=self._resolve_project_id(auth_project_id),
-            region=self._region,
+            region=self._resolved_region,
             base_url=self._base_url,
             timeout=self._timeout,
             max_retries=self._max_retries,
         )
 
     @override
-    async def _create_async_client(self) -> "anthropic.AsyncAnthropicVertex":
+    async def _create_async_client(self) -> "httpx.AsyncClient":
         credentials, auth_project_id = self._split_auth_result(await self._vertex_auth.aget_credentials())
+        self._resolved_region = self._resolve_region()
+        self._resolved_project_id = self._resolve_project_id(auth_project_id)
         return create_async_vertex_client(
             credentials=credentials,
-            project_id=self._resolve_project_id(auth_project_id),
-            region=self._region,
+            region=self._resolved_region,
             base_url=self._base_url,
             timeout=self._timeout,
             max_retries=self._max_retries,
         )
+
+    @override
+    def _request_path(self, model: str, *, stream: bool) -> str:
+        specifier = "streamRawPredict" if stream else "rawPredict"
+        return (
+            f"projects/{self._resolved_project_id}/locations/{self._resolved_region}"
+            f"/publishers/anthropic/models/{model}:{specifier}"
+        )
+
+    @override
+    def _transform_body(self, body: dict[str, Any], model: str) -> dict[str, Any]:
+        transformed = {key: value for key, value in body.items() if key != "model"}
+        transformed["anthropic_version"] = VERTEX_ANTHROPIC_VERSION
+        return transformed
 
     @staticmethod
     @override
     def _provider_params_kwargs(params: AnthropicParams) -> dict[str, Any]:
-        """Convert AnthropicParams to SDK kwargs, dropping Anthropic-API-only parameters."""
+        """Convert AnthropicParams to body kwargs, dropping Anthropic-API-only parameters."""
         kwargs = AnthropicProvider._provider_params_kwargs(params)  # noqa: SLF001
         kwargs.pop("service_tier", None)
         kwargs.pop("inference_geo", None)
@@ -556,7 +586,7 @@ class AnthropicVertexProvider(AnthropicProvider):
 class AnthropicFoundryProvider(AnthropicProvider):
     """Claude in Microsoft Foundry provider.
 
-    Reuses the Anthropic API request/response handling unchanged; only client
+    Reuses the Anthropic Messages API request/response handling; only client
     creation and auth differ. ``service_tier`` and ``inference_geo`` are
     Anthropic-API-only parameters and are dropped from outgoing requests; the
     US-inference cost multiplier never applies.
@@ -590,7 +620,7 @@ class AnthropicFoundryProvider(AnthropicProvider):
         return None, auth_result
 
     @override
-    def _create_sync_client(self) -> "anthropic.AnthropicFoundry":
+    def _create_sync_client(self) -> "httpx.Client":
         api_key, azure_ad_token_provider = self._split_foundry_auth(self._foundry_auth.get_credentials())
         return create_sync_foundry_client(
             api_key=api_key,
@@ -602,7 +632,7 @@ class AnthropicFoundryProvider(AnthropicProvider):
         )
 
     @override
-    async def _create_async_client(self) -> "anthropic.AsyncAnthropicFoundry":
+    async def _create_async_client(self) -> "httpx.AsyncClient":
         api_key, azure_ad_token_provider = self._split_foundry_auth(await self._foundry_auth.aget_credentials())
         return create_async_foundry_client(
             api_key=api_key,
@@ -616,7 +646,7 @@ class AnthropicFoundryProvider(AnthropicProvider):
     @staticmethod
     @override
     def _provider_params_kwargs(params: AnthropicParams) -> dict[str, Any]:
-        """Convert AnthropicParams to SDK kwargs, dropping Anthropic-API-only parameters."""
+        """Convert AnthropicParams to body kwargs, dropping Anthropic-API-only parameters."""
         kwargs = AnthropicProvider._provider_params_kwargs(params)  # noqa: SLF001
         kwargs.pop("service_tier", None)
         kwargs.pop("inference_geo", None)

--- a/packages/lmux-anthropic/src/lmux_anthropic/provider.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/provider.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 import os
-from collections.abc import AsyncIterator, Callable, Iterator, Sequence
+from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from datetime import date
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, override
 
@@ -31,6 +31,8 @@ from lmux_anthropic._lazy import (
     create_sync_client,
     create_sync_foundry_client,
     create_sync_vertex_client,
+    foundry_auth_headers,
+    vertex_auth_headers,
 )
 from lmux_anthropic._mappers import (
     map_content_block_delta,
@@ -169,7 +171,7 @@ class AnthropicProvider(
             self._async_client = None
             self._async_loop = None
 
-    # MARK: Request shaping hooks (overridden by Vertex)
+    # MARK: Request shaping hooks (overridden by Vertex/Foundry)
 
     def _request_path(self, model: str, *, stream: bool) -> str:  # noqa: ARG002
         """Path for the Messages request; ``model``/``stream`` matter only on Vertex."""
@@ -178,6 +180,15 @@ class AnthropicProvider(
     def _transform_body(self, body: dict[str, Any], model: str) -> dict[str, Any]:  # noqa: ARG002
         """Adjust the request body per-transport; identity for the Anthropic API."""
         return body
+
+    def _request_headers(self) -> Mapping[str, str]:
+        """Auth headers applied per request.
+
+        Empty for the direct API — its static ``x-api-key`` lives on the cached client.
+        Vertex and Foundry override this to resolve/refresh a short-lived token on every
+        request, so a long-lived provider never sends an expired credential.
+        """
+        return {}
 
     # MARK: Chat
 
@@ -203,7 +214,11 @@ class AnthropicProvider(
         )  # fmt: skip
         try:
             client = self._get_sync_client()
-            response = client.post(self._request_path(model, stream=False), json=self._transform_body(body, model))
+            response = client.post(
+                self._request_path(model, stream=False),
+                json=self._transform_body(body, model),
+                headers=self._request_headers(),
+            )
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
         raise_for_status(response, self._provider_name)
@@ -232,7 +247,9 @@ class AnthropicProvider(
         try:
             client = await self._get_async_client()
             response = await client.post(
-                self._request_path(model, stream=False), json=self._transform_body(body, model)
+                self._request_path(model, stream=False),
+                json=self._transform_body(body, model),
+                headers=self._request_headers(),
             )
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
@@ -263,13 +280,14 @@ class AnthropicProvider(
             client = self._get_sync_client()
             path = self._request_path(model, stream=True)
             body = self._transform_body(body, model)
+            headers = self._request_headers()
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
 
         as_of = self._resolve_pricing_as_of(provider_params)
         stream = _StreamState(model)
         try:
-            with client.stream("POST", path, json=body) as response:
+            with client.stream("POST", path, json=body, headers=headers) as response:
                 if response.status_code >= _HTTP_ERROR:
                     response.read()
                     raise error_from_response(response, self._provider_name)  # noqa: TRY301
@@ -309,13 +327,14 @@ class AnthropicProvider(
             client = await self._get_async_client()
             path = self._request_path(model, stream=True)
             body = self._transform_body(body, model)
+            headers = self._request_headers()
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
 
         as_of = self._resolve_pricing_as_of(provider_params)
         stream = _StreamState(model)
         try:
-            async with client.stream("POST", path, json=body) as response:
+            async with client.stream("POST", path, json=body, headers=headers) as response:
                 if response.status_code >= _HTTP_ERROR:
                     await response.aread()
                     raise error_from_response(response, self._provider_name)  # noqa: TRY301
@@ -508,12 +527,28 @@ class AnthropicVertexProvider(AnthropicProvider):
         self._region: str | None = region
         self._resolved_project_id: str | None = None
         self._resolved_region: str | None = None
+        self._credentials: Credentials | None = None
+        self._auth_project_id: str | None = None
 
     @staticmethod
     def _split_auth_result(auth_result: "VertexAuthResult") -> "tuple[Credentials, str | None]":
         if isinstance(auth_result, tuple):
             return auth_result  # ty: ignore[invalid-return-type]
         return auth_result, None
+
+    def _sync_credentials(self) -> "Credentials":
+        """Resolve Google credentials once and cache them; they refresh their own token in place."""
+        credentials = self._credentials
+        if credentials is None:
+            credentials, self._auth_project_id = self._split_auth_result(self._vertex_auth.get_credentials())
+            self._credentials = credentials
+        return credentials
+
+    async def _acredentials(self) -> "Credentials":
+        # Resolved per async-client creation (once per loop); the sync path caches for per-request reuse.
+        credentials, self._auth_project_id = self._split_auth_result(await self._vertex_auth.aget_credentials())
+        self._credentials = credentials
+        return credentials
 
     def _resolve_project_id(self, auth_project_id: str | None) -> str:
         """Resolve the project ID: explicit argument, then env var, then auth-derived.
@@ -539,12 +574,15 @@ class AnthropicVertexProvider(AnthropicProvider):
         return region
 
     @override
+    def _request_headers(self) -> Mapping[str, str]:
+        return vertex_auth_headers(self._sync_credentials())
+
+    @override
     def _create_sync_client(self) -> "httpx.Client":
-        credentials, auth_project_id = self._split_auth_result(self._vertex_auth.get_credentials())
+        self._sync_credentials()
         self._resolved_region = self._resolve_region()
-        self._resolved_project_id = self._resolve_project_id(auth_project_id)
+        self._resolved_project_id = self._resolve_project_id(self._auth_project_id)
         return create_sync_vertex_client(
-            credentials=credentials,
             region=self._resolved_region,
             base_url=self._base_url,
             timeout=self._timeout,
@@ -553,11 +591,10 @@ class AnthropicVertexProvider(AnthropicProvider):
 
     @override
     async def _create_async_client(self) -> "httpx.AsyncClient":
-        credentials, auth_project_id = self._split_auth_result(await self._vertex_auth.aget_credentials())
+        await self._acredentials()
         self._resolved_region = self._resolve_region()
-        self._resolved_project_id = self._resolve_project_id(auth_project_id)
+        self._resolved_project_id = self._resolve_project_id(self._auth_project_id)
         return create_async_vertex_client(
-            credentials=credentials,
             region=self._resolved_region,
             base_url=self._base_url,
             timeout=self._timeout,
@@ -631,6 +668,9 @@ class AnthropicFoundryProvider(AnthropicProvider):
         )
         self._foundry_auth: AuthProvider[FoundryAuthResult] = auth or AnthropicFoundryEnvAuthProvider()
         self._resource: str | None = resource
+        self._foundry_api_key: str | None = None
+        self._foundry_token_provider: Callable[[], str] | None = None
+        self._foundry_auth_resolved: bool = False
 
     @staticmethod
     def _split_foundry_auth(auth_result: "FoundryAuthResult") -> "tuple[str | None, Callable[[], str] | None]":
@@ -638,12 +678,31 @@ class AnthropicFoundryProvider(AnthropicProvider):
             return auth_result, None
         return None, auth_result
 
+    def _sync_foundry_auth(self) -> "tuple[str | None, Callable[[], str] | None]":
+        """Resolve the Foundry credential once (an API key, or a token-provider callable to invoke per request)."""
+        if not self._foundry_auth_resolved:
+            self._foundry_api_key, self._foundry_token_provider = self._split_foundry_auth(
+                self._foundry_auth.get_credentials()
+            )
+            self._foundry_auth_resolved = True
+        return self._foundry_api_key, self._foundry_token_provider
+
+    async def _afoundry_auth(self) -> "tuple[str | None, Callable[[], str] | None]":
+        # Resolved per async-client creation (once per loop); the sync path caches for per-request reuse.
+        self._foundry_api_key, self._foundry_token_provider = self._split_foundry_auth(
+            await self._foundry_auth.aget_credentials()
+        )
+        self._foundry_auth_resolved = True
+        return self._foundry_api_key, self._foundry_token_provider
+
+    @override
+    def _request_headers(self) -> Mapping[str, str]:
+        return foundry_auth_headers(*self._sync_foundry_auth())
+
     @override
     def _create_sync_client(self) -> "httpx.Client":
-        api_key, azure_ad_token_provider = self._split_foundry_auth(self._foundry_auth.get_credentials())
+        self._sync_foundry_auth()
         return create_sync_foundry_client(
-            api_key=api_key,
-            azure_ad_token_provider=azure_ad_token_provider,
             resource=self._resource,
             base_url=self._base_url,
             timeout=self._timeout,
@@ -652,10 +711,8 @@ class AnthropicFoundryProvider(AnthropicProvider):
 
     @override
     async def _create_async_client(self) -> "httpx.AsyncClient":
-        api_key, azure_ad_token_provider = self._split_foundry_auth(await self._foundry_auth.aget_credentials())
+        await self._afoundry_auth()
         return create_async_foundry_client(
-            api_key=api_key,
-            azure_ad_token_provider=azure_ad_token_provider,
             resource=self._resource,
             base_url=self._base_url,
             timeout=self._timeout,

--- a/packages/lmux-anthropic/src/lmux_anthropic/provider.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/provider.py
@@ -16,7 +16,13 @@ from lmux.cost import ModelPricing, calculate_cost
 from lmux.exceptions import LmuxError, ProviderError
 from lmux.protocols import AuthProvider, CompletionProvider, PricingProvider
 from lmux.types import ChatChunk, ChatResponse, Cost, Message, ResponseFormat, Tool, ToolChoice, Usage
-from lmux_anthropic._exceptions import error_from_response, map_transport_error, raise_for_status
+from lmux_anthropic._exceptions import (
+    error_from_response,
+    error_from_stream,
+    map_transport_error,
+    parse_json,
+    raise_for_status,
+)
 from lmux_anthropic._lazy import (
     VERTEX_ANTHROPIC_VERSION,
     create_async_client,
@@ -194,7 +200,7 @@ class AnthropicProvider(
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
         raise_for_status(response, self._provider_name)
-        return self._map_response(response.json(), provider_params)
+        return self._map_response(parse_json(response, self._provider_name), provider_params)
 
     @override
     async def achat(
@@ -224,7 +230,7 @@ class AnthropicProvider(
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
         raise_for_status(response, self._provider_name)
-        return self._map_response(response.json(), provider_params)
+        return self._map_response(parse_json(response, self._provider_name), provider_params)
 
     @override
     def chat_stream(
@@ -261,7 +267,10 @@ class AnthropicProvider(
                     response.read()
                     raise error_from_response(response, self._provider_name)  # noqa: TRY301
                 for _event, data in iter_sse(response):
-                    chunk = stream.feed(json.loads(data))
+                    payload = json.loads(data)
+                    if payload.get("type") == "error":
+                        raise error_from_stream(payload, self._provider_name)  # noqa: TRY301
+                    chunk = stream.feed(payload)
                     if chunk is not None:
                         yield self._finalize_chunk(chunk, stream, provider_params, as_of)
         except LmuxError:
@@ -304,7 +313,10 @@ class AnthropicProvider(
                     await response.aread()
                     raise error_from_response(response, self._provider_name)  # noqa: TRY301
                 async for _event, data in aiter_sse(response):
-                    chunk = stream.feed(json.loads(data))
+                    payload = json.loads(data)
+                    if payload.get("type") == "error":
+                        raise error_from_stream(payload, self._provider_name)  # noqa: TRY301
+                    chunk = stream.feed(payload)
                     if chunk is not None:
                         yield self._finalize_chunk(chunk, stream, provider_params, as_of)
         except LmuxError:

--- a/packages/lmux-anthropic/src/lmux_anthropic/provider.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/provider.py
@@ -20,7 +20,7 @@ from lmux_anthropic._exceptions import (
     error_from_response,
     error_from_stream,
     map_transport_error,
-    parse_json,
+    parse_message,
     raise_for_status,
 )
 from lmux_anthropic._lazy import (
@@ -43,6 +43,13 @@ from lmux_anthropic._mappers import (
     map_tool_choice,
     map_tools,
     model_uses_adaptive_thinking,
+)
+from lmux_anthropic._wire import (
+    WireContentBlockDeltaEvent,
+    WireContentBlockStartEvent,
+    WireMessage,
+    WireMessageDeltaEvent,
+    WireMessageStartEvent,
 )
 from lmux_anthropic.auth import (
     AnthropicEnvAuthProvider,
@@ -200,7 +207,7 @@ class AnthropicProvider(
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
         raise_for_status(response, self._provider_name)
-        return self._map_response(parse_json(response, self._provider_name), provider_params)
+        return self._map_response(parse_message(response, self._provider_name), provider_params)
 
     @override
     async def achat(
@@ -230,7 +237,7 @@ class AnthropicProvider(
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
         raise_for_status(response, self._provider_name)
-        return self._map_response(parse_json(response, self._provider_name), provider_params)
+        return self._map_response(parse_message(response, self._provider_name), provider_params)
 
     @override
     def chat_stream(
@@ -326,9 +333,9 @@ class AnthropicProvider(
 
     # MARK: Internal Helpers
 
-    def _map_response(self, body: dict[str, Any], provider_params: AnthropicParams | None) -> ChatResponse:
+    def _map_response(self, message: WireMessage, provider_params: AnthropicParams | None) -> ChatResponse:
         as_of = self._resolve_pricing_as_of(provider_params)
-        response = map_message_response(body, self._provider_name, lambda m, u: self._calculate_cost(m, u, as_of))
+        response = map_message_response(message, self._provider_name, lambda m, u: self._calculate_cost(m, u, as_of))
         return self._apply_multipliers(response, provider_params)
 
     def _finalize_chunk(
@@ -456,14 +463,14 @@ class _StreamState:
         """Map one streamed event to a ChatChunk, or None if it carries no delta."""
         event_type = event.get("type")
         if event_type == "message_start":
-            self.model, self._start_usage = map_message_start(event)
+            self.model, self._start_usage = map_message_start(WireMessageStartEvent.model_validate(event))
             return None
         if event_type == "content_block_start":
-            return map_content_block_start(event)
+            return map_content_block_start(WireContentBlockStartEvent.model_validate(event))
         if event_type == "content_block_delta":
-            return map_content_block_delta(event)
+            return map_content_block_delta(WireContentBlockDeltaEvent.model_validate(event))
         if event_type == "message_delta" and self._start_usage is not None:
-            return map_message_delta(event, self._start_usage)
+            return map_message_delta(WireMessageDeltaEvent.model_validate(event), self._start_usage)
         return None
 
 

--- a/packages/lmux-anthropic/src/lmux_anthropic/provider.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/provider.py
@@ -182,11 +182,17 @@ class AnthropicProvider(
         return body
 
     def _request_headers(self) -> Mapping[str, str]:
-        """Auth headers applied per request.
+        """Auth headers applied per request (sync path).
 
         Empty for the direct API — its static ``x-api-key`` lives on the cached client.
         Vertex and Foundry override this to resolve/refresh a short-lived token on every
         request, so a long-lived provider never sends an expired credential.
+        """
+        return {}
+
+    async def _arequest_headers(self) -> Mapping[str, str]:
+        """Auth headers for the async path. Vertex/Foundry override this to offload the
+        (blocking) token refresh to a worker thread so it never stalls the event loop.
         """
         return {}
 
@@ -249,7 +255,7 @@ class AnthropicProvider(
             response = await client.post(
                 self._request_path(model, stream=False),
                 json=self._transform_body(body, model),
-                headers=self._request_headers(),
+                headers=await self._arequest_headers(),
             )
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
@@ -327,7 +333,7 @@ class AnthropicProvider(
             client = await self._get_async_client()
             path = self._request_path(model, stream=True)
             body = self._transform_body(body, model)
-            headers = self._request_headers()
+            headers = await self._arequest_headers()
         except Exception as e:
             raise map_transport_error(e, self._provider_name) from e
 
@@ -578,6 +584,11 @@ class AnthropicVertexProvider(AnthropicProvider):
         return vertex_auth_headers(self._sync_credentials())
 
     @override
+    async def _arequest_headers(self) -> Mapping[str, str]:
+        # The token refresh does blocking HTTP; run it off the event loop.
+        return await asyncio.to_thread(vertex_auth_headers, self._sync_credentials())
+
+    @override
     def _create_sync_client(self) -> "httpx.Client":
         self._sync_credentials()
         self._resolved_region = self._resolve_region()
@@ -698,6 +709,12 @@ class AnthropicFoundryProvider(AnthropicProvider):
     @override
     def _request_headers(self) -> Mapping[str, str]:
         return foundry_auth_headers(*self._sync_foundry_auth())
+
+    @override
+    async def _arequest_headers(self) -> Mapping[str, str]:
+        # An Entra token provider may do blocking HTTP; run it off the event loop.
+        api_key, token_provider = self._sync_foundry_auth()
+        return await asyncio.to_thread(foundry_auth_headers, api_key, token_provider)
 
     @override
     def _create_sync_client(self) -> "httpx.Client":

--- a/packages/lmux-anthropic/tests/test_exceptions.py
+++ b/packages/lmux-anthropic/tests/test_exceptions.py
@@ -12,7 +12,13 @@ from lmux.exceptions import (
     RateLimitError,
     TimeoutError,  # noqa: A004
 )
-from lmux_anthropic._exceptions import error_from_response, map_transport_error, raise_for_status
+from lmux_anthropic._exceptions import (
+    error_from_response,
+    error_from_stream,
+    map_transport_error,
+    parse_json,
+    raise_for_status,
+)
 
 
 def _response(status: int, *, message: str = "boom", headers: dict[str, str] | None = None) -> httpx.Response:
@@ -122,3 +128,28 @@ class TestMapTransportError:
 
     def test_all_mapped_are_lmux_errors(self) -> None:
         assert isinstance(map_transport_error(RuntimeError("x")), LmuxError)
+
+
+class TestParseJson:
+    def test_valid_body(self) -> None:
+        assert parse_json(httpx.Response(200, json={"ok": 1})) == {"ok": 1}
+
+    def test_malformed_body_maps_to_provider_error(self) -> None:
+        with pytest.raises(ProviderError):
+            parse_json(httpx.Response(200, text="not json"))
+
+    def test_non_object_body_maps_to_provider_error(self) -> None:
+        with pytest.raises(ProviderError):
+            parse_json(httpx.Response(200, json=["not", "an", "object"]))
+
+
+class TestErrorFromStream:
+    def test_error_object_with_message(self) -> None:
+        err = error_from_stream({"type": "error", "error": {"message": "stream boom"}})
+        assert isinstance(err, ProviderError)
+        assert "stream boom" in str(err)
+
+    def test_error_not_a_dict(self) -> None:
+        err = error_from_stream({"type": "error", "error": "raw string error"})
+        assert isinstance(err, ProviderError)
+        assert "raw string error" in str(err)

--- a/packages/lmux-anthropic/tests/test_exceptions.py
+++ b/packages/lmux-anthropic/tests/test_exceptions.py
@@ -1,8 +1,6 @@
-"""Tests for Anthropic exception mapping."""
+"""Tests for Anthropic HTTP exception mapping."""
 
-from unittest.mock import MagicMock
-
-import anthropic
+import httpx
 import pytest
 
 from lmux.exceptions import (
@@ -14,202 +12,113 @@ from lmux.exceptions import (
     RateLimitError,
     TimeoutError,  # noqa: A004
 )
-from lmux_anthropic._exceptions import map_anthropic_error
-
-# MARK: Fixtures
+from lmux_anthropic._exceptions import error_from_response, map_transport_error, raise_for_status
 
 
-@pytest.fixture
-def auth_error() -> anthropic.AuthenticationError:
-    response = MagicMock()
-    response.status_code = 401
-    response.headers = {}
-    return anthropic.AuthenticationError(message="test error", response=response, body=None)
+def _response(status: int, *, message: str = "boom", headers: dict[str, str] | None = None) -> httpx.Response:
+    return httpx.Response(status, json={"type": "error", "error": {"message": message}}, headers=headers)
 
 
-@pytest.fixture
-def permission_denied_error() -> anthropic.PermissionDeniedError:
-    response = MagicMock()
-    response.status_code = 403
-    response.headers = {}
-    return anthropic.PermissionDeniedError(message="test error", response=response, body=None)
+# MARK: error_from_response
 
 
-@pytest.fixture
-def rate_limit_error() -> anthropic.RateLimitError:
-    response = MagicMock()
-    response.status_code = 429
-    response.headers = {}
-    return anthropic.RateLimitError(message="test error", response=response, body=None)
-
-
-@pytest.fixture
-def rate_limit_error_with_retry() -> anthropic.RateLimitError:
-    response = MagicMock()
-    response.status_code = 429
-    response.headers = {"retry-after": "30.5"}
-    return anthropic.RateLimitError(message="test error", response=response, body=None)
-
-
-@pytest.fixture
-def rate_limit_error_invalid_retry() -> anthropic.RateLimitError:
-    response = MagicMock()
-    response.status_code = 429
-    response.headers = {"retry-after": "not-a-number"}
-    return anthropic.RateLimitError(message="test error", response=response, body=None)
-
-
-@pytest.fixture
-def bad_request_error() -> anthropic.BadRequestError:
-    response = MagicMock()
-    response.status_code = 400
-    response.headers = {}
-    return anthropic.BadRequestError(message="test error", response=response, body=None)
-
-
-@pytest.fixture
-def not_found_error() -> anthropic.NotFoundError:
-    response = MagicMock()
-    response.status_code = 404
-    response.headers = {}
-    return anthropic.NotFoundError(message="test error", response=response, body=None)
-
-
-@pytest.fixture
-def internal_server_error() -> anthropic.InternalServerError:
-    response = MagicMock()
-    response.status_code = 500
-    response.headers = {}
-    return anthropic.InternalServerError(message="test error", response=response, body=None)
-
-
-@pytest.fixture
-def timeout_error() -> anthropic.APITimeoutError:
-    return anthropic.APITimeoutError(request=MagicMock())
-
-
-# MARK: Tests
-
-
-class TestMapAnthropicError:
-    def test_authentication_error(self, auth_error: anthropic.AuthenticationError) -> None:
-        result = map_anthropic_error(auth_error)
+class TestErrorFromResponse:
+    def test_authentication_401(self) -> None:
+        result = error_from_response(_response(401))
         assert isinstance(result, AuthenticationError)
         assert result.provider == "anthropic"
         assert result.status_code == 401
 
-    def test_custom_provider_propagated(self, auth_error: anthropic.AuthenticationError) -> None:
-        result = map_anthropic_error(auth_error, "anthropic-vertex")
+    def test_authentication_403(self) -> None:
+        result = error_from_response(_response(403))
         assert isinstance(result, AuthenticationError)
-        assert result.provider == "anthropic-vertex"
-
-    def test_permission_denied_error(self, permission_denied_error: anthropic.PermissionDeniedError) -> None:
-        result = map_anthropic_error(permission_denied_error)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "anthropic"
         assert result.status_code == 403
 
-    def test_rate_limit_error(self, rate_limit_error: anthropic.RateLimitError) -> None:
-        result = map_anthropic_error(rate_limit_error)
+    def test_rate_limit_without_retry_after(self) -> None:
+        result = error_from_response(_response(429))
         assert isinstance(result, RateLimitError)
-        assert result.provider == "anthropic"
         assert result.status_code == 429
         assert result.retry_after is None
 
-    def test_rate_limit_with_retry_after(self, rate_limit_error_with_retry: anthropic.RateLimitError) -> None:
-        result = map_anthropic_error(rate_limit_error_with_retry)
+    def test_rate_limit_with_retry_after(self) -> None:
+        result = error_from_response(_response(429, headers={"retry-after": "30.5"}))
         assert isinstance(result, RateLimitError)
         assert result.retry_after == 30.5
 
-    def test_rate_limit_invalid_retry_after(self, rate_limit_error_invalid_retry: anthropic.RateLimitError) -> None:
-        result = map_anthropic_error(rate_limit_error_invalid_retry)
+    def test_rate_limit_invalid_retry_after(self) -> None:
+        result = error_from_response(_response(429, headers={"retry-after": "soon"}))
         assert isinstance(result, RateLimitError)
         assert result.retry_after is None
 
-    def test_bad_request_error(self, bad_request_error: anthropic.BadRequestError) -> None:
-        result = map_anthropic_error(bad_request_error)
+    def test_bad_request_400(self) -> None:
+        result = error_from_response(_response(400))
         assert isinstance(result, InvalidRequestError)
         assert result.status_code == 400
 
-    def test_not_found_error(self, not_found_error: anthropic.NotFoundError) -> None:
-        result = map_anthropic_error(not_found_error)
+    def test_not_found_404(self) -> None:
+        result = error_from_response(_response(404))
         assert isinstance(result, NotFoundError)
         assert result.status_code == 404
 
-    def test_internal_server_error(self, internal_server_error: anthropic.InternalServerError) -> None:
-        result = map_anthropic_error(internal_server_error)
+    def test_server_error_500(self) -> None:
+        result = error_from_response(_response(500))
         assert isinstance(result, ProviderError)
         assert result.status_code == 500
 
-    def test_timeout_error(self, timeout_error: anthropic.APITimeoutError) -> None:
-        result = map_anthropic_error(timeout_error)
+    def test_custom_provider_propagated(self) -> None:
+        result = error_from_response(_response(401), "anthropic-vertex")
+        assert result.provider == "anthropic-vertex"
+
+    def test_message_extracted_from_error_body(self) -> None:
+        result = error_from_response(_response(400, message="bad model"))
+        assert "bad model" in str(result)
+
+    def test_non_json_body_uses_text(self) -> None:
+        result = error_from_response(httpx.Response(500, text="plain failure"))
+        assert "plain failure" in str(result)
+
+    def test_json_without_error_dict_uses_text(self) -> None:
+        result = error_from_response(httpx.Response(400, json={"detail": "nope"}))
+        assert isinstance(result, InvalidRequestError)
+
+    def test_error_dict_without_message_falls_back_to_text(self) -> None:
+        result = error_from_response(httpx.Response(400, json={"error": {"type": "x"}}))
+        assert isinstance(result, InvalidRequestError)
+
+
+# MARK: raise_for_status
+
+
+class TestRaiseForStatus:
+    def test_ok_does_not_raise(self) -> None:
+        raise_for_status(httpx.Response(200, json={}))
+
+    def test_error_raises(self) -> None:
+        with pytest.raises(InvalidRequestError):
+            raise_for_status(_response(400))
+
+
+# MARK: map_transport_error
+
+
+class TestMapTransportError:
+    def test_timeout(self) -> None:
+        result = map_transport_error(httpx.ConnectTimeout("slow"))
         assert isinstance(result, TimeoutError)
         assert result.provider == "anthropic"
 
-    def test_generic_api_status_error(self) -> None:
-        response = MagicMock()
-        response.status_code = 422
-        response.headers = {}
-        error = anthropic.UnprocessableEntityError(message="test error", response=response, body=None)
-        result = map_anthropic_error(error)
+    def test_generic_transport_error(self) -> None:
+        result = map_transport_error(httpx.ConnectError("refused"))
         assert isinstance(result, ProviderError)
-        assert result.provider == "anthropic"
+        assert "refused" in str(result)
 
-    def test_api_connection_error(self) -> None:
-        error = anthropic.APIConnectionError(request=MagicMock())
-        result = map_anthropic_error(error)
-        assert isinstance(result, ProviderError)
-        assert result.provider == "anthropic"
-        assert result.status_code is None
+    def test_custom_provider(self) -> None:
+        result = map_transport_error(httpx.ConnectError("refused"), "anthropic-foundry")
+        assert result.provider == "anthropic-foundry"
 
-    def test_non_anthropic_exception(self) -> None:
-        error = RuntimeError("something broke")
-        result = map_anthropic_error(error)
-        assert isinstance(result, ProviderError)
-        assert result.provider == "anthropic"
+    def test_lmux_error_passed_through(self) -> None:
+        original = ProviderError("already mapped", provider="anthropic-vertex")
+        assert map_transport_error(original) is original
 
-    def test_rate_limit_no_response_attribute(self) -> None:
-        exc = anthropic.RateLimitError(
-            message="rate limited", response=MagicMock(status_code=429, headers={}), body=None
-        )
-        del exc.response
-        result = map_anthropic_error(exc)
-        assert isinstance(result, RateLimitError)
-        assert result.retry_after is None
-
-    @pytest.mark.parametrize(
-        "error",
-        [
-            pytest.param(
-                anthropic.AuthenticationError(message="e", response=MagicMock(status_code=401, headers={}), body=None),
-                id="auth",
-            ),
-            pytest.param(
-                anthropic.PermissionDeniedError(
-                    message="e", response=MagicMock(status_code=403, headers={}), body=None
-                ),
-                id="permission_denied",
-            ),
-            pytest.param(
-                anthropic.RateLimitError(message="e", response=MagicMock(status_code=429, headers={}), body=None),
-                id="rate_limit",
-            ),
-            pytest.param(
-                anthropic.BadRequestError(message="e", response=MagicMock(status_code=400, headers={}), body=None),
-                id="bad_request",
-            ),
-            pytest.param(
-                anthropic.NotFoundError(message="e", response=MagicMock(status_code=404, headers={}), body=None),
-                id="not_found",
-            ),
-            pytest.param(
-                anthropic.InternalServerError(message="e", response=MagicMock(status_code=500, headers={}), body=None),
-                id="internal_server",
-            ),
-            pytest.param(anthropic.APITimeoutError(request=MagicMock()), id="timeout"),
-            pytest.param(RuntimeError("fallback"), id="runtime"),
-        ],
-    )
-    def test_all_mapped_errors_are_lmux_errors(self, error: Exception) -> None:
-        result = map_anthropic_error(error)
-        assert isinstance(result, LmuxError)
+    def test_all_mapped_are_lmux_errors(self) -> None:
+        assert isinstance(map_transport_error(RuntimeError("x")), LmuxError)

--- a/packages/lmux-anthropic/tests/test_exceptions.py
+++ b/packages/lmux-anthropic/tests/test_exceptions.py
@@ -8,6 +8,7 @@ from lmux.exceptions import (
     InvalidRequestError,
     LmuxError,
     NotFoundError,
+    PermissionDeniedError,
     ProviderError,
     RateLimitError,
     TimeoutError,  # noqa: A004
@@ -35,9 +36,9 @@ class TestErrorFromResponse:
         assert result.provider == "anthropic"
         assert result.status_code == 401
 
-    def test_authentication_403(self) -> None:
+    def test_permission_denied_403(self) -> None:
         result = error_from_response(_response(403))
-        assert isinstance(result, AuthenticationError)
+        assert isinstance(result, PermissionDeniedError)
         assert result.status_code == 403
 
     def test_rate_limit_without_retry_after(self) -> None:

--- a/packages/lmux-anthropic/tests/test_exceptions.py
+++ b/packages/lmux-anthropic/tests/test_exceptions.py
@@ -17,9 +17,10 @@ from lmux_anthropic._exceptions import (
     error_from_response,
     error_from_stream,
     map_transport_error,
-    parse_json,
+    parse_message,
     raise_for_status,
 )
+from lmux_anthropic._wire import WireMessage
 
 
 def _response(status: int, *, message: str = "boom", headers: dict[str, str] | None = None) -> httpx.Response:
@@ -131,17 +132,28 @@ class TestMapTransportError:
         assert isinstance(map_transport_error(RuntimeError("x")), LmuxError)
 
 
-class TestParseJson:
+class TestParseMessage:
     def test_valid_body(self) -> None:
-        assert parse_json(httpx.Response(200, json={"ok": 1})) == {"ok": 1}
+        body = {
+            "model": "claude-sonnet-4-6",
+            "content": [{"type": "text", "text": "hi"}],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "stop_reason": "end_turn",
+        }
+        result = parse_message(httpx.Response(200, json=body))
+        assert result == WireMessage.model_validate(body)
 
     def test_malformed_body_maps_to_provider_error(self) -> None:
         with pytest.raises(ProviderError):
-            parse_json(httpx.Response(200, text="not json"))
+            parse_message(httpx.Response(200, text="not json"))
 
     def test_non_object_body_maps_to_provider_error(self) -> None:
         with pytest.raises(ProviderError):
-            parse_json(httpx.Response(200, json=["not", "an", "object"]))
+            parse_message(httpx.Response(200, json=["not", "an", "object"]))
+
+    def test_missing_required_field_maps_to_provider_error(self) -> None:
+        with pytest.raises(ProviderError):
+            parse_message(httpx.Response(200, json={"model": "m"}))  # no content / usage
 
 
 class TestErrorFromStream:

--- a/packages/lmux-anthropic/tests/test_lazy.py
+++ b/packages/lmux-anthropic/tests/test_lazy.py
@@ -129,8 +129,15 @@ class TestFoundryBaseUrl:
     def test_from_resource(self) -> None:
         assert foundry_base_url("res") == "https://res.services.ai.azure.com/anthropic"
 
-    def test_base_url_wins(self) -> None:
-        assert _resolve_foundry_base_url("https://custom", "res") == "https://custom"
+    def test_base_url_and_resource_conflict(self) -> None:
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _resolve_foundry_base_url("https://custom", "res")
+
+    def test_explicit_resource_conflicts_with_env_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A stale env base URL must not silently override an explicitly selected resource.
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_BASE_URL", "https://env.foundry")
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _resolve_foundry_base_url(None, "res")
 
     def test_from_resource_when_no_base_url(self) -> None:
         assert _resolve_foundry_base_url(None, "res") == "https://res.services.ai.azure.com/anthropic"

--- a/packages/lmux-anthropic/tests/test_lazy.py
+++ b/packages/lmux-anthropic/tests/test_lazy.py
@@ -1,0 +1,125 @@
+"""Tests for the Anthropic HTTP client factories and Vertex refresh glue."""
+
+from typing import TYPE_CHECKING, cast
+
+import httpx
+import pytest
+import respx
+
+from lmux_anthropic._lazy import (
+    HttpxTransportRequest,
+    _foundry_headers,
+    _resolve_foundry_base_url,
+    create_sync_foundry_client,
+    create_sync_vertex_client,
+    foundry_base_url,
+    resolve_vertex_token,
+    vertex_base_url,
+)
+
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials
+
+
+class _Credentials:
+    def __init__(
+        self, *, access: str | None, expired: bool = False, refreshed_access: str | None = "refreshed"
+    ) -> None:
+        self.token = access
+        self.expired = expired
+        self._refreshed_access = refreshed_access
+        self.refreshed = False
+
+    def refresh(self, request: object) -> None:  # noqa: ARG002
+        self.refreshed = True
+        self.token = self._refreshed_access
+
+
+class TestResolveVertexToken:
+    def test_returns_existing_token_without_refresh(self) -> None:
+        creds = _Credentials(access="live-token")
+        assert resolve_vertex_token(cast("Credentials", creds)) == "live-token"
+        assert creds.refreshed is False
+
+    def test_refreshes_when_no_token(self) -> None:
+        creds = _Credentials(access=None)
+        assert resolve_vertex_token(cast("Credentials", creds)) == "refreshed"
+        assert creds.refreshed is True
+
+    def test_refreshes_when_expired(self) -> None:
+        creds = _Credentials(access="stale", expired=True)
+        assert resolve_vertex_token(cast("Credentials", creds)) == "refreshed"
+        assert creds.refreshed is True
+
+    def test_raises_when_still_no_token(self) -> None:
+        creds = _Credentials(access=None, refreshed_access=None)
+        with pytest.raises(RuntimeError, match="access token"):
+            resolve_vertex_token(cast("Credentials", creds))
+
+
+class TestHttpxTransportRequest:
+    def test_performs_http_request(self, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post("https://oauth2.example/token").mock(
+            return_value=httpx.Response(200, json={"access_token": "t"}, headers={"x-test": "1"})
+        )
+        response = HttpxTransportRequest()(
+            "https://oauth2.example/token", method="POST", body=b"grant=x", headers={"content-type": "text/plain"}
+        )
+        assert response.status == 200
+        assert response.headers["x-test"] == "1"
+        assert b"access_token" in response.data
+        assert route.called
+
+    def test_default_get(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.get("https://oauth2.example/ping").mock(return_value=httpx.Response(204))
+        response = HttpxTransportRequest()("https://oauth2.example/ping")
+        assert response.status == 204
+
+
+class TestVertexBaseUrl:
+    def test_regional(self) -> None:
+        assert vertex_base_url("us-east5") == "https://us-east5-aiplatform.googleapis.com/v1"
+
+    def test_global(self) -> None:
+        assert vertex_base_url("global") == "https://aiplatform.googleapis.com/v1"
+
+    def test_factory_uses_base_url_override(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post("https://vx.test/v1/messages").mock(return_value=httpx.Response(200, json={}))
+        client = create_sync_vertex_client(
+            credentials=cast("Credentials", _Credentials(access="t")), region="us-east5", base_url="https://vx.test"
+        )
+        response = client.post("v1/messages", json={})
+        assert response.status_code == 200
+
+
+class TestFoundryHeaders:
+    def test_api_key(self) -> None:
+        assert _foundry_headers("k", None)["api-key"] == "k"
+
+    def test_token_provider(self) -> None:
+        assert _foundry_headers(None, lambda: "tok")["Authorization"] == "Bearer tok"
+
+    def test_neither_raises(self) -> None:
+        with pytest.raises(ValueError, match="api_key"):
+            _foundry_headers(None, None)
+
+
+class TestFoundryBaseUrl:
+    def test_from_resource(self) -> None:
+        assert foundry_base_url("res") == "https://res.services.ai.azure.com/anthropic"
+
+    def test_base_url_wins(self) -> None:
+        assert _resolve_foundry_base_url("https://custom", "res") == "https://custom"
+
+    def test_from_resource_when_no_base_url(self) -> None:
+        assert _resolve_foundry_base_url(None, "res") == "https://res.services.ai.azure.com/anthropic"
+
+    def test_neither_raises(self) -> None:
+        with pytest.raises(ValueError, match="base_url"):
+            _resolve_foundry_base_url(None, None)
+
+    def test_factory_with_base_url(self, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post("https://custom.foundry/v1/messages").mock(return_value=httpx.Response(200, json={}))
+        client = create_sync_foundry_client(api_key="k", base_url="https://custom.foundry")
+        client.post("v1/messages", json={})
+        assert route.called

--- a/packages/lmux-anthropic/tests/test_lazy.py
+++ b/packages/lmux-anthropic/tests/test_lazy.py
@@ -1,4 +1,4 @@
-"""Tests for the Anthropic HTTP client factories and Vertex refresh glue."""
+"""Tests for the Anthropic HTTP client factories and Vertex/Foundry auth glue."""
 
 from typing import TYPE_CHECKING, cast
 
@@ -8,12 +8,13 @@ import respx
 
 from lmux_anthropic._lazy import (
     HttpxTransportRequest,
-    _foundry_headers,
     _resolve_foundry_base_url,
     create_sync_foundry_client,
     create_sync_vertex_client,
+    foundry_auth_headers,
     foundry_base_url,
     resolve_vertex_token,
+    vertex_auth_headers,
     vertex_base_url,
 )
 
@@ -57,6 +58,17 @@ class TestResolveVertexToken:
             resolve_vertex_token(cast("Credentials", creds))
 
 
+class TestVertexAuthHeaders:
+    def test_builds_bearer(self) -> None:
+        creds = _Credentials(access="live-token")
+        assert vertex_auth_headers(cast("Credentials", creds)) == {"Authorization": "Bearer live-token"}
+
+    def test_refreshes_expired_token(self) -> None:
+        creds = _Credentials(access="stale", expired=True)
+        assert vertex_auth_headers(cast("Credentials", creds)) == {"Authorization": "Bearer refreshed"}
+        assert creds.refreshed is True
+
+
 class TestHttpxTransportRequest:
     def test_performs_http_request(self, respx_mock: respx.MockRouter) -> None:
         route = respx_mock.post("https://oauth2.example/token").mock(
@@ -83,28 +95,37 @@ class TestVertexBaseUrl:
     def test_global(self) -> None:
         assert vertex_base_url("global") == "https://aiplatform.googleapis.com/v1"
 
+    def test_multi_region_us(self) -> None:
+        assert vertex_base_url("us") == "https://aiplatform.us.rep.googleapis.com/v1"
+
+    def test_multi_region_eu(self) -> None:
+        assert vertex_base_url("eu") == "https://aiplatform.eu.rep.googleapis.com/v1"
+
     def test_factory_uses_base_url_override(self, respx_mock: respx.MockRouter) -> None:
         respx_mock.post("https://vx.test/v1/messages").mock(return_value=httpx.Response(200, json={}))
-        client = create_sync_vertex_client(
-            credentials=cast("Credentials", _Credentials(access="t")), region="us-east5", base_url="https://vx.test"
-        )
+        client = create_sync_vertex_client(region="us-east5", base_url="https://vx.test")
         response = client.post("v1/messages", json={})
         assert response.status_code == 200
 
 
-class TestFoundryHeaders:
-    def test_api_key(self) -> None:
-        assert _foundry_headers("k", None)["api-key"] == "k"
+class TestFoundryAuthHeaders:
+    def test_api_key_sends_both(self) -> None:
+        assert foundry_auth_headers("k", None) == {"x-api-key": "k", "api-key": "k"}
 
     def test_token_provider(self) -> None:
-        assert _foundry_headers(None, lambda: "tok")["Authorization"] == "Bearer tok"
+        assert foundry_auth_headers(None, lambda: "tok") == {"Authorization": "Bearer tok"}
 
     def test_neither_raises(self) -> None:
         with pytest.raises(ValueError, match="api_key"):
-            _foundry_headers(None, None)
+            foundry_auth_headers(None, None)
 
 
 class TestFoundryBaseUrl:
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ANTHROPIC_FOUNDRY_BASE_URL", raising=False)
+        monkeypatch.delenv("ANTHROPIC_FOUNDRY_RESOURCE", raising=False)
+
     def test_from_resource(self) -> None:
         assert foundry_base_url("res") == "https://res.services.ai.azure.com/anthropic"
 
@@ -114,12 +135,20 @@ class TestFoundryBaseUrl:
     def test_from_resource_when_no_base_url(self) -> None:
         assert _resolve_foundry_base_url(None, "res") == "https://res.services.ai.azure.com/anthropic"
 
+    def test_base_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_BASE_URL", "https://env.foundry")
+        assert _resolve_foundry_base_url(None, None) == "https://env.foundry"
+
+    def test_resource_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ANTHROPIC_FOUNDRY_RESOURCE", "env-res")
+        assert _resolve_foundry_base_url(None, None) == "https://env-res.services.ai.azure.com/anthropic"
+
     def test_neither_raises(self) -> None:
-        with pytest.raises(ValueError, match="base_url"):
+        with pytest.raises(ValueError, match="base_url or resource"):
             _resolve_foundry_base_url(None, None)
 
     def test_factory_with_base_url(self, respx_mock: respx.MockRouter) -> None:
         route = respx_mock.post("https://custom.foundry/v1/messages").mock(return_value=httpx.Response(200, json={}))
-        client = create_sync_foundry_client(api_key="k", base_url="https://custom.foundry")
+        client = create_sync_foundry_client(base_url="https://custom.foundry")
         client.post("v1/messages", json={})
         assert route.called

--- a/packages/lmux-anthropic/tests/test_mappers.py
+++ b/packages/lmux-anthropic/tests/test_mappers.py
@@ -44,6 +44,13 @@ from lmux_anthropic._mappers import (
     map_tools,
     model_uses_adaptive_thinking,
 )
+from lmux_anthropic._wire import (
+    WireContentBlockDeltaEvent,
+    WireContentBlockStartEvent,
+    WireMessage,
+    WireMessageDeltaEvent,
+    WireMessageStartEvent,
+)
 
 # MARK: Fixtures
 
@@ -526,7 +533,7 @@ class TestMapMessageResponse:
             "content": [{"type": "text", "text": "Hello!"}],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result == ChatResponse(
             content="Hello!",
             tool_calls=None,
@@ -544,7 +551,7 @@ class TestMapMessageResponse:
             "content": [{"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {"city": "NYC"}}],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result.content is None
         assert result.tool_calls == [
             ToolCall(id="call_1", function=FunctionCallResult(name="get_weather", arguments='{"city": "NYC"}'))
@@ -561,7 +568,7 @@ class TestMapMessageResponse:
             ],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result.content == "Answer"
         assert result.reasoning == "Let me think about this..."
 
@@ -572,7 +579,7 @@ class TestMapMessageResponse:
             "content": [{"type": "thinking", "thinking": "Deep thought..."}],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result.content is None
         assert result.reasoning == "Deep thought..."
 
@@ -583,7 +590,7 @@ class TestMapMessageResponse:
             "content": [{"type": "text", "text": "Part 1"}, {"type": "text", "text": "Part 2"}],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result.content == "Part 1\nPart 2"
 
     def test_thinking_with_tool_use_and_text(self, cost_fn: CostCalculator) -> None:
@@ -598,7 +605,7 @@ class TestMapMessageResponse:
             ],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result.reasoning == "Reasoning..."
         assert result.tool_calls is not None
         assert len(result.tool_calls) == 2
@@ -611,7 +618,7 @@ class TestMapMessageResponse:
             "content": [{"type": "some_future_block"}, {"type": "text", "text": "Answer"}],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result.content == "Answer"
         assert result.reasoning is None
 
@@ -622,7 +629,7 @@ class TestMapMessageResponse:
             "content": [{"type": "text", "text": "Hello"}],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", none_cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", none_cost_fn)
         assert result.cost is None
 
     def test_cache_tokens_mapped(self, cost_fn: CostCalculator) -> None:
@@ -634,7 +641,7 @@ class TestMapMessageResponse:
                 input_tokens=100, output_tokens=50, cache_read_input_tokens=20, cache_creation_input_tokens=10
             ),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result.usage is not None
         # input_tokens is normalized to the inclusive total (100 + 20 + 10)
         assert result.usage.input_tokens == 130
@@ -648,7 +655,7 @@ class TestMapMessageResponse:
             "content": [{"type": "text", "text": "Hello"}],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result.finish_reason is None
 
     def test_missing_stop_reason(self, cost_fn: CostCalculator) -> None:
@@ -657,7 +664,7 @@ class TestMapMessageResponse:
             "content": [{"type": "text", "text": "Hello"}],
             "usage": self._usage(),
         }
-        result = map_message_response(message, "anthropic", cost_fn)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", cost_fn)
         assert result.finish_reason is None
 
     def test_breakdown_mapped_from_cache_creation(self) -> None:
@@ -671,7 +678,7 @@ class TestMapMessageResponse:
                 cache_creation={"ephemeral_5m_input_tokens": 500, "ephemeral_1h_input_tokens": 1500},
             ),
         }
-        result = map_message_response(message, "anthropic", lambda _m, _u: None)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", lambda _m, _u: None)
         assert result.usage is not None
         assert result.usage.input_tokens == 2100
         assert result.usage.cache_creation_tokens_by_ttl == {"5m": 500, "1h": 1500}
@@ -686,7 +693,7 @@ class TestMapMessageResponse:
                 cache_creation={"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 1500},
             ),
         }
-        result = map_message_response(message, "anthropic", lambda _m, _u: None)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", lambda _m, _u: None)
         assert result.usage is not None
         assert result.usage.cache_creation_tokens_by_ttl == {"1h": 1500}
 
@@ -697,7 +704,7 @@ class TestMapMessageResponse:
             "content": [{"type": "text", "text": "Hello"}],
             "usage": self._usage(cache_creation={"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0}),
         }
-        result = map_message_response(message, "anthropic", lambda _m, _u: None)
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", lambda _m, _u: None)
         assert result.usage is not None
         assert result.usage.cache_creation_tokens_by_ttl is None
 
@@ -716,7 +723,7 @@ class TestMapMessageStart:
                 },
             },
         }
-        model, usage = map_message_start(event)
+        model, usage = map_message_start(WireMessageStartEvent.model_validate(event))
         assert model == "claude-sonnet-4-6"
         assert usage == Usage(input_tokens=65, output_tokens=0, cache_read_tokens=10, cache_creation_tokens=5)
 
@@ -728,7 +735,7 @@ class TestMapContentBlockStart:
             "index": 0,
             "content_block": {"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {}},
         }
-        result = map_content_block_start(event)
+        result = map_content_block_start(WireContentBlockStartEvent.model_validate(event))
         assert result == ChatChunk(
             tool_call_deltas=[
                 ToolCallDelta(index=0, id="call_1", type="function", function=FunctionCallDelta(name="get_weather"))
@@ -737,13 +744,13 @@ class TestMapContentBlockStart:
 
     def test_text_block_returns_none(self) -> None:
         event = {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
-        assert map_content_block_start(event) is None
+        assert map_content_block_start(WireContentBlockStartEvent.model_validate(event)) is None
 
 
 class TestMapContentBlockDelta:
     def test_text_delta(self) -> None:
         event = {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}
-        result = map_content_block_delta(event)
+        result = map_content_block_delta(WireContentBlockDeltaEvent.model_validate(event))
         assert result == ChatChunk(delta="Hello")
 
     def test_input_json_delta(self) -> None:
@@ -752,7 +759,7 @@ class TestMapContentBlockDelta:
             "index": 1,
             "delta": {"type": "input_json_delta", "partial_json": '{"city":'},
         }
-        result = map_content_block_delta(event)
+        result = map_content_block_delta(WireContentBlockDeltaEvent.model_validate(event))
         assert result == ChatChunk(
             tool_call_deltas=[ToolCallDelta(index=1, function=FunctionCallDelta(arguments='{"city":'))]
         )
@@ -763,20 +770,20 @@ class TestMapContentBlockDelta:
             "index": 0,
             "delta": {"type": "thinking_delta", "thinking": "Let me think..."},
         }
-        result = map_content_block_delta(event)
+        result = map_content_block_delta(WireContentBlockDeltaEvent.model_validate(event))
         assert result is not None
         assert result.reasoning_delta == "Let me think..."
 
     def test_unknown_delta_type_returns_none(self) -> None:
         event = {"type": "content_block_delta", "index": 0, "delta": {"type": "some_future_delta"}}
-        assert map_content_block_delta(event) is None
+        assert map_content_block_delta(WireContentBlockDeltaEvent.model_validate(event)) is None
 
 
 class TestMapMessageDelta:
     def test_final_chunk_with_usage(self) -> None:
         event = {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 50}}
         start_usage = Usage(input_tokens=100, output_tokens=0, cache_read_tokens=10, cache_creation_tokens=5)
-        result = map_message_delta(event, start_usage)
+        result = map_message_delta(WireMessageDeltaEvent.model_validate(event), start_usage)
         assert result == ChatChunk(
             finish_reason="stop",
             usage=Usage(input_tokens=100, output_tokens=50, cache_read_tokens=10, cache_creation_tokens=5),
@@ -790,7 +797,7 @@ class TestMapMessageDelta:
             cache_creation_tokens_by_ttl={"1h": 2000},
         )
         event = {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 42}}
-        chunk = map_message_delta(event, start_usage)
+        chunk = map_message_delta(WireMessageDeltaEvent.model_validate(event), start_usage)
         assert chunk.usage == Usage(
             input_tokens=2100,
             output_tokens=42,

--- a/packages/lmux-anthropic/tests/test_mappers.py
+++ b/packages/lmux-anthropic/tests/test_mappers.py
@@ -160,7 +160,7 @@ class TestMapMessages:
         assert isinstance(content, list)
         assert len(content) == 2
         assert content[0] == {"type": "text", "text": "Let me check."}
-        assert content[1]["type"] == "tool_use"  # ty: ignore[not-subscriptable]
+        assert content[1]["type"] == "tool_use"
 
     def test_tool_message(self) -> None:
         _, messages = map_messages([ToolMessage(content="72°F", tool_call_id="call_1")])
@@ -180,8 +180,8 @@ class TestMapMessages:
         content = messages[0]["content"]
         assert isinstance(content, list)
         assert len(content) == 2
-        assert content[0]["tool_use_id"] == "call_1"  # ty: ignore[not-subscriptable]
-        assert content[1]["tool_use_id"] == "call_2"  # ty: ignore[not-subscriptable]
+        assert content[0]["tool_use_id"] == "call_1"
+        assert content[1]["tool_use_id"] == "call_2"
 
     def test_tool_message_after_multimodal_user_not_merged(self) -> None:
         _, messages = map_messages(
@@ -195,7 +195,7 @@ class TestMapMessages:
         assert messages[1]["role"] == "user"
         content = messages[1]["content"]
         assert isinstance(content, list)
-        assert content[0]["type"] == "tool_result"  # ty: ignore[not-subscriptable]
+        assert content[0]["type"] == "tool_result"
 
     def test_tool_message_after_user_not_merged(self) -> None:
         _, messages = map_messages(
@@ -514,19 +514,18 @@ class TestMapResponseFormat:
 
 
 class TestMapMessageResponse:
-    def test_text_response(self, cost_fn: CostCalculator) -> None:
-        message = MagicMock()
-        message.content = [MagicMock(type="text", text="Hello!")]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "end_turn"
+    def _usage(self, **overrides: object) -> dict[str, Any]:
+        usage: dict[str, Any] = {"input_tokens": 10, "output_tokens": 5}
+        usage.update(overrides)
+        return usage
 
+    def test_text_response(self, cost_fn: CostCalculator) -> None:
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "usage": self._usage(),
+        }
         result = map_message_response(message, "anthropic", cost_fn)
         assert result == ChatResponse(
             content="Hello!",
@@ -539,24 +538,12 @@ class TestMapMessageResponse:
         )
 
     def test_tool_use_response(self, cost_fn: CostCalculator) -> None:
-        tool_block = MagicMock()
-        tool_block.type = "tool_use"
-        tool_block.id = "call_1"
-        tool_block.name = "get_weather"
-        tool_block.input = {"city": "NYC"}
-
-        message = MagicMock()
-        message.content = [tool_block]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "tool_use"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "tool_use",
+            "content": [{"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {"city": "NYC"}}],
+            "usage": self._usage(),
+        }
         result = map_message_response(message, "anthropic", cost_fn)
         assert result.content is None
         assert result.tool_calls == [
@@ -565,102 +552,52 @@ class TestMapMessageResponse:
         assert result.finish_reason == "tool_calls"
 
     def test_thinking_blocks_extracted(self, cost_fn: CostCalculator) -> None:
-        thinking_block = MagicMock()
-        thinking_block.type = "thinking"
-        thinking_block.thinking = "Let me think about this..."
-        text_block = MagicMock()
-        text_block.type = "text"
-        text_block.text = "Answer"
-
-        message = MagicMock()
-        message.content = [thinking_block, text_block]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "end_turn"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [
+                {"type": "thinking", "thinking": "Let me think about this..."},
+                {"type": "text", "text": "Answer"},
+            ],
+            "usage": self._usage(),
+        }
         result = map_message_response(message, "anthropic", cost_fn)
         assert result.content == "Answer"
         assert result.reasoning == "Let me think about this..."
 
     def test_thinking_blocks_only_no_text(self, cost_fn: CostCalculator) -> None:
-        thinking_block = MagicMock()
-        thinking_block.type = "thinking"
-        thinking_block.thinking = "Deep thought..."
-
-        message = MagicMock()
-        message.content = [thinking_block]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "end_turn"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "thinking", "thinking": "Deep thought..."}],
+            "usage": self._usage(),
+        }
         result = map_message_response(message, "anthropic", cost_fn)
         assert result.content is None
         assert result.reasoning == "Deep thought..."
 
     def test_multiple_text_blocks_joined(self, cost_fn: CostCalculator) -> None:
-        message = MagicMock()
-        message.content = [
-            MagicMock(type="text", text="Part 1"),
-            MagicMock(type="text", text="Part 2"),
-        ]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "end_turn"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Part 1"}, {"type": "text", "text": "Part 2"}],
+            "usage": self._usage(),
+        }
         result = map_message_response(message, "anthropic", cost_fn)
         assert result.content == "Part 1\nPart 2"
 
     def test_thinking_with_tool_use_and_text(self, cost_fn: CostCalculator) -> None:
-        thinking_block = MagicMock()
-        thinking_block.type = "thinking"
-        thinking_block.thinking = "Reasoning..."
-
-        tool_block1 = MagicMock()
-        tool_block1.type = "tool_use"
-        tool_block1.id = "call_1"
-        tool_block1.name = "get_weather"
-        tool_block1.input = {"city": "NYC"}
-
-        tool_block2 = MagicMock()
-        tool_block2.type = "tool_use"
-        tool_block2.id = "call_2"
-        tool_block2.name = "get_time"
-        tool_block2.input = {}
-
-        text_block = MagicMock()
-        text_block.type = "text"
-        text_block.text = "Here's the weather"
-
-        message = MagicMock()
-        message.content = [thinking_block, tool_block1, tool_block2, text_block]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "tool_use"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "tool_use",
+            "content": [
+                {"type": "thinking", "thinking": "Reasoning..."},
+                {"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {"city": "NYC"}},
+                {"type": "tool_use", "id": "call_2", "name": "get_time", "input": {}},
+                {"type": "text", "text": "Here's the weather"},
+            ],
+            "usage": self._usage(),
+        }
         result = map_message_response(message, "anthropic", cost_fn)
         assert result.reasoning == "Reasoning..."
         assert result.tool_calls is not None
@@ -668,57 +605,35 @@ class TestMapMessageResponse:
         assert result.content == "Here's the weather"
 
     def test_unknown_block_type_ignored(self, cost_fn: CostCalculator) -> None:
-        unknown_block = MagicMock()
-        unknown_block.type = "some_future_block"
-        text_block = MagicMock()
-        text_block.type = "text"
-        text_block.text = "Answer"
-
-        message = MagicMock()
-        message.content = [unknown_block, text_block]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "end_turn"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "some_future_block"}, {"type": "text", "text": "Answer"}],
+            "usage": self._usage(),
+        }
         result = map_message_response(message, "anthropic", cost_fn)
         assert result.content == "Answer"
         assert result.reasoning is None
 
     def test_none_cost_when_unknown_model(self, none_cost_fn: CostCalculator) -> None:
-        message = MagicMock()
-        message.content = [MagicMock(type="text", text="Hello")]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-        message.model = "unknown-model"
-        message.stop_reason = "end_turn"
-
+        message = {
+            "model": "unknown-model",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Hello"}],
+            "usage": self._usage(),
+        }
         result = map_message_response(message, "anthropic", none_cost_fn)
         assert result.cost is None
 
     def test_cache_tokens_mapped(self, cost_fn: CostCalculator) -> None:
-        message = MagicMock()
-        message.content = [MagicMock(type="text", text="Hello")]
-        message.usage = MagicMock(
-            input_tokens=100,
-            output_tokens=50,
-            cache_read_input_tokens=20,
-            cache_creation_input_tokens=10,
-            cache_creation=None,
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "end_turn"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Hello"}],
+            "usage": self._usage(
+                input_tokens=100, output_tokens=50, cache_read_input_tokens=20, cache_creation_input_tokens=10
+            ),
+        }
         result = map_message_response(message, "anthropic", cost_fn)
         assert result.usage is not None
         # input_tokens is normalized to the inclusive total (100 + 20 + 10)
@@ -727,71 +642,61 @@ class TestMapMessageResponse:
         assert result.usage.cache_creation_tokens == 10
 
     def test_none_stop_reason(self, cost_fn: CostCalculator) -> None:
-        message = MagicMock()
-        message.content = [MagicMock(type="text", text="Hello")]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = None
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": None,
+            "content": [{"type": "text", "text": "Hello"}],
+            "usage": self._usage(),
+        }
         result = map_message_response(message, "anthropic", cost_fn)
         assert result.finish_reason is None
 
-    # MARK: Streaming mappers
+    def test_missing_stop_reason(self, cost_fn: CostCalculator) -> None:
+        message = {
+            "model": "claude-sonnet-4-6",
+            "content": [{"type": "text", "text": "Hello"}],
+            "usage": self._usage(),
+        }
+        result = map_message_response(message, "anthropic", cost_fn)
+        assert result.finish_reason is None
 
     def test_breakdown_mapped_from_cache_creation(self) -> None:
-        message = MagicMock()
-        message.content = [MagicMock(type="text", text="Hello")]
-        message.usage = MagicMock(
-            input_tokens=100,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=2000,
-            cache_creation=MagicMock(ephemeral_5m_input_tokens=500, ephemeral_1h_input_tokens=1500),
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "end_turn"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Hello"}],
+            "usage": self._usage(
+                input_tokens=100,
+                cache_creation_input_tokens=2000,
+                cache_creation={"ephemeral_5m_input_tokens": 500, "ephemeral_1h_input_tokens": 1500},
+            ),
+        }
         result = map_message_response(message, "anthropic", lambda _m, _u: None)
         assert result.usage is not None
         assert result.usage.input_tokens == 2100
         assert result.usage.cache_creation_tokens_by_ttl == {"5m": 500, "1h": 1500}
 
     def test_zero_breakdown_fields_omitted(self) -> None:
-        message = MagicMock()
-        message.content = [MagicMock(type="text", text="Hello")]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=1500,
-            cache_creation=MagicMock(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=1500),
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "end_turn"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Hello"}],
+            "usage": self._usage(
+                cache_creation_input_tokens=1500,
+                cache_creation={"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 1500},
+            ),
+        }
         result = map_message_response(message, "anthropic", lambda _m, _u: None)
         assert result.usage is not None
         assert result.usage.cache_creation_tokens_by_ttl == {"1h": 1500}
 
     def test_all_zero_breakdown_is_none(self) -> None:
-        message = MagicMock()
-        message.content = [MagicMock(type="text", text="Hello")]
-        message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=5,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=MagicMock(ephemeral_5m_input_tokens=0, ephemeral_1h_input_tokens=0),
-        )
-        message.model = "claude-sonnet-4-6"
-        message.stop_reason = "end_turn"
-
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Hello"}],
+            "usage": self._usage(cache_creation={"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0}),
+        }
         result = map_message_response(message, "anthropic", lambda _m, _u: None)
         assert result.usage is not None
         assert result.usage.cache_creation_tokens_by_ttl is None
@@ -799,15 +704,18 @@ class TestMapMessageResponse:
 
 class TestMapMessageStart:
     def test_extracts_model_and_usage(self) -> None:
-        event = MagicMock()
-        event.message.model = "claude-sonnet-4-6"
-        event.message.usage = MagicMock(
-            input_tokens=50,
-            output_tokens=0,
-            cache_read_input_tokens=10,
-            cache_creation_input_tokens=5,
-            cache_creation=None,
-        )
+        event = {
+            "type": "message_start",
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "usage": {
+                    "input_tokens": 50,
+                    "output_tokens": 0,
+                    "cache_read_input_tokens": 10,
+                    "cache_creation_input_tokens": 5,
+                },
+            },
+        }
         model, usage = map_message_start(event)
         assert model == "claude-sonnet-4-6"
         assert usage == Usage(input_tokens=65, output_tokens=0, cache_read_tokens=10, cache_creation_tokens=5)
@@ -815,12 +723,11 @@ class TestMapMessageStart:
 
 class TestMapContentBlockStart:
     def test_tool_use_block(self) -> None:
-        event = MagicMock()
-        event.content_block.type = "tool_use"
-        event.content_block.id = "call_1"
-        event.content_block.name = "get_weather"
-        event.index = 0
-
+        event = {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {}},
+        }
         result = map_content_block_start(event)
         assert result == ChatChunk(
             tool_call_deltas=[
@@ -829,61 +736,51 @@ class TestMapContentBlockStart:
         )
 
     def test_text_block_returns_none(self) -> None:
-        event = MagicMock()
-        event.content_block.type = "text"
+        event = {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
         assert map_content_block_start(event) is None
 
 
 class TestMapContentBlockDelta:
     def test_text_delta(self) -> None:
-        event = MagicMock()
-        event.delta.type = "text_delta"
-        event.delta.text = "Hello"
-        event.index = 0
-
+        event = {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}
         result = map_content_block_delta(event)
         assert result == ChatChunk(delta="Hello")
 
     def test_input_json_delta(self) -> None:
-        event = MagicMock()
-        event.delta.type = "input_json_delta"
-        event.delta.partial_json = '{"city":'
-        event.index = 1
-
+        event = {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "input_json_delta", "partial_json": '{"city":'},
+        }
         result = map_content_block_delta(event)
         assert result == ChatChunk(
             tool_call_deltas=[ToolCallDelta(index=1, function=FunctionCallDelta(arguments='{"city":'))]
         )
 
     def test_thinking_delta_returns_reasoning(self) -> None:
-        event = MagicMock()
-        event.delta.type = "thinking_delta"
-        event.delta.thinking = "Let me think..."
+        event = {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "Let me think..."},
+        }
         result = map_content_block_delta(event)
         assert result is not None
         assert result.reasoning_delta == "Let me think..."
 
     def test_unknown_delta_type_returns_none(self) -> None:
-        event = MagicMock()
-        event.delta.type = "some_future_delta"
+        event = {"type": "content_block_delta", "index": 0, "delta": {"type": "some_future_delta"}}
         assert map_content_block_delta(event) is None
 
 
 class TestMapMessageDelta:
     def test_final_chunk_with_usage(self) -> None:
-        event = MagicMock()
-        event.delta.stop_reason = "end_turn"
-        event.usage.output_tokens = 50
-
+        event = {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 50}}
         start_usage = Usage(input_tokens=100, output_tokens=0, cache_read_tokens=10, cache_creation_tokens=5)
         result = map_message_delta(event, start_usage)
-
         assert result == ChatChunk(
             finish_reason="stop",
             usage=Usage(input_tokens=100, output_tokens=50, cache_read_tokens=10, cache_creation_tokens=5),
         )
-
-    # MARK: map_tool_choice
 
     def test_delta_usage_carries_breakdown(self) -> None:
         start_usage = Usage(
@@ -892,10 +789,7 @@ class TestMapMessageDelta:
             cache_creation_tokens=2000,
             cache_creation_tokens_by_ttl={"1h": 2000},
         )
-        event = MagicMock()
-        event.usage = MagicMock(output_tokens=42)
-        event.delta = MagicMock(stop_reason="end_turn")
-
+        event = {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 42}}
         chunk = map_message_delta(event, start_usage)
         assert chunk.usage == Usage(
             input_tokens=2100,

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -172,6 +172,28 @@ def async_provider(fake_auth: FakeAuth) -> AnthropicProvider:
     return AnthropicProvider(auth=fake_auth)
 
 
+@pytest.fixture
+def sync_create_raises(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_anthropic.provider.create_sync_client", side_effect=RuntimeError("client init failed"))
+
+
+@pytest.fixture
+def async_create_raises(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_anthropic.provider.create_async_client", side_effect=RuntimeError("client init failed"))
+
+
+@pytest.fixture
+def async_create_two_clients(mocker: MockerFixture) -> tuple[MagicMock, MagicMock, MagicMock]:
+    c1, c2 = MagicMock(), MagicMock()
+    create = mocker.patch("lmux_anthropic.provider.create_async_client", side_effect=[c1, c2])
+    return create, c1, c2
+
+
+@pytest.fixture
+def mock_get_running_loop(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_anthropic.provider.asyncio.get_running_loop")
+
+
 def _ok(respx_mock: respx.MockRouter, message: dict[str, Any] | None = None) -> respx.Route:
     return respx_mock.post(_URL).mock(
         return_value=httpx.Response(200, json=message if message is not None else _message())
@@ -573,11 +595,11 @@ class TestChatStream:
         with pytest.raises(ProviderError):
             list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
-    def test_client_init_failure(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_anthropic.provider.create_sync_client", side_effect=RuntimeError("boom"))
+    def test_client_init_failure(self, fake_auth: FakeAuth, sync_create_raises: MagicMock) -> None:
         provider = AnthropicProvider(auth=fake_auth)
-        with pytest.raises(ProviderError, match="boom"):
+        with pytest.raises(ProviderError, match="client init failed"):
             list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+        sync_create_raises.assert_called_once()
 
 
 # MARK: AchatStream
@@ -625,12 +647,12 @@ class TestAchatStream:
             async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass  # pragma: no cover
 
-    async def test_client_init_failure(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_anthropic.provider.create_async_client", side_effect=RuntimeError("boom"))
+    async def test_client_init_failure(self, fake_auth: FakeAuth, async_create_raises: MagicMock) -> None:
         provider = AnthropicProvider(auth=fake_auth)
-        with pytest.raises(ProviderError, match="boom"):
+        with pytest.raises(ProviderError, match="client init failed"):
             async for _ in provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass  # pragma: no cover
+        async_create_raises.assert_called_once()
 
 
 # MARK: Client management
@@ -672,24 +694,27 @@ class TestClientManagement:
         provider.chat(MODEL, [UserMessage(content="Hi")])
         assert json.loads(route.calls.last.request.content)["max_tokens"] == 8192
 
-    def test_sync_init_failure_mapped(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_anthropic.provider.create_sync_client", side_effect=RuntimeError("connection refused"))
+    def test_sync_init_failure_mapped(self, fake_auth: FakeAuth, sync_create_raises: MagicMock) -> None:
         provider = AnthropicProvider(auth=fake_auth)
-        with pytest.raises(ProviderError, match="connection refused"):
+        with pytest.raises(ProviderError, match="client init failed"):
             provider.chat(MODEL, [UserMessage(content="Hi")])
+        sync_create_raises.assert_called_once()
 
-    async def test_async_init_failure_mapped(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_anthropic.provider.create_async_client", side_effect=RuntimeError("connection refused"))
+    async def test_async_init_failure_mapped(self, fake_auth: FakeAuth, async_create_raises: MagicMock) -> None:
         provider = AnthropicProvider(auth=fake_auth)
-        with pytest.raises(ProviderError, match="connection refused"):
+        with pytest.raises(ProviderError, match="client init failed"):
             await provider.achat(MODEL, [UserMessage(content="Hi")])
+        async_create_raises.assert_called_once()
 
-    async def test_async_client_recreated_on_new_loop(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        c1, c2 = MagicMock(), MagicMock()
-        create = mocker.patch("lmux_anthropic.provider.create_async_client", side_effect=[c1, c2])
-        get_loop = mocker.patch("lmux_anthropic.provider.asyncio.get_running_loop")
+    async def test_async_client_recreated_on_new_loop(
+        self,
+        fake_auth: FakeAuth,
+        async_create_two_clients: tuple[MagicMock, MagicMock, MagicMock],
+        mock_get_running_loop: MagicMock,
+    ) -> None:
+        create, c1, c2 = async_create_two_clients
         loop1, loop2 = asyncio.new_event_loop(), asyncio.new_event_loop()
-        get_loop.side_effect = [loop1, loop2]
+        mock_get_running_loop.side_effect = [loop1, loop2]
         provider = AnthropicProvider(auth=fake_auth)
         r1 = await provider._get_async_client()
         r2 = await provider._get_async_client()

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import threading
 from collections.abc import Callable
 from datetime import date
 from typing import TYPE_CHECKING, Any, cast
@@ -53,10 +54,12 @@ class FakeCredentials:
         self.token = access
         self.expired = expired
         self.refreshed = False
+        self.refresh_thread: int | None = None
         self._refreshed_value = "refreshed-token"
 
     def refresh(self, request: object) -> None:  # noqa: ARG002
         self.refreshed = True
+        self.refresh_thread = threading.get_ident()
         self.token = self._refreshed_value
 
 
@@ -835,6 +838,17 @@ class TestVertexChat:
         provider.chat(MODEL, [UserMessage(content="Hi")])
         assert vertex_auth.credentials.refreshed is True
         assert route.calls[-1].request.headers["authorization"] == "Bearer refreshed-token"
+
+    async def test_async_refresh_runs_off_the_event_loop(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_vertex_url(MODEL)).mock(return_value=httpx.Response(200, json=_message()))
+        auth = FakeVertexAuth()
+        auth.credentials = FakeCredentials(access=None)  # empty token forces a blocking refresh
+        provider = AnthropicVertexProvider(auth=auth, project_id="my-proj", region="us-east5")
+        await provider.achat(MODEL, [UserMessage(content="Hi")])
+        assert auth.credentials.refreshed is True
+        # The refresh must run on a worker thread (asyncio.to_thread), not stall the event loop.
+        assert auth.credentials.refresh_thread is not None
+        assert auth.credentials.refresh_thread != threading.get_ident()
 
     def test_model_prefix_pricing(
         self, vertex_sync_provider: AnthropicVertexProvider, respx_mock: respx.MockRouter

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -92,7 +92,10 @@ class FakeFoundryAuth:
 
 class FakeFoundryTokenAuth:
     def __init__(self) -> None:
+        self.invocations = 0
+
         def _token_provider() -> str:
+            self.invocations += 1
             return "entra-token"
 
         self.token_provider: Callable[[], str] = _token_provider
@@ -774,7 +777,12 @@ class TestPreload:
 
 
 def _vertex_url(model: str, *, region: str = "us-east5", project: str = "my-proj", stream: bool = False) -> str:
-    host = "aiplatform.googleapis.com" if region == "global" else f"{region}-aiplatform.googleapis.com"
+    if region == "global":
+        host = "aiplatform.googleapis.com"
+    elif region in ("us", "eu"):
+        host = f"aiplatform.{region}.rep.googleapis.com"
+    else:
+        host = f"{region}-aiplatform.googleapis.com"
     specifier = "streamRawPredict" if stream else "rawPredict"
     return f"https://{host}/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:{specifier}"
 
@@ -803,10 +811,30 @@ class TestVertexChat:
         assert body["anthropic_version"] == "vertex-2023-10-16"
 
     async def test_basic_achat(self, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter) -> None:
-        respx_mock.post(_vertex_url(MODEL)).mock(return_value=httpx.Response(200, json=_message()))
+        route = respx_mock.post(_vertex_url(MODEL)).mock(return_value=httpx.Response(200, json=_message()))
         provider = AnthropicVertexProvider(auth=vertex_auth, project_id="my-proj", region="us-east5")
         result = await provider.achat(MODEL, [UserMessage(content="Hi")])
         assert result.provider == "anthropic-vertex"
+        assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
+
+    def test_multi_region_us_routes_to_rep_endpoint(
+        self, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.post(_vertex_url(MODEL, region="us")).mock(return_value=httpx.Response(200, json=_message()))
+        provider = AnthropicVertexProvider(auth=vertex_auth, project_id="my-proj", region="us")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called  # https://aiplatform.us.rep.googleapis.com/... not us-aiplatform.googleapis.com
+
+    def test_token_refreshed_per_request(self, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_vertex_url(MODEL)).mock(return_value=httpx.Response(200, json=_message()))
+        provider = AnthropicVertexProvider(auth=vertex_auth, project_id="my-proj", region="us-east5")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.calls[-1].request.headers["authorization"] == "Bearer vertex-token"
+        # The token expires between requests; the next call must refresh rather than reuse a frozen client header.
+        vertex_auth.credentials.expired = True
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert vertex_auth.credentials.refreshed is True
+        assert route.calls[-1].request.headers["authorization"] == "Bearer refreshed-token"
 
     def test_model_prefix_pricing(
         self, vertex_sync_provider: AnthropicVertexProvider, respx_mock: respx.MockRouter
@@ -977,7 +1005,7 @@ class TestVertexChatStream:
     def test_stream_stamps_vertex_identity(
         self, vertex_sync_provider: AnthropicVertexProvider, respx_mock: respx.MockRouter
     ) -> None:
-        respx_mock.post(_vertex_url(MODEL, stream=True)).mock(
+        route = respx_mock.post(_vertex_url(MODEL, stream=True)).mock(
             return_value=httpx.Response(200, content=_default_stream())
         )
         chunks = list(vertex_sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
@@ -985,14 +1013,16 @@ class TestVertexChatStream:
         assert chunks[-1].model == MODEL
         assert chunks[-1].provider == "anthropic-vertex"
         assert chunks[-1].cost is not None
+        assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
 
     async def test_async_stream(self, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter) -> None:
-        respx_mock.post(_vertex_url(MODEL, stream=True)).mock(
+        route = respx_mock.post(_vertex_url(MODEL, stream=True)).mock(
             return_value=httpx.Response(200, content=_default_stream())
         )
         provider = AnthropicVertexProvider(auth=vertex_auth, project_id="my-proj", region="us-east5")
         chunks = [c async for c in provider.achat_stream(MODEL, [UserMessage(content="Hi")])]
         assert chunks[-1].provider == "anthropic-vertex"
+        assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
 
 
 # MARK: Foundry
@@ -1024,11 +1054,29 @@ class TestFoundryChat:
         result = await provider.achat(MODEL, [UserMessage(content="Hi")])
         assert result.provider == "anthropic-foundry"
 
+    def test_api_key_sends_both_headers(
+        self, foundry_sync_provider: AnthropicFoundryProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
+        foundry_sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        headers = route.calls.last.request.headers
+        # The Anthropic-on-Foundry endpoint authenticates with x-api-key; api-key is kept for compatibility.
+        assert headers["x-api-key"] == "foundry-key"
+        assert headers["api-key"] == "foundry-key"
+
     def test_token_auth_uses_bearer(self, respx_mock: respx.MockRouter) -> None:
         route = respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
         provider = AnthropicFoundryProvider(auth=FakeFoundryTokenAuth(), resource="my-resource")
         provider.chat(MODEL, [UserMessage(content="Hi")])
         assert route.calls.last.request.headers["authorization"] == "Bearer entra-token"
+
+    def test_token_provider_invoked_per_request(self, respx_mock: respx.MockRouter) -> None:
+        auth = FakeFoundryTokenAuth()
+        respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
+        provider = AnthropicFoundryProvider(auth=auth, resource="my-resource")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert auth.invocations == 2  # invoked per request, not frozen at client creation
 
     def test_api_only_params_dropped(
         self, foundry_sync_provider: AnthropicFoundryProvider, respx_mock: respx.MockRouter

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -396,6 +396,11 @@ class TestChat:
         with pytest.raises(ProviderError, match="refused"):
             sync_provider.chat(MODEL, [UserMessage(content="Hi")])
 
+    def test_non_json_body_mapped(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=b"not json"))
+        with pytest.raises(ProviderError):
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+
     def test_us_inference_multiplier(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
         _ok(respx_mock)
         standard = sync_provider.chat(MODEL, [UserMessage(content="Hi")])
@@ -437,6 +442,11 @@ class TestAchat:
         with pytest.raises(ProviderError, match="refused"):
             await async_provider.achat(MODEL, [UserMessage(content="Hi")])
 
+    async def test_non_json_body_mapped(self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=b"not json"))
+        with pytest.raises(ProviderError):
+            await async_provider.achat(MODEL, [UserMessage(content="Hi")])
+
 
 # MARK: ChatStream
 
@@ -455,6 +465,24 @@ class TestChatStream:
         assert chunks[-1].cost is not None
         assert chunks[-1].cost.total_cost > 0
         assert json.loads(route.calls.last.request.content)["stream"] is True
+
+    def test_mid_stream_error_raises_after_partial(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        sse = _sse(
+            [
+                (
+                    "content_block_delta",
+                    {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hel"}},
+                ),
+                ("error", {"type": "error", "error": {"type": "overloaded_error", "message": "mid-stream boom"}}),
+            ]
+        )
+        respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=sse))
+        stream = sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")])
+        assert next(stream).delta == "Hel"  # partial output arrives first
+        with pytest.raises(ProviderError, match="mid-stream boom"):
+            next(stream)
 
     def test_cost_bills_resolved_model(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
         respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=_default_stream()))
@@ -564,6 +592,24 @@ class TestAchatStream:
         assert chunks[-1].model == MODEL
         assert chunks[-1].provider == "anthropic"
         assert chunks[-1].cost is not None
+
+    async def test_mid_stream_error_raises_after_partial(
+        self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        sse = _sse(
+            [
+                (
+                    "content_block_delta",
+                    {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hel"}},
+                ),
+                ("error", {"type": "error", "error": {"type": "overloaded_error", "message": "mid-stream boom"}}),
+            ]
+        )
+        respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=sse))
+        stream = async_provider.achat_stream(MODEL, [UserMessage(content="Hi")])
+        assert (await anext(stream)).delta == "Hel"  # partial output arrives first
+        with pytest.raises(ProviderError, match="mid-stream boom"):
+            await anext(stream)
 
     async def test_status_error_on_open(self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
         respx_mock.post(_URL).mock(return_value=httpx.Response(500, json={"error": {"message": "boom"}}))

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -1,22 +1,22 @@
-"""Tests for Anthropic provider."""
+"""Tests for the Anthropic provider (SDK-lite, respx)."""
 
 import asyncio
+import json
 from collections.abc import Callable
 from datetime import date
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
 
-import anthropic
+import httpx
 import pytest
+import respx
 from pytest_mock import MockerFixture
 
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials
+
 from lmux.cost import ModelPricing, PricingTier
-from lmux.exceptions import (
-    AuthenticationError,
-    InvalidRequestError,
-    ProviderError,
-    UnsupportedFeatureError,
-)
+from lmux.exceptions import AuthenticationError, InvalidRequestError, ProviderError, UnsupportedFeatureError
 from lmux.types import (
     FunctionDefinition,
     JsonObjectResponseFormat,
@@ -31,12 +31,14 @@ from lmux_anthropic.auth import AnthropicFoundryEnvAuthProvider, AnthropicVertex
 from lmux_anthropic.params import AnthropicParams
 from lmux_anthropic.provider import AnthropicFoundryProvider, AnthropicProvider, AnthropicVertexProvider
 
-# MARK: Shared Fixtures
+MODEL = "claude-sonnet-4-6"
+_URL = "https://api.anthropic.com/v1/messages"
+
+
+# MARK: Fakes & builders
 
 
 class FakeAuth:
-    """Fake auth provider for testing."""
-
     def get_credentials(self) -> str:
         return "sk-ant-fake-key"
 
@@ -44,1599 +46,43 @@ class FakeAuth:
         return "sk-ant-fake-key"
 
 
-@pytest.fixture
-def fake_auth() -> FakeAuth:
-    return FakeAuth()
-
-
-def _make_message_response(
-    *,
-    text: str = "Hello!",
-    model: str = "claude-sonnet-4-6",
-    stop_reason: str = "end_turn",
-    input_tokens: int = 10,
-    output_tokens: int = 5,
-) -> MagicMock:
-    text_block = MagicMock()
-    text_block.type = "text"
-    text_block.text = text
-
-    message = MagicMock()
-    message.content = [text_block]
-    message.model = model
-    message.stop_reason = stop_reason
-    message.usage = MagicMock(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        cache_read_input_tokens=0,
-        cache_creation_input_tokens=0,
-        cache_creation=None,
-    )
-    return message
-
-
-@pytest.fixture
-def message_response() -> MagicMock:
-    return _make_message_response()
-
-
-def _make_stream_events() -> list[MagicMock]:
-    start_event = MagicMock()
-    start_event.type = "message_start"
-    start_event.message.model = "claude-sonnet-4-6"
-    start_event.message.usage = MagicMock(
-        input_tokens=10, output_tokens=0, cache_read_input_tokens=0, cache_creation_input_tokens=0, cache_creation=None
-    )
-
-    text_delta = MagicMock()
-    text_delta.type = "content_block_delta"
-    text_delta.delta.type = "text_delta"
-    text_delta.delta.text = "Hel"
-    text_delta.index = 0
-
-    text_delta2 = MagicMock()
-    text_delta2.type = "content_block_delta"
-    text_delta2.delta.type = "text_delta"
-    text_delta2.delta.text = "lo!"
-    text_delta2.index = 0
-
-    delta_event = MagicMock()
-    delta_event.type = "message_delta"
-    delta_event.delta.stop_reason = "end_turn"
-    delta_event.usage.output_tokens = 5
-
-    return [start_event, text_delta, text_delta2, delta_event]
-
-
-@pytest.fixture
-def stream_events() -> list[MagicMock]:
-    return _make_stream_events()
-
-
-@pytest.fixture
-def mock_sync_client() -> MagicMock:
-    return MagicMock()
-
-
-@pytest.fixture
-def mock_sync_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("lmux_anthropic.provider.create_sync_client", return_value=mock_sync_client)
-
-
-@pytest.fixture
-def sync_provider(fake_auth: FakeAuth, mock_sync_create: MagicMock) -> AnthropicProvider:
-    assert mock_sync_create  # fixture activates the patch
-    return AnthropicProvider(auth=fake_auth)
-
-
-@pytest.fixture
-def mock_async_client() -> MagicMock:
-    mock = MagicMock()
-    mock.messages.create = AsyncMock()
-    mock.close = AsyncMock()
-    return mock
-
-
-@pytest.fixture
-def mock_async_create(mock_async_client: MagicMock, mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("lmux_anthropic.provider.create_async_client", return_value=mock_async_client)
-
-
-@pytest.fixture
-def async_provider(fake_auth: FakeAuth, mock_async_create: MagicMock) -> AnthropicProvider:
-    assert mock_async_create  # fixture activates the patch
-    return AnthropicProvider(auth=fake_auth)
-
-
-@pytest.fixture
-def bad_request_error() -> anthropic.BadRequestError:
-    response = MagicMock()
-    response.status_code = 400
-    response.headers = {}
-    return anthropic.BadRequestError(message="test error", response=response, body=None)
-
-
-@pytest.fixture
-def auth_error() -> anthropic.AuthenticationError:
-    response = MagicMock()
-    response.status_code = 401
-    response.headers = {}
-    return anthropic.AuthenticationError(message="test error", response=response, body=None)
-
-
-@pytest.fixture
-def server_error() -> anthropic.InternalServerError:
-    response = MagicMock()
-    response.status_code = 500
-    response.headers = {}
-    return anthropic.InternalServerError(message="test error", response=response, body=None)
-
-
-# MARK: Chat
-
-
-class TestPricingAsOf:
-    def test_live_cost_uses_current_date_in_intro_window(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """During the introductory window, live Sonnet 5 cost bills the introductory rate."""
-        monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 7, 1))
-        mock_sync_client.messages.create.return_value = _make_message_response(
-            model="claude-sonnet-5", input_tokens=1000, output_tokens=500
-        )
-        response = sync_provider.chat("claude-sonnet-5", [UserMessage(content="Hi")])
-        assert response.cost is not None
-        assert response.cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
-        assert response.cost.output_cost == pytest.approx(500 * 10.0 / 1_000_000)
-
-    def test_live_cost_uses_current_date_after_switch(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """After 2026-09-01, live Sonnet 5 cost bills the standard rate."""
-        monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 9, 15))
-        mock_sync_client.messages.create.return_value = _make_message_response(
-            model="claude-sonnet-5", input_tokens=1000, output_tokens=500
-        )
-        response = sync_provider.chat("claude-sonnet-5", [UserMessage(content="Hi")])
-        assert response.cost is not None
-        assert response.cost.input_cost == pytest.approx(1000 * 3.0 / 1_000_000)
-        assert response.cost.output_cost == pytest.approx(500 * 15.0 / 1_000_000)
-
-    def test_pricing_as_of_override_wins_over_clock(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """An explicit pricing_as_of overrides the current date (e.g. for cost replay)."""
-        monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 9, 15))
-        mock_sync_client.messages.create.return_value = _make_message_response(
-            model="claude-sonnet-5", input_tokens=1000, output_tokens=500
-        )
-        response = sync_provider.chat(
-            "claude-sonnet-5",
-            [UserMessage(content="Hi")],
-            provider_params=AnthropicParams(pricing_as_of=date(2026, 7, 1)),
-        )
-        assert response.cost is not None
-        # The override date lands in the intro window, so the introductory rate wins.
-        assert response.cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
-        assert response.cost.output_cost == pytest.approx(500 * 10.0 / 1_000_000)
-
-    async def test_achat_applies_dated_pricing(
-        self,
-        async_provider: AnthropicProvider,
-        mock_async_client: MagicMock,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """The async path resolves and applies the dated pricing date like the sync path."""
-        monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 7, 1))
-        mock_async_client.messages.create.return_value = _make_message_response(
-            model="claude-sonnet-5", input_tokens=1000, output_tokens=500
-        )
-        response = await async_provider.achat("claude-sonnet-5", [UserMessage(content="Hi")])
-        assert response.cost is not None
-        assert response.cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
-
-
-class TestChat:
-    def test_basic_chat(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        result = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert result.content == "Hello!"
-        assert result.model == "claude-sonnet-4-6"
-        assert result.provider == "anthropic"
-        assert result.usage is not None
-        assert result.usage.input_tokens == 10
-        assert result.usage.output_tokens == 5
-        mock_sync_client.messages.create.assert_called_once()
-
-    def test_chat_with_params(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat(
-            "claude-sonnet-4-6",
-            [UserMessage(content="Hi")],
-            temperature=0.5,
-            max_tokens=100,
-            top_p=0.9,
-            stop=["END"],
-        )
-
-        mock_sync_client.messages.create.assert_called_once_with(
-            model="claude-sonnet-4-6",
-            messages=[{"role": "user", "content": "Hi"}],
-            max_tokens=100,
-            stream=False,
-            temperature=0.5,
-            top_p=0.9,
-            stop_sequences=["END"],
-        )
-
-    def test_chat_default_max_tokens(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["max_tokens"] == 4096
-
-    def test_chat_explicit_max_tokens_overrides_default(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")], max_tokens=200)
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["max_tokens"] == 200
-
-    def test_chat_with_system_message(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat("claude-sonnet-4-6", [SystemMessage(content="Be helpful."), UserMessage(content="Hi")])
-
-        mock_sync_client.messages.create.assert_called_once_with(
-            model="claude-sonnet-4-6",
-            messages=[{"role": "user", "content": "Hi"}],
-            max_tokens=4096,
-            stream=False,
-            system="Be helpful.",
-        )
-
-    def test_chat_with_tools(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        tools = [Tool(function=FunctionDefinition(name="get_weather"))]
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")], tools=tools)
-
-        mock_sync_client.messages.create.assert_called_once_with(
-            model="claude-sonnet-4-6",
-            messages=[{"role": "user", "content": "Hi"}],
-            max_tokens=4096,
-            stream=False,
-            tools=[{"name": "get_weather", "input_schema": {"type": "object"}}],
-        )
-
-    def test_chat_with_tool_choice(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")], tool_choice="required")
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["tool_choice"] == {"type": "any"}
-
-    def test_chat_with_json_schema_response_format(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        rf = JsonSchemaResponseFormat(name="person", json_schema={"type": "object"})
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")], response_format=rf)
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["output_config"] == {
-            "format": {"type": "json_schema", "schema": {"type": "object", "additionalProperties": False}}
-        }
-
-    def test_chat_text_response_format_is_noop(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")], response_format=TextResponseFormat())
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert "output_config" not in call_kwargs
-
-    def test_chat_json_object_raises(self, sync_provider: AnthropicProvider) -> None:
-        with pytest.raises(UnsupportedFeatureError, match="JsonObjectResponseFormat is not supported"):
-            _ = sync_provider.chat(
-                "claude-sonnet-4-6", [UserMessage(content="Hi")], response_format=JsonObjectResponseFormat()
-            )
-
-    def test_chat_with_provider_params(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat(
-            "claude-sonnet-4-6",
-            [UserMessage(content="Hi")],
-            provider_params=AnthropicParams(
-                thinking={"type": "enabled", "budget_tokens": 10000},
-                top_k=40,
-                service_tier="auto",
-            ),
-        )
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 10000}
-        assert call_kwargs["top_k"] == 40
-        assert call_kwargs["service_tier"] == "auto"
-
-    def test_chat_with_stop_string(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")], stop="STOP")
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["stop_sequences"] == ["STOP"]
-
-    def test_chat_with_reasoning_effort(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        # default max_tokens=4096, so medium (8192) gets capped to 4095
-        _ = sync_provider.chat("claude-sonnet-4-5", [UserMessage(content="Hi")], reasoning_effort="medium")
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 4095}
-
-    def test_chat_with_reasoning_effort_and_high_max_tokens(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat(
-            "claude-sonnet-4-5", [UserMessage(content="Hi")], reasoning_effort="high", max_tokens=50000
-        )
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 32768}
-        assert call_kwargs["max_tokens"] == 50000
-
-    def test_chat_reasoning_effort_adaptive_model(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        # A 4.6+ model uses adaptive thinking + output_config.effort, not budget_tokens.
-        _ = sync_provider.chat("claude-opus-4-8", [UserMessage(content="Hi")], reasoning_effort="high")
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "adaptive"}
-        assert call_kwargs["output_config"] == {"effort": "high"}
-
-    def test_chat_reasoning_effort_adaptive_merges_response_format(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        # effort must merge into the output_config produced by response_format, not clobber it.
-        rf = JsonSchemaResponseFormat(name="person", json_schema={"type": "object"})
-        _ = sync_provider.chat(
-            "claude-opus-4-8", [UserMessage(content="Hi")], reasoning_effort="medium", response_format=rf
-        )
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "adaptive"}
-        assert call_kwargs["output_config"] == {
-            "format": {"type": "json_schema", "schema": {"type": "object", "additionalProperties": False}},
-            "effort": "medium",
-        }
-
-    def test_chat_reasoning_effort_ignored_when_provider_thinking(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        # provider_params.thinking wins: reasoning_effort is fully ignored, leaving no stray effort.
-        _ = sync_provider.chat(
-            "claude-opus-4-8",
-            [UserMessage(content="Hi")],
-            reasoning_effort="high",
-            provider_params=AnthropicParams(thinking={"type": "enabled", "budget_tokens": 5000}),
-        )
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 5000}
-        assert "output_config" not in call_kwargs
-
-    def test_chat_exception_mapping(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        bad_request_error: anthropic.BadRequestError,
-    ) -> None:
-        mock_sync_client.messages.create.side_effect = bad_request_error
-
-        with pytest.raises(InvalidRequestError):
-            _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-    def test_chat_cost_calculated(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        result = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert result.cost is not None
-        assert result.cost.total_cost > 0
-
-    def test_chat_us_inference_multiplier(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        result_standard = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        result_us = sync_provider.chat(
-            "claude-sonnet-4-6",
-            [UserMessage(content="Hi")],
-            provider_params=AnthropicParams(inference_geo="us"),
-        )
-
-        assert result_standard.cost is not None
-        assert result_us.cost is not None
-        assert result_us.cost.total_cost == pytest.approx(result_standard.cost.total_cost * 1.1)
-
-    def test_chat_no_multiplier_without_params(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        result = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        result_empty = sync_provider.chat(
-            "claude-sonnet-4-6",
-            [UserMessage(content="Hi")],
-            provider_params=AnthropicParams(),
-        )
-
-        assert result.cost is not None
-        assert result_empty.cost is not None
-        assert result.cost.total_cost == result_empty.cost.total_cost
-
-
-# MARK: Achat
-
-
-class TestAchat:
-    async def test_basic_achat(
-        self, async_provider: AnthropicProvider, mock_async_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-
-        result = await async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert result.content == "Hello!"
-        assert result.provider == "anthropic"
-        mock_async_client.messages.create.assert_awaited_once()
-
-    async def test_achat_exception_mapping(
-        self,
-        async_provider: AnthropicProvider,
-        mock_async_client: MagicMock,
-        auth_error: anthropic.AuthenticationError,
-    ) -> None:
-        mock_async_client.messages.create.side_effect = auth_error
-
-        with pytest.raises(AuthenticationError):
-            _ = await async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-
-# MARK: ChatStream
-
-
-class TestChatStream:
-    def test_yields_chunks(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[MagicMock],
-    ) -> None:
-        mock_sync_client.messages.create.return_value = iter(stream_events)
-
-        chunks = list(sync_provider.chat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")]))
-
-        assert len(chunks) == 3
-        assert chunks[0].delta == "Hel"
-        assert chunks[1].delta == "lo!"
-        assert chunks[2].finish_reason == "stop"
-        # The terminal chunk stamps the endpoint identity, mirroring the non-streaming path.
-        assert chunks[2].model == "claude-sonnet-4-6"
-        assert chunks[2].provider == "anthropic"
-        # Interior chunks carry no endpoint identity.
-        assert chunks[0].model is None
-        assert chunks[0].provider is None
-
-    def test_cost_on_final_chunk(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[MagicMock],
-    ) -> None:
-        mock_sync_client.messages.create.return_value = iter(stream_events)
-
-        chunks = list(sync_provider.chat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")]))
-
-        assert chunks[0].cost is None
-        assert chunks[1].cost is None
-        assert chunks[2].cost is not None
-        assert chunks[2].cost.total_cost > 0
-
-    def test_cost_bills_against_resolved_model(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[MagicMock],
-    ) -> None:
-        # The requested name is an opaque alias absent from the pricing table; message_start
-        # resolves to a priced model. Streaming must bill against the resolved model (as the
-        # non-streaming path does), so the terminal chunk still gets a cost.
-        mock_sync_client.messages.create.return_value = iter(stream_events)
-
-        chunks = list(sync_provider.chat_stream("opaque-alias", [UserMessage(content="Hi")]))
-
-        assert chunks[2].model == "claude-sonnet-4-6"
-        assert chunks[2].cost is not None
-        assert chunks[2].cost.total_cost > 0
-
-    def test_stream_with_content_block_start(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-    ) -> None:
-        start_event = MagicMock()
-        start_event.type = "message_start"
-        start_event.message.model = "claude-sonnet-4-6"
-        start_event.message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=0,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-
-        text_block_start = MagicMock()
-        text_block_start.type = "content_block_start"
-        text_block_start.content_block.type = "text"
-
-        block_start = MagicMock()
-        block_start.type = "content_block_start"
-        block_start.content_block.type = "tool_use"
-        block_start.content_block.id = "call_1"
-        block_start.content_block.name = "get_weather"
-        block_start.index = 0
-
-        thinking_delta_event = MagicMock()
-        thinking_delta_event.type = "content_block_delta"
-        thinking_delta_event.delta.type = "thinking_delta"
-        thinking_delta_event.delta.thinking = "Let me think..."
-
-        unknown_delta_event = MagicMock()
-        unknown_delta_event.type = "content_block_delta"
-        unknown_delta_event.delta.type = "some_future_delta"
-
-        unknown_event = MagicMock()
-        unknown_event.type = "content_block_stop"
-
-        delta_event = MagicMock()
-        delta_event.type = "message_delta"
-        delta_event.delta.stop_reason = "tool_use"
-        delta_event.usage.output_tokens = 5
-
-        mock_sync_client.messages.create.return_value = iter(
-            [
-                start_event,
-                text_block_start,
-                block_start,
-                thinking_delta_event,
-                unknown_delta_event,
-                unknown_event,
-                delta_event,
-            ]
-        )
-
-        chunks = list(sync_provider.chat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")]))
-
-        assert len(chunks) == 3
-        assert chunks[0].tool_call_deltas is not None
-        assert chunks[0].tool_call_deltas[0].function is not None
-        assert chunks[0].tool_call_deltas[0].function.name == "get_weather"
-        assert chunks[1].reasoning_delta == "Let me think..."
-        assert chunks[2].finish_reason == "tool_calls"
-
-    def test_stream_with_reasoning_effort(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[MagicMock],
-    ) -> None:
-        mock_sync_client.messages.create.return_value = iter(stream_events)
-
-        _ = list(sync_provider.chat_stream("claude-sonnet-4-5", [UserMessage(content="Hi")], reasoning_effort="medium"))
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 4095}
-
-    def test_stream_exception_on_create(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        server_error: anthropic.InternalServerError,
-    ) -> None:
-        mock_sync_client.messages.create.side_effect = server_error
-
-        with pytest.raises(ProviderError):
-            _ = list(sync_provider.chat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")]))
-
-    def test_stream_exception_during_iteration(
-        self,
-        sync_provider: AnthropicProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[MagicMock],
-        server_error: anthropic.InternalServerError,
-    ) -> None:
-        def _failing_iter() -> Any:  # noqa: ANN401
-            yield stream_events[0]
-            yield stream_events[1]
-            raise server_error
-
-        mock_sync_client.messages.create.return_value = _failing_iter()
-
-        with pytest.raises(ProviderError, match="test error"):
-            _ = list(sync_provider.chat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")]))
-
-
-# MARK: AchatStream
-
-
-class TestAchatStream:
-    async def test_yields_chunks(
-        self,
-        async_provider: AnthropicProvider,
-        mock_async_client: MagicMock,
-        stream_events: list[MagicMock],
-    ) -> None:
-        async def _async_iter() -> Any:  # noqa: ANN401
-            for event in stream_events:
-                yield event
-
-        mock_async_client.messages.create.return_value = _async_iter()
-
-        chunks = [
-            chunk async for chunk in async_provider.achat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        ]
-
-        assert len(chunks) == 3
-        assert chunks[0].delta == "Hel"
-        assert chunks[2].finish_reason == "stop"
-        assert chunks[2].cost is not None
-        # The terminal chunk stamps the endpoint identity, mirroring the non-streaming path.
-        assert chunks[2].model == "claude-sonnet-4-6"
-        assert chunks[2].provider == "anthropic"
-
-    async def test_cost_bills_against_resolved_model(
-        self,
-        async_provider: AnthropicProvider,
-        mock_async_client: MagicMock,
-        stream_events: list[MagicMock],
-    ) -> None:
-        # Async parity: bill against the message_start-resolved model, not the requested alias.
-        async def _async_iter() -> Any:  # noqa: ANN401
-            for event in stream_events:
-                yield event
-
-        mock_async_client.messages.create.return_value = _async_iter()
-
-        chunks = [chunk async for chunk in async_provider.achat_stream("opaque-alias", [UserMessage(content="Hi")])]
-
-        assert chunks[2].model == "claude-sonnet-4-6"
-        assert chunks[2].cost is not None
-
-    async def test_stream_with_content_block_start(
-        self,
-        async_provider: AnthropicProvider,
-        mock_async_client: MagicMock,
-    ) -> None:
-        start_event = MagicMock()
-        start_event.type = "message_start"
-        start_event.message.model = "claude-sonnet-4-6"
-        start_event.message.usage = MagicMock(
-            input_tokens=10,
-            output_tokens=0,
-            cache_read_input_tokens=0,
-            cache_creation_input_tokens=0,
-            cache_creation=None,
-        )
-
-        text_block_start = MagicMock()
-        text_block_start.type = "content_block_start"
-        text_block_start.content_block.type = "text"
-
-        block_start = MagicMock()
-        block_start.type = "content_block_start"
-        block_start.content_block.type = "tool_use"
-        block_start.content_block.id = "call_1"
-        block_start.content_block.name = "get_weather"
-        block_start.index = 0
-
-        thinking_delta_event = MagicMock()
-        thinking_delta_event.type = "content_block_delta"
-        thinking_delta_event.delta.type = "thinking_delta"
-        thinking_delta_event.delta.thinking = "Let me think..."
-
-        unknown_delta_event = MagicMock()
-        unknown_delta_event.type = "content_block_delta"
-        unknown_delta_event.delta.type = "some_future_delta"
-
-        unknown_event = MagicMock()
-        unknown_event.type = "content_block_stop"
-
-        delta_event = MagicMock()
-        delta_event.type = "message_delta"
-        delta_event.delta.stop_reason = "tool_use"
-        delta_event.usage.output_tokens = 5
-
-        async def _async_iter() -> Any:  # noqa: ANN401
-            for event in [
-                start_event,
-                text_block_start,
-                block_start,
-                thinking_delta_event,
-                unknown_delta_event,
-                unknown_event,
-                delta_event,
-            ]:
-                yield event
-
-        mock_async_client.messages.create.return_value = _async_iter()
-
-        chunks = [
-            chunk async for chunk in async_provider.achat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        ]
-
-        assert len(chunks) == 3
-        assert chunks[0].tool_call_deltas is not None
-        assert chunks[0].tool_call_deltas[0].function is not None
-        assert chunks[0].tool_call_deltas[0].function.name == "get_weather"
-        assert chunks[1].reasoning_delta == "Let me think..."
-        assert chunks[2].finish_reason == "tool_calls"
-
-    async def test_stream_with_reasoning_effort(
-        self,
-        async_provider: AnthropicProvider,
-        mock_async_client: MagicMock,
-        stream_events: list[MagicMock],
-    ) -> None:
-        async def _async_iter() -> Any:  # noqa: ANN401
-            for event in stream_events:
-                yield event
-
-        mock_async_client.messages.create.return_value = _async_iter()
-
-        chunks = [
-            chunk
-            async for chunk in async_provider.achat_stream(
-                "claude-sonnet-4-5", [UserMessage(content="Hi")], reasoning_effort="medium"
-            )
-        ]
-
-        assert len(chunks) == 3
-        call_kwargs = mock_async_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 4095}
-
-    async def test_exception_on_create(
-        self,
-        async_provider: AnthropicProvider,
-        mock_async_client: MagicMock,
-        server_error: anthropic.InternalServerError,
-    ) -> None:
-        mock_async_client.messages.create.side_effect = server_error
-
-        with pytest.raises(ProviderError):
-            async for _ in async_provider.achat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")]):
-                pass  # pragma: no cover
-
-    async def test_exception_during_iteration(
-        self,
-        async_provider: AnthropicProvider,
-        mock_async_client: MagicMock,
-        stream_events: list[MagicMock],
-        server_error: anthropic.InternalServerError,
-    ) -> None:
-        async def _failing_async_iter() -> Any:  # noqa: ANN401
-            yield stream_events[0]
-            raise server_error
-
-        mock_async_client.messages.create.return_value = _failing_async_iter()
-
-        with pytest.raises(ProviderError, match="test error"):
-            async for _ in async_provider.achat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")]):
-                pass  # pragma: no cover
-
-
-# MARK: Client Management
-
-
-class TestClientManagement:
-    def test_sync_client_reused(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi again")])
-
-        assert mock_sync_client.messages.create.call_count == 2
-
-    async def test_async_client_reused(
-        self, async_provider: AnthropicProvider, mock_async_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-
-        _ = await async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        _ = await async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi again")])
-
-        assert mock_async_client.messages.create.call_count == 2
-
-    def test_custom_base_url_passed(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-        provider = AnthropicProvider(auth=fake_auth, base_url="https://custom.api/v1")
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_create.assert_called_once_with(
-            api_key="sk-ant-fake-key", base_url="https://custom.api/v1", timeout=None, max_retries=None
-        )
-
-    def test_timeout_and_retries_passed(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-        provider = AnthropicProvider(auth=fake_auth, timeout=30.0, max_retries=5)
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_create.assert_called_once_with(api_key="sk-ant-fake-key", base_url=None, timeout=30.0, max_retries=5)
-
-    def test_create_sync_client_called_once(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-        provider = AnthropicProvider(auth=fake_auth)
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi again")])
-
-        mock_sync_create.assert_called_once()
-
-    async def test_create_async_client_called_once(
-        self,
-        fake_auth: FakeAuth,
-        mock_async_create: MagicMock,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-        provider = AnthropicProvider(auth=fake_auth)
-        _ = await provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        _ = await provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi again")])
-
-        mock_async_create.assert_called_once()
-
-    async def test_async_custom_base_url_passed(
-        self,
-        fake_auth: FakeAuth,
-        mock_async_create: MagicMock,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-        provider = AnthropicProvider(auth=fake_auth, base_url="https://custom.api/v1")
-        _ = await provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_async_create.assert_called_once_with(
-            api_key="sk-ant-fake-key", base_url="https://custom.api/v1", timeout=None, max_retries=None
-        )
-
-    async def test_async_timeout_and_retries_passed(
-        self,
-        fake_auth: FakeAuth,
-        mock_async_create: MagicMock,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-        provider = AnthropicProvider(auth=fake_auth, timeout=30.0, max_retries=5)
-        _ = await provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_async_create.assert_called_once_with(api_key="sk-ant-fake-key", base_url=None, timeout=30.0, max_retries=5)
-
-    def test_sync_client_init_failure_mapped(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-    ) -> None:
-        mock_sync_create.side_effect = Exception("connection refused")
-        provider = AnthropicProvider(auth=fake_auth)
-
-        with pytest.raises(ProviderError, match="connection refused"):
-            _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-    async def test_async_client_init_failure_mapped(
-        self,
-        fake_auth: FakeAuth,
-        mock_async_create: MagicMock,
-    ) -> None:
-        mock_async_create.side_effect = Exception("connection refused")
-        provider = AnthropicProvider(auth=fake_auth)
-
-        with pytest.raises(ProviderError, match="connection refused"):
-            _ = await provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-    @pytest.fixture
-    def mock_get_running_loop(self, mocker: MockerFixture) -> MagicMock:
-        return mocker.patch("lmux_anthropic.provider.asyncio.get_running_loop")
-
-    async def test_achat_recreates_client_on_new_event_loop(
-        self,
-        fake_auth: FakeAuth,
-        mock_async_create: MagicMock,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
-        mock_get_running_loop: MagicMock,
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-        provider = AnthropicProvider(auth=fake_auth)
-
-        loop1 = asyncio.new_event_loop()
-        loop2 = asyncio.new_event_loop()
-        mock_get_running_loop.side_effect = [loop1, loop2]
-
-        _ = await provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        _ = await provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi again")])
-
-        assert mock_async_create.call_count == 2
-        assert mock_get_running_loop.call_count == 2
-        loop1.close()
-        loop2.close()
-
-
-# MARK: Provider Params Kwargs
-
-
-class TestProviderParamsKwargs:
-    def test_empty_params(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")], provider_params=AnthropicParams())
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert "thinking" not in call_kwargs
-        assert "metadata" not in call_kwargs
-        assert "top_k" not in call_kwargs
-        assert "service_tier" not in call_kwargs
-        assert "inference_geo" not in call_kwargs
-        assert "cache_control" not in call_kwargs
-
-    def test_all_params(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-        params = AnthropicParams(
-            thinking={"type": "enabled", "budget_tokens": 5000},
-            metadata={"user_id": "u1"},
-            top_k=40,
-            service_tier="auto",
-            inference_geo="us",
-            cache_control={"type": "ephemeral"},
-        )
-
-        _ = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")], provider_params=params)
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 5000}
-        assert call_kwargs["metadata"] == {"user_id": "u1"}
-        assert call_kwargs["top_k"] == 40
-        assert call_kwargs["service_tier"] == "auto"
-        assert call_kwargs["inference_geo"] == "us"
-        assert call_kwargs["cache_control"] == {"type": "ephemeral"}
-
-
-# MARK: Register Pricing
-
-
-class TestRegisterPricing:
-    def test_custom_pricing_for_unknown_model(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock
-    ) -> None:
-        custom_response = _make_message_response(model="claude-custom-v1", input_tokens=1000, output_tokens=500)
-        mock_sync_client.messages.create.return_value = custom_response
-
-        sync_provider.register_pricing(
-            "claude-custom-v1",
-            ModelPricing(
-                tiers=[PricingTier(input_cost_per_token=5.0 / 1_000_000, output_cost_per_token=15.0 / 1_000_000)]
-            ),
-        )
-        result = sync_provider.chat("claude-custom-v1", [UserMessage(content="Hi")])
-
-        assert result.cost is not None
-        assert result.cost.input_cost == pytest.approx(1000 * 5.0 / 1_000_000)
-        assert result.cost.output_cost == pytest.approx(500 * 15.0 / 1_000_000)
-
-    def test_custom_pricing_overrides_builtin(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        custom_pricing = ModelPricing(
-            tiers=[PricingTier(input_cost_per_token=99.0 / 1_000_000, output_cost_per_token=199.0 / 1_000_000)]
-        )
-        sync_provider.register_pricing("claude-sonnet-4-6", custom_pricing)
-        result = sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert result.cost is not None
-        assert result.cost.input_cost == pytest.approx(10 * 99.0 / 1_000_000)
-        assert result.cost.output_cost == pytest.approx(5 * 199.0 / 1_000_000)
-
-    def test_unregistered_unknown_model_returns_none_cost(
-        self, sync_provider: AnthropicProvider, mock_sync_client: MagicMock
-    ) -> None:
-        unknown_response = _make_message_response(model="totally-unknown-model")
-        mock_sync_client.messages.create.return_value = unknown_response
-
-        result = sync_provider.chat("totally-unknown-model", [UserMessage(content="Hi")])
-
-        assert result.cost is None
-
-
-# MARK: Custom Default Max Tokens
-
-
-class TestCustomDefaultMaxTokens:
-    def test_custom_default(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-        provider = AnthropicProvider(auth=fake_auth, default_max_tokens=8192)
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_create.assert_called_once()
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["max_tokens"] == 8192
-
-
-# MARK: Aclose
-
-
-class TestAclose:
-    async def test_aclose_closes_client(
-        self,
-        fake_auth: FakeAuth,
-        mock_async_create: MagicMock,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-        provider = AnthropicProvider(auth=fake_auth)
-
-        _ = await provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        await provider.aclose()
-
-        mock_async_create.assert_called_once()
-        mock_async_client.close.assert_awaited_once()
-        assert provider._async_client is None
-
-    async def test_aclose_noop_when_no_client(self, fake_auth: FakeAuth) -> None:
-        provider = AnthropicProvider(auth=fake_auth)
-        await provider.aclose()
-
-
-# MARK: Preload
-
-
-class TestPreload:
-    def test_preload_imports_anthropic(self) -> None:
-        preload()  # should not raise
-
-
-# MARK: Vertex
+class FakeCredentials:
+    """Minimal google.auth-style credentials for Vertex tests."""
+
+    def __init__(self, *, access: str | None = "vertex-token", expired: bool = False) -> None:
+        self.token = access
+        self.expired = expired
+        self.refreshed = False
+        self._refreshed_value = "refreshed-token"
+
+    def refresh(self, request: object) -> None:  # noqa: ARG002
+        self.refreshed = True
+        self.token = self._refreshed_value
 
 
 class FakeVertexAuth:
-    """Fake Vertex auth provider returning (credentials, project_id), like the ADC provider."""
-
     def __init__(self) -> None:
-        self.credentials: MagicMock = MagicMock()
+        self.credentials = FakeCredentials()
 
-    def get_credentials(self) -> tuple[MagicMock, str]:
-        return (self.credentials, "auth-project")
+    def get_credentials(self) -> "tuple[Credentials, str]":
+        return (cast("Credentials", self.credentials), "auth-project")
 
-    async def aget_credentials(self) -> tuple[MagicMock, str]:
-        return (self.credentials, "auth-project")
+    async def aget_credentials(self) -> "tuple[Credentials, str]":
+        return (cast("Credentials", self.credentials), "auth-project")
 
 
 class FakeBareVertexAuth:
-    """Fake Vertex auth provider returning bare credentials without a project ID."""
-
     def __init__(self) -> None:
-        self.credentials: MagicMock = MagicMock()
+        self.credentials = FakeCredentials()
 
-    def get_credentials(self) -> MagicMock:
-        return self.credentials
+    def get_credentials(self) -> "Credentials":
+        return cast("Credentials", self.credentials)
 
-    async def aget_credentials(self) -> MagicMock:
-        return self.credentials
-
-
-@pytest.fixture
-def fake_vertex_auth() -> FakeVertexAuth:
-    return FakeVertexAuth()
-
-
-@pytest.fixture
-def mock_sync_vertex_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("lmux_anthropic.provider.create_sync_vertex_client", return_value=mock_sync_client)
-
-
-@pytest.fixture
-def mock_async_vertex_create(mock_async_client: MagicMock, mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("lmux_anthropic.provider.create_async_vertex_client", return_value=mock_async_client)
-
-
-@pytest.fixture
-def vertex_sync_provider(
-    fake_vertex_auth: FakeVertexAuth, mock_sync_vertex_create: MagicMock
-) -> AnthropicVertexProvider:
-    assert mock_sync_vertex_create  # fixture activates the patch
-    return AnthropicVertexProvider(auth=fake_vertex_auth, project_id="my-proj", region="us-east5")
-
-
-@pytest.fixture
-def vertex_async_provider(
-    fake_vertex_auth: FakeVertexAuth, mock_async_vertex_create: MagicMock
-) -> AnthropicVertexProvider:
-    assert mock_async_vertex_create  # fixture activates the patch
-    return AnthropicVertexProvider(auth=fake_vertex_auth, project_id="my-proj", region="us-east5")
-
-
-class TestVertexChat:
-    def test_basic_chat(
-        self,
-        vertex_sync_provider: AnthropicVertexProvider,
-        mock_sync_client: MagicMock,
-        mock_sync_create: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        result = vertex_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert result.content == "Hello!"
-        assert result.provider == "anthropic-vertex"
-        assert result.cost is not None
-        mock_sync_client.messages.create.assert_called_once()
-        mock_sync_create.assert_not_called()  # the Anthropic API client factory must never be used
-
-    def test_vertex_model_id_prefix_matches_pricing(
-        self, vertex_sync_provider: AnthropicVertexProvider, mock_sync_client: MagicMock
-    ) -> None:
-        """Vertex @-suffixed model IDs resolve cost via longest-prefix matching."""
-        mock_sync_client.messages.create.return_value = _make_message_response(model="claude-sonnet-4-5@20250929")
-
-        result = vertex_sync_provider.chat("claude-sonnet-4-5@20250929", [UserMessage(content="Hi")])
-
-        assert result.cost is not None
-        assert result.cost.total_cost > 0
-
-    def test_api_only_params_dropped(
-        self, vertex_sync_provider: AnthropicVertexProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        """service_tier and inference_geo are Anthropic-API-only and must not reach Vertex."""
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = vertex_sync_provider.chat(
-            "claude-sonnet-4-6",
-            [UserMessage(content="Hi")],
-            provider_params=AnthropicParams(
-                thinking={"type": "enabled", "budget_tokens": 1024},
-                metadata={"user_id": "u1"},
-                top_k=40,
-                service_tier="auto",
-                inference_geo="us",
-                cache_control={"type": "ephemeral"},
-            ),
-        )
-
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 1024}
-        assert call_kwargs["metadata"] == {"user_id": "u1"}
-        assert call_kwargs["top_k"] == 40
-        assert call_kwargs["cache_control"] == {"type": "ephemeral"}
-        assert "service_tier" not in call_kwargs
-        assert "inference_geo" not in call_kwargs
-
-    def test_inference_geo_multiplier_not_applied(
-        self, vertex_sync_provider: AnthropicVertexProvider, mock_sync_client: MagicMock, message_response: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        result_standard = vertex_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        result_us = vertex_sync_provider.chat(
-            "claude-sonnet-4-6",
-            [UserMessage(content="Hi")],
-            provider_params=AnthropicParams(inference_geo="us"),
-        )
-
-        assert result_standard.cost is not None
-        assert result_us.cost is not None
-        assert result_us.cost.total_cost == result_standard.cost.total_cost
-
-    def test_regional_premium_applied(
-        self,
-        fake_vertex_auth: FakeVertexAuth,
-        mock_sync_vertex_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        """Regional endpoints bill Claude 4.5+ models at a 10% premium over the global endpoint."""
-        assert mock_sync_vertex_create  # fixture activates the patch
-        mock_sync_client.messages.create.return_value = message_response
-        global_provider = AnthropicVertexProvider(auth=fake_vertex_auth, project_id="p", region="global")
-        regional_provider = AnthropicVertexProvider(auth=fake_vertex_auth, project_id="p", region="us-east5")
-
-        result_global = global_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        result_regional = regional_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert result_global.cost is not None
-        assert result_regional.cost is not None
-        assert result_regional.cost.total_cost == pytest.approx(result_global.cost.total_cost * 1.1)
-
-    def test_no_premium_for_uniform_pricing_models(
-        self,
-        fake_vertex_auth: FakeVertexAuth,
-        mock_sync_vertex_create: MagicMock,
-        mock_sync_client: MagicMock,
-    ) -> None:
-        """Older Claude models are priced uniformly across all Vertex endpoints."""
-        assert mock_sync_vertex_create  # fixture activates the patch
-        mock_sync_client.messages.create.return_value = _make_message_response(model="claude-3-5-haiku")
-        global_provider = AnthropicVertexProvider(auth=fake_vertex_auth, project_id="p", region="global")
-        regional_provider = AnthropicVertexProvider(auth=fake_vertex_auth, project_id="p", region="us-east5")
-
-        result_global = global_provider.chat("claude-3-5-haiku", [UserMessage(content="Hi")])
-        result_regional = regional_provider.chat("claude-3-5-haiku", [UserMessage(content="Hi")])
-
-        assert result_global.cost is not None
-        assert result_regional.cost is not None
-        assert result_regional.cost.total_cost == result_global.cost.total_cost
-
-    def test_region_falls_back_to_env(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        fake_vertex_auth: FakeVertexAuth,
-        mock_sync_vertex_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        """Without an explicit region, the premium decision uses CLOUD_ML_REGION."""
-        assert mock_sync_vertex_create  # fixture activates the patch
-        mock_sync_client.messages.create.return_value = message_response
-        provider = AnthropicVertexProvider(auth=fake_vertex_auth, project_id="p")
-
-        monkeypatch.setenv("CLOUD_ML_REGION", "global")
-        result_global = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        monkeypatch.setenv("CLOUD_ML_REGION", "us-east5")
-        result_regional = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert result_global.cost is not None
-        assert result_regional.cost is not None
-        assert result_regional.cost.total_cost == pytest.approx(result_global.cost.total_cost * 1.1)
-
-    def test_chat_exception_reports_vertex_provider(
-        self,
-        vertex_sync_provider: AnthropicVertexProvider,
-        mock_sync_client: MagicMock,
-        bad_request_error: anthropic.BadRequestError,
-    ) -> None:
-        mock_sync_client.messages.create.side_effect = bad_request_error
-
-        with pytest.raises(InvalidRequestError) as exc_info:
-            _ = vertex_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert exc_info.value.provider == "anthropic-vertex"
-
-
-class TestVertexAchat:
-    async def test_basic_achat(
-        self,
-        vertex_async_provider: AnthropicVertexProvider,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-
-        result = await vertex_async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert result.content == "Hello!"
-        assert result.provider == "anthropic-vertex"
-        mock_async_client.messages.create.assert_awaited_once()
-
-
-class TestVertexChatStream:
-    def test_inference_geo_multiplier_not_applied_on_final_chunk(
-        self, vertex_sync_provider: AnthropicVertexProvider, mock_sync_client: MagicMock
-    ) -> None:
-        mock_sync_client.messages.create.side_effect = [iter(_make_stream_events()), iter(_make_stream_events())]
-
-        chunks_standard = list(vertex_sync_provider.chat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")]))
-        chunks_us = list(
-            vertex_sync_provider.chat_stream(
-                "claude-sonnet-4-6",
-                [UserMessage(content="Hi")],
-                provider_params=AnthropicParams(inference_geo="us"),
-            )
-        )
-
-        assert chunks_standard[-1].cost is not None
-        assert chunks_us[-1].cost is not None
-        assert chunks_us[-1].cost.total_cost == chunks_standard[-1].cost.total_cost
-
-    async def test_async_stream_yields_chunks(
-        self,
-        vertex_async_provider: AnthropicVertexProvider,
-        mock_async_client: MagicMock,
-        stream_events: list[MagicMock],
-    ) -> None:
-        async def _async_iter() -> Any:  # noqa: ANN401
-            for event in stream_events:
-                yield event
-
-        mock_async_client.messages.create.return_value = _async_iter()
-
-        chunks = [
-            chunk
-            async for chunk in vertex_async_provider.achat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        ]
-
-        assert len(chunks) == 3
-        assert chunks[2].finish_reason == "stop"
-        assert chunks[2].cost is not None
-        # The terminal chunk reports the Vertex endpoint identity, not the base provider name.
-        assert chunks[2].model == "claude-sonnet-4-6"
-        assert chunks[2].provider == "anthropic-vertex"
-
-
-class TestVertexClientManagement:
-    def test_factory_receives_constructor_args(
-        self,
-        fake_vertex_auth: FakeVertexAuth,
-        vertex_sync_provider: AnthropicVertexProvider,
-        mock_sync_vertex_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = vertex_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_vertex_create.assert_called_once_with(
-            credentials=fake_vertex_auth.credentials,
-            project_id="my-proj",
-            region="us-east5",
-            base_url=None,
-            timeout=None,
-            max_retries=None,
-        )
-
-    def test_factory_receives_overrides(
-        self,
-        fake_vertex_auth: FakeVertexAuth,
-        mock_sync_vertex_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-        provider = AnthropicVertexProvider(
-            auth=fake_vertex_auth,
-            project_id="my-proj",
-            region="global",
-            base_url="https://example.test",
-            timeout=30.0,
-            max_retries=5,
-        )
-
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_vertex_create.assert_called_once_with(
-            credentials=fake_vertex_auth.credentials,
-            project_id="my-proj",
-            region="global",
-            base_url="https://example.test",
-            timeout=30.0,
-            max_retries=5,
-        )
-
-    async def test_async_factory_receives_constructor_args(
-        self,
-        fake_vertex_auth: FakeVertexAuth,
-        vertex_async_provider: AnthropicVertexProvider,
-        mock_async_vertex_create: MagicMock,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-
-        _ = await vertex_async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_async_vertex_create.assert_called_once_with(
-            credentials=fake_vertex_auth.credentials,
-            project_id="my-proj",
-            region="us-east5",
-            base_url=None,
-            timeout=None,
-            max_retries=None,
-        )
-
-    def test_project_id_falls_back_to_auth_provider(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        fake_vertex_auth: FakeVertexAuth,
-        mock_sync_vertex_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        """Without an explicit project_id or env var, the auth-derived project (e.g. from ADC) is used."""
-        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
-        mock_sync_client.messages.create.return_value = message_response
-        provider = AnthropicVertexProvider(auth=fake_vertex_auth, region="global")
-
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_vertex_create.assert_called_once_with(
-            credentials=fake_vertex_auth.credentials,
-            project_id="auth-project",
-            region="global",
-            base_url=None,
-            timeout=None,
-            max_retries=None,
-        )
-
-    def test_env_project_id_beats_auth_derived(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        fake_vertex_auth: FakeVertexAuth,
-        mock_sync_vertex_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        """ANTHROPIC_VERTEX_PROJECT_ID wins over the auth-derived project, matching the SDK's precedence."""
-        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "env-project")
-        mock_sync_client.messages.create.return_value = message_response
-        provider = AnthropicVertexProvider(auth=fake_vertex_auth, region="global")
-
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_vertex_create.assert_called_once_with(
-            credentials=fake_vertex_auth.credentials,
-            project_id="env-project",
-            region="global",
-            base_url=None,
-            timeout=None,
-            max_retries=None,
-        )
-
-    def test_bare_credentials_auth_supported(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        mock_sync_vertex_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        """Auth providers returning bare credentials (no project tuple) still work."""
-        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
-        mock_sync_client.messages.create.return_value = message_response
-        bare_auth = FakeBareVertexAuth()
-        provider = AnthropicVertexProvider(auth=bare_auth, region="global")
-
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_vertex_create.assert_called_once_with(
-            credentials=bare_auth.credentials,
-            project_id=None,
-            region="global",
-            base_url=None,
-            timeout=None,
-            max_retries=None,
-        )
-
-    async def test_bare_credentials_auth_supported_async(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        mock_async_vertex_create: MagicMock,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        """Async auth providers returning bare credentials (no project tuple) still work."""
-        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
-        mock_async_client.messages.create.return_value = message_response
-        bare_auth = FakeBareVertexAuth()
-        provider = AnthropicVertexProvider(auth=bare_auth, region="global")
-
-        _ = await provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_async_vertex_create.assert_called_once_with(
-            credentials=bare_auth.credentials,
-            project_id=None,
-            region="global",
-            base_url=None,
-            timeout=None,
-            max_retries=None,
-        )
-
-    def test_default_auth_is_adc(self) -> None:
-        provider = AnthropicVertexProvider()
-        assert isinstance(provider._vertex_auth, AnthropicVertexADCAuthProvider)
-
-
-# MARK: Foundry
+    async def aget_credentials(self) -> "Credentials":
+        return cast("Credentials", self.credentials)
 
 
 class FakeFoundryAuth:
-    """Fake Foundry auth provider returning an API key."""
-
     def get_credentials(self) -> str:
         return "foundry-key"
 
@@ -1645,11 +91,9 @@ class FakeFoundryAuth:
 
 
 class FakeFoundryTokenAuth:
-    """Fake Foundry auth provider returning an Entra ID token-provider callable."""
-
     def __init__(self) -> None:
         def _token_provider() -> str:
-            return "entra-token"  # pragma: no cover
+            return "entra-token"
 
         self.token_provider: Callable[[], str] = _token_provider
 
@@ -1660,258 +104,895 @@ class FakeFoundryTokenAuth:
         return self.token_provider
 
 
-@pytest.fixture
-def fake_foundry_auth() -> FakeFoundryAuth:
-    return FakeFoundryAuth()
+def _message(  # noqa: PLR0913
+    *,
+    text: str = "Hello!",
+    model: str = MODEL,
+    stop_reason: str = "end_turn",
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+    content: list[dict[str, Any]] | None = None,
+    usage: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "stop_reason": stop_reason,
+        "content": content if content is not None else [{"type": "text", "text": text}],
+        "usage": usage if usage is not None else {"input_tokens": input_tokens, "output_tokens": output_tokens},
+    }
+
+
+def _sse(events: list[tuple[str, dict[str, Any]]]) -> bytes:
+    blocks = [f"event: {etype}\ndata: {json.dumps(data)}" for etype, data in events]
+    return ("\n\n".join(blocks) + "\n\n").encode()
+
+
+def _default_stream(model: str = MODEL) -> bytes:
+    return _sse(
+        [
+            (
+                "message_start",
+                {
+                    "type": "message_start",
+                    "message": {"model": model, "usage": {"input_tokens": 10, "output_tokens": 0}},
+                },
+            ),
+            (
+                "content_block_delta",
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hel"}},
+            ),
+            (
+                "content_block_delta",
+                {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "lo!"}},
+            ),
+            (
+                "message_delta",
+                {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 5}},
+            ),
+            ("message_stop", {"type": "message_stop"}),
+        ]
+    )
 
 
 @pytest.fixture
-def mock_sync_foundry_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("lmux_anthropic.provider.create_sync_foundry_client", return_value=mock_sync_client)
+def fake_auth() -> FakeAuth:
+    return FakeAuth()
 
 
 @pytest.fixture
-def mock_async_foundry_create(mock_async_client: MagicMock, mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("lmux_anthropic.provider.create_async_foundry_client", return_value=mock_async_client)
+def sync_provider(fake_auth: FakeAuth) -> AnthropicProvider:
+    return AnthropicProvider(auth=fake_auth)
 
 
 @pytest.fixture
-def foundry_sync_provider(
-    fake_foundry_auth: FakeFoundryAuth, mock_sync_foundry_create: MagicMock
-) -> AnthropicFoundryProvider:
-    assert mock_sync_foundry_create  # fixture activates the patch
-    return AnthropicFoundryProvider(auth=fake_foundry_auth, resource="my-resource")
+def async_provider(fake_auth: FakeAuth) -> AnthropicProvider:
+    return AnthropicProvider(auth=fake_auth)
 
 
-@pytest.fixture
-def foundry_async_provider(
-    fake_foundry_auth: FakeFoundryAuth, mock_async_foundry_create: MagicMock
-) -> AnthropicFoundryProvider:
-    assert mock_async_foundry_create  # fixture activates the patch
-    return AnthropicFoundryProvider(auth=fake_foundry_auth, resource="my-resource")
+def _ok(respx_mock: respx.MockRouter, message: dict[str, Any] | None = None) -> respx.Route:
+    return respx_mock.post(_URL).mock(
+        return_value=httpx.Response(200, json=message if message is not None else _message())
+    )
 
 
-class TestFoundryChat:
-    def test_basic_chat(
-        self,
-        foundry_sync_provider: AnthropicFoundryProvider,
-        mock_sync_client: MagicMock,
-        mock_sync_create: MagicMock,
-        message_response: MagicMock,
+# MARK: Pricing as-of
+
+
+class TestPricingAsOf:
+    def test_intro_window_rate(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        result = foundry_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        assert result.content == "Hello!"
-        assert result.provider == "anthropic-foundry"
+        monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 7, 1))
+        _ok(respx_mock, _message(model="claude-sonnet-5", input_tokens=1000, output_tokens=500))
+        result = sync_provider.chat("claude-sonnet-5", [UserMessage(content="Hi")])
         assert result.cost is not None
-        mock_sync_client.messages.create.assert_called_once()
-        mock_sync_create.assert_not_called()  # the Anthropic API client factory must never be used
+        assert result.cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
+        assert result.cost.output_cost == pytest.approx(500 * 10.0 / 1_000_000)
 
-    def test_api_only_params_dropped(
-        self,
-        foundry_sync_provider: AnthropicFoundryProvider,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
+    def test_rate_after_switch(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """service_tier and inference_geo are Anthropic-API-only and must not reach Foundry."""
-        mock_sync_client.messages.create.return_value = message_response
+        monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 9, 15))
+        _ok(respx_mock, _message(model="claude-sonnet-5", input_tokens=1000, output_tokens=500))
+        result = sync_provider.chat("claude-sonnet-5", [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 3.0 / 1_000_000)
 
-        _ = foundry_sync_provider.chat(
-            "claude-sonnet-4-6",
+    def test_override_wins_over_clock(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 9, 15))
+        _ok(respx_mock, _message(model="claude-sonnet-5", input_tokens=1000, output_tokens=500))
+        result = sync_provider.chat(
+            "claude-sonnet-5",
+            [UserMessage(content="Hi")],
+            provider_params=AnthropicParams(pricing_as_of=date(2026, 7, 1)),
+        )
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
+
+    async def test_achat_applies_dated_pricing(
+        self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 7, 1))
+        _ok(respx_mock, _message(model="claude-sonnet-5", input_tokens=1000, output_tokens=500))
+        result = await async_provider.achat("claude-sonnet-5", [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
+
+
+# MARK: Chat
+
+
+class TestChat:
+    def test_basic(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        result = sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result.content == "Hello!"
+        assert result.model == MODEL
+        assert result.provider == "anthropic"
+        assert result.cost is not None
+        assert route.called
+
+    def test_request_shape_and_headers(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(
+            MODEL,
+            [SystemMessage(content="Be nice"), UserMessage(content="Hi")],
+            temperature=0.5,
+            max_tokens=100,
+            top_p=0.9,
+            stop="END",
+        )
+        request = route.calls.last.request
+        assert request.headers["x-api-key"] == "sk-ant-fake-key"
+        assert request.headers["anthropic-version"] == "2023-06-01"
+        body = json.loads(request.content)
+        assert body == {
+            "model": MODEL,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "max_tokens": 100,
+            "stream": False,
+            "system": "Be nice",
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "stop_sequences": ["END"],
+        }
+
+    def test_stop_list(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], stop=["A", "B"])
+        assert json.loads(route.calls.last.request.content)["stop_sequences"] == ["A", "B"]
+
+    def test_default_max_tokens(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert json.loads(route.calls.last.request.content)["max_tokens"] == 4096
+
+    def test_tools_and_tool_choice(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            tools=[Tool(function=FunctionDefinition(name="get_weather"))],
+            tool_choice="required",
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"name": "get_weather", "input_schema": {"type": "object"}}]
+        assert body["tool_choice"] == {"type": "any"}
+
+    def test_json_schema_response_format(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            response_format=JsonSchemaResponseFormat(name="out", json_schema={"type": "object", "properties": {}}),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["output_config"]["format"]["type"] == "json_schema"
+
+    def test_text_response_format_noop(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], response_format=TextResponseFormat())
+        assert "output_config" not in json.loads(route.calls.last.request.content)
+
+    def test_json_object_raises(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock)
+        with pytest.raises(UnsupportedFeatureError):
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")], response_format=JsonObjectResponseFormat())
+
+    def test_reasoning_effort_budget_model(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat("claude-sonnet-4-5", [UserMessage(content="Hi")], reasoning_effort="medium")
+        assert json.loads(route.calls.last.request.content)["thinking"] == {"type": "enabled", "budget_tokens": 4095}
+
+    def test_reasoning_effort_high_max_tokens(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(
+            "claude-sonnet-4-5", [UserMessage(content="Hi")], max_tokens=100000, reasoning_effort="medium"
+        )
+        assert json.loads(route.calls.last.request.content)["thinking"] == {"type": "enabled", "budget_tokens": 8192}
+
+    def test_reasoning_effort_adaptive_model(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], reasoning_effort="high")
+        body = json.loads(route.calls.last.request.content)
+        assert body["thinking"] == {"type": "adaptive"}
+        assert body["output_config"] == {"effort": "high"}
+
+    def test_reasoning_effort_adaptive_merges_response_format(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            reasoning_effort="low",
+            response_format=JsonSchemaResponseFormat(name="out", json_schema={"type": "object", "properties": {}}),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["output_config"]["effort"] == "low"
+        assert body["output_config"]["format"]["type"] == "json_schema"
+
+    def test_reasoning_effort_ignored_when_provider_thinking(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            reasoning_effort="high",
+            provider_params=AnthropicParams(thinking={"type": "enabled", "budget_tokens": 2048}),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+        assert "output_config" not in body
+
+    def test_provider_params(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             provider_params=AnthropicParams(
-                thinking={"type": "enabled", "budget_tokens": 1024},
+                thinking={"type": "enabled", "budget_tokens": 5000},
+                metadata={"user_id": "u1"},
                 top_k=40,
                 service_tier="auto",
                 inference_geo="us",
+                cache_control={"type": "ephemeral"},
             ),
         )
+        body = json.loads(route.calls.last.request.content)
+        assert body["thinking"] == {"type": "enabled", "budget_tokens": 5000}
+        assert body["metadata"] == {"user_id": "u1"}
+        assert body["top_k"] == 40
+        assert body["service_tier"] == "auto"
+        assert body["inference_geo"] == "us"
+        assert body["cache_control"] == {"type": "ephemeral"}
 
-        call_kwargs = mock_sync_client.messages.create.call_args.kwargs
-        assert call_kwargs["thinking"] == {"type": "enabled", "budget_tokens": 1024}
-        assert call_kwargs["top_k"] == 40
-        assert "service_tier" not in call_kwargs
-        assert "inference_geo" not in call_kwargs
+    def test_empty_provider_params(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=AnthropicParams())
+        body = json.loads(route.calls.last.request.content)
+        assert "service_tier" not in body
+        assert "thinking" not in body
+
+    def test_status_error_mapped(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(return_value=httpx.Response(400, json={"error": {"message": "bad"}}))
+        with pytest.raises(InvalidRequestError):
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    def test_transport_error_mapped(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    def test_us_inference_multiplier(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock)
+        standard = sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        us = sync_provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=AnthropicParams(inference_geo="us"))
+        assert standard.cost is not None
+        assert us.cost is not None
+        assert us.cost.total_cost == pytest.approx(standard.cost.total_cost * 1.1)
+
+    def test_no_multiplier_with_empty_params(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        _ok(respx_mock)
+        standard = sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        empty = sync_provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=AnthropicParams())
+        assert standard.cost is not None
+        assert empty.cost is not None
+        assert standard.cost.total_cost == empty.cost.total_cost
+
+
+# MARK: Achat
+
+
+class TestAchat:
+    async def test_basic(self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock)
+        result = await async_provider.achat(MODEL, [UserMessage(content="Hi")])
+        assert result.content == "Hello!"
+        assert result.provider == "anthropic"
+
+    async def test_status_error_mapped(self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(return_value=httpx.Response(401, json={"error": {"message": "no"}}))
+        with pytest.raises(AuthenticationError):
+            await async_provider.achat(MODEL, [UserMessage(content="Hi")])
+
+    async def test_transport_error_mapped(
+        self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.post(_URL).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            await async_provider.achat(MODEL, [UserMessage(content="Hi")])
+
+
+# MARK: ChatStream
+
+
+class TestChatStream:
+    def test_yields_and_costs(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=_default_stream()))
+        chunks = list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+        assert [c.delta for c in chunks[:2]] == ["Hel", "lo!"]
+        assert chunks[-1].finish_reason == "stop"
+        assert chunks[0].model is None
+        assert chunks[0].provider is None
+        assert chunks[0].cost is None
+        assert chunks[-1].model == MODEL
+        assert chunks[-1].provider == "anthropic"
+        assert chunks[-1].cost is not None
+        assert chunks[-1].cost.total_cost > 0
+        assert json.loads(route.calls.last.request.content)["stream"] is True
+
+    def test_cost_bills_resolved_model(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=_default_stream()))
+        chunks = list(sync_provider.chat_stream("opaque-alias", [UserMessage(content="Hi")]))
+        assert chunks[-1].model == MODEL
+        assert chunks[-1].cost is not None
+
+    def test_content_block_start_and_deltas(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        events = _sse(
+            [
+                (
+                    "message_start",
+                    {
+                        "type": "message_start",
+                        "message": {"model": MODEL, "usage": {"input_tokens": 10, "output_tokens": 0}},
+                    },
+                ),
+                (
+                    "content_block_start",
+                    {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}},
+                ),
+                (
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": {"type": "tool_use", "id": "call_1", "name": "get_weather", "input": {}},
+                    },
+                ),
+                (
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {"type": "thinking_delta", "thinking": "Let me think..."},
+                    },
+                ),
+                (
+                    "content_block_delta",
+                    {"type": "content_block_delta", "index": 0, "delta": {"type": "some_future_delta"}},
+                ),
+                ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+                (
+                    "message_delta",
+                    {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 5}},
+                ),
+            ]
+        )
+        respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=events))
+        chunks = list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+        assert len(chunks) == 3
+        assert chunks[0].tool_call_deltas is not None
+        assert chunks[0].tool_call_deltas[0].function is not None
+        assert chunks[0].tool_call_deltas[0].function.name == "get_weather"
+        assert chunks[1].reasoning_delta == "Let me think..."
+        assert chunks[2].finish_reason == "tool_calls"
+
+    def test_message_delta_without_start_is_dropped(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        events = _sse(
+            [
+                (
+                    "message_delta",
+                    {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 5}},
+                )
+            ]
+        )
+        respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=events))
+        assert list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")])) == []
+
+    def test_reasoning_effort_passthrough(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=_default_stream()))
+        list(sync_provider.chat_stream("claude-sonnet-4-5", [UserMessage(content="Hi")], reasoning_effort="medium"))
+        assert json.loads(route.calls.last.request.content)["thinking"] == {"type": "enabled", "budget_tokens": 4095}
+
+    def test_status_error_on_open(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(return_value=httpx.Response(500, json={"error": {"message": "boom"}}))
+        with pytest.raises(ProviderError):
+            list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
+    def test_malformed_chunk_mapped(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(
+            return_value=httpx.Response(200, content=b"event: message_start\ndata: {not json}\n\n")
+        )
+        with pytest.raises(ProviderError):
+            list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
+    def test_client_init_failure(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_anthropic.provider.create_sync_client", side_effect=RuntimeError("boom"))
+        provider = AnthropicProvider(auth=fake_auth)
+        with pytest.raises(ProviderError, match="boom"):
+            list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
+
+# MARK: AchatStream
+
+
+class TestAchatStream:
+    async def test_yields_and_costs(self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=_default_stream()))
+        chunks = [c async for c in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")])]
+        assert [c.delta for c in chunks[:2]] == ["Hel", "lo!"]
+        assert chunks[-1].finish_reason == "stop"
+        assert chunks[-1].model == MODEL
+        assert chunks[-1].provider == "anthropic"
+        assert chunks[-1].cost is not None
+
+    async def test_status_error_on_open(self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_URL).mock(return_value=httpx.Response(500, json={"error": {"message": "boom"}}))
+        with pytest.raises(ProviderError):
+            async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
+                pass  # pragma: no cover
+
+    async def test_malformed_chunk_mapped(
+        self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.post(_URL).mock(return_value=httpx.Response(200, content=b"event: message_start\ndata: {nope}\n\n"))
+        with pytest.raises(ProviderError):
+            async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
+                pass  # pragma: no cover
+
+    async def test_client_init_failure(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_anthropic.provider.create_async_client", side_effect=RuntimeError("boom"))
+        provider = AnthropicProvider(auth=fake_auth)
+        with pytest.raises(ProviderError, match="boom"):
+            async for _ in provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
+                pass  # pragma: no cover
+
+
+# MARK: Client management
+
+
+class TestClientManagement:
+    def test_sync_client_reused(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="a")])
+        client = sync_provider._sync_client
+        sync_provider.chat(MODEL, [UserMessage(content="b")])
+        assert sync_provider._sync_client is client
+
+    async def test_async_client_reused(self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock)
+        await async_provider.achat(MODEL, [UserMessage(content="a")])
+        client = async_provider._async_client
+        await async_provider.achat(MODEL, [UserMessage(content="b")])
+        assert async_provider._async_client is client
+
+    def test_custom_base_url(self, fake_auth: FakeAuth, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post("https://custom.api/v1/messages").mock(
+            return_value=httpx.Response(200, json=_message())
+        )
+        provider = AnthropicProvider(auth=fake_auth, base_url="https://custom.api")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
+
+    def test_timeout_and_retries(self, fake_auth: FakeAuth, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock)
+        provider = AnthropicProvider(auth=fake_auth, timeout=30.0, max_retries=5)
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert provider._sync_client is not None
+        assert provider._sync_client.timeout.read == 30.0
+
+    def test_custom_default_max_tokens(self, fake_auth: FakeAuth, respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock)
+        provider = AnthropicProvider(auth=fake_auth, default_max_tokens=8192)
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert json.loads(route.calls.last.request.content)["max_tokens"] == 8192
+
+    def test_sync_init_failure_mapped(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_anthropic.provider.create_sync_client", side_effect=RuntimeError("connection refused"))
+        provider = AnthropicProvider(auth=fake_auth)
+        with pytest.raises(ProviderError, match="connection refused"):
+            provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    async def test_async_init_failure_mapped(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_anthropic.provider.create_async_client", side_effect=RuntimeError("connection refused"))
+        provider = AnthropicProvider(auth=fake_auth)
+        with pytest.raises(ProviderError, match="connection refused"):
+            await provider.achat(MODEL, [UserMessage(content="Hi")])
+
+    async def test_async_client_recreated_on_new_loop(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        c1, c2 = MagicMock(), MagicMock()
+        create = mocker.patch("lmux_anthropic.provider.create_async_client", side_effect=[c1, c2])
+        get_loop = mocker.patch("lmux_anthropic.provider.asyncio.get_running_loop")
+        loop1, loop2 = asyncio.new_event_loop(), asyncio.new_event_loop()
+        get_loop.side_effect = [loop1, loop2]
+        provider = AnthropicProvider(auth=fake_auth)
+        r1 = await provider._get_async_client()
+        r2 = await provider._get_async_client()
+        assert (r1, r2) == (c1, c2)
+        assert create.call_count == 2
+        loop1.close()
+        loop2.close()
+
+
+# MARK: Register pricing & aclose & preload
+
+
+class TestRegisterPricing:
+    def test_custom_for_unknown_model(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock, _message(model="claude-custom-v1", input_tokens=1000, output_tokens=500))
+        sync_provider.register_pricing(
+            "claude-custom-v1",
+            ModelPricing(tiers=[PricingTier(input_cost_per_token=5e-6, output_cost_per_token=15e-6)]),
+        )
+        result = sync_provider.chat("claude-custom-v1", [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 5e-6)
+
+    def test_custom_overrides_builtin(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock)
+        sync_provider.register_pricing(
+            MODEL, ModelPricing(tiers=[PricingTier(input_cost_per_token=99e-6, output_cost_per_token=199e-6)])
+        )
+        result = sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(10 * 99e-6)
+
+    def test_unknown_model_none_cost(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock, _message(model="totally-unknown"))
+        result = sync_provider.chat("totally-unknown", [UserMessage(content="Hi")])
+        assert result.cost is None
+
+
+class TestAclose:
+    async def test_closes_client(self, async_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
+        _ok(respx_mock)
+        await async_provider.achat(MODEL, [UserMessage(content="Hi")])
+        assert async_provider._async_client is not None
+        await async_provider.aclose()
+        assert async_provider._async_client is None
+
+    async def test_noop_when_no_client(self, async_provider: AnthropicProvider) -> None:
+        await async_provider.aclose()
+
+
+class TestPreload:
+    def test_preload(self) -> None:
+        preload()
+
+
+# MARK: Vertex
+
+
+def _vertex_url(model: str, *, region: str = "us-east5", project: str = "my-proj", stream: bool = False) -> str:
+    host = "aiplatform.googleapis.com" if region == "global" else f"{region}-aiplatform.googleapis.com"
+    specifier = "streamRawPredict" if stream else "rawPredict"
+    return f"https://{host}/v1/projects/{project}/locations/{region}/publishers/anthropic/models/{model}:{specifier}"
+
+
+@pytest.fixture
+def vertex_auth() -> FakeVertexAuth:
+    return FakeVertexAuth()
+
+
+@pytest.fixture
+def vertex_sync_provider(vertex_auth: FakeVertexAuth) -> AnthropicVertexProvider:
+    return AnthropicVertexProvider(auth=vertex_auth, project_id="my-proj", region="us-east5")
+
+
+class TestVertexChat:
+    def test_basic(self, vertex_sync_provider: AnthropicVertexProvider, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_vertex_url(MODEL)).mock(return_value=httpx.Response(200, json=_message()))
+        result = vertex_sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result.content == "Hello!"
+        assert result.provider == "anthropic-vertex"
+        assert result.cost is not None
+        request = route.calls.last.request
+        assert request.headers["authorization"] == "Bearer vertex-token"
+        body = json.loads(request.content)
+        assert "model" not in body
+        assert body["anthropic_version"] == "vertex-2023-10-16"
+
+    async def test_basic_achat(self, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_vertex_url(MODEL)).mock(return_value=httpx.Response(200, json=_message()))
+        provider = AnthropicVertexProvider(auth=vertex_auth, project_id="my-proj", region="us-east5")
+        result = await provider.achat(MODEL, [UserMessage(content="Hi")])
+        assert result.provider == "anthropic-vertex"
+
+    def test_model_prefix_pricing(
+        self, vertex_sync_provider: AnthropicVertexProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        model = "claude-sonnet-4-5@20250929"
+        respx_mock.post(_vertex_url(model)).mock(return_value=httpx.Response(200, json=_message(model=model)))
+        result = vertex_sync_provider.chat(model, [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.total_cost > 0
+
+    def test_api_only_params_dropped(
+        self, vertex_sync_provider: AnthropicVertexProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.post(_vertex_url(MODEL)).mock(return_value=httpx.Response(200, json=_message()))
+        vertex_sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            provider_params=AnthropicParams(
+                top_k=40, service_tier="auto", inference_geo="us", cache_control={"type": "ephemeral"}
+            ),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["top_k"] == 40
+        assert body["cache_control"] == {"type": "ephemeral"}
+        assert "service_tier" not in body
+        assert "inference_geo" not in body
 
     def test_inference_geo_multiplier_not_applied(
-        self,
-        foundry_sync_provider: AnthropicFoundryProvider,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
+        self, vertex_sync_provider: AnthropicVertexProvider, respx_mock: respx.MockRouter
     ) -> None:
-        """Foundry bills Anthropic list prices; no multiplier ever applies."""
-        mock_sync_client.messages.create.return_value = message_response
-
-        result_standard = foundry_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-        result_us = foundry_sync_provider.chat(
-            "claude-sonnet-4-6",
-            [UserMessage(content="Hi")],
-            provider_params=AnthropicParams(inference_geo="us"),
+        respx_mock.post(_vertex_url(MODEL)).mock(return_value=httpx.Response(200, json=_message()))
+        standard = vertex_sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        us = vertex_sync_provider.chat(
+            MODEL, [UserMessage(content="Hi")], provider_params=AnthropicParams(inference_geo="us")
         )
+        assert standard.cost is not None
+        assert us.cost is not None
+        assert standard.cost.total_cost == us.cost.total_cost
 
-        assert result_standard.cost is not None
-        assert result_us.cost is not None
-        assert result_us.cost.total_cost == result_standard.cost.total_cost
+    def test_regional_premium_applied(self, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_vertex_url(MODEL, region="global", project="p")).mock(
+            return_value=httpx.Response(200, json=_message())
+        )
+        respx_mock.post(_vertex_url(MODEL, region="us-east5", project="p")).mock(
+            return_value=httpx.Response(200, json=_message())
+        )
+        global_provider = AnthropicVertexProvider(auth=vertex_auth, project_id="p", region="global")
+        regional_provider = AnthropicVertexProvider(auth=vertex_auth, project_id="p", region="us-east5")
+        result_global = global_provider.chat(MODEL, [UserMessage(content="Hi")])
+        result_regional = regional_provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result_global.cost is not None
+        assert result_regional.cost is not None
+        assert result_regional.cost.total_cost == pytest.approx(result_global.cost.total_cost * 1.1)
 
-    def test_chat_exception_reports_foundry_provider(
-        self,
-        foundry_sync_provider: AnthropicFoundryProvider,
-        mock_sync_client: MagicMock,
-        bad_request_error: anthropic.BadRequestError,
+    def test_no_premium_uniform_model(self, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter) -> None:
+        model = "claude-3-5-haiku"
+        respx_mock.post(_vertex_url(model, region="global", project="p")).mock(
+            return_value=httpx.Response(200, json=_message(model=model))
+        )
+        respx_mock.post(_vertex_url(model, region="us-east5", project="p")).mock(
+            return_value=httpx.Response(200, json=_message(model=model))
+        )
+        result_global = AnthropicVertexProvider(auth=vertex_auth, project_id="p", region="global").chat(
+            model, [UserMessage(content="Hi")]
+        )
+        result_regional = AnthropicVertexProvider(auth=vertex_auth, project_id="p", region="us-east5").chat(
+            model, [UserMessage(content="Hi")]
+        )
+        assert result_global.cost is not None
+        assert result_regional.cost is not None
+        assert result_global.cost.total_cost == result_regional.cost.total_cost
+
+    def test_region_falls_back_to_env(
+        self, monkeypatch: pytest.MonkeyPatch, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.messages.create.side_effect = bad_request_error
+        respx_mock.post(_vertex_url(MODEL, region="global", project="p")).mock(
+            return_value=httpx.Response(200, json=_message())
+        )
+        respx_mock.post(_vertex_url(MODEL, region="us-east5", project="p")).mock(
+            return_value=httpx.Response(200, json=_message())
+        )
+        provider = AnthropicVertexProvider(auth=vertex_auth, project_id="p")
+        monkeypatch.setenv("CLOUD_ML_REGION", "global")
+        result_global = provider.chat(MODEL, [UserMessage(content="Hi")])
+        provider._sync_client = None  # force client recreation for the new region
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-east5")
+        result_regional = provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result_global.cost is not None
+        assert result_regional.cost is not None
+        assert result_regional.cost.total_cost == pytest.approx(result_global.cost.total_cost * 1.1)
 
+    def test_missing_region_raises(self, monkeypatch: pytest.MonkeyPatch, vertex_auth: FakeVertexAuth) -> None:
+        monkeypatch.delenv("CLOUD_ML_REGION", raising=False)
+        provider = AnthropicVertexProvider(auth=vertex_auth, project_id="p")
+        with pytest.raises(ProviderError, match="region"):
+            provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    def test_missing_project_raises(self, monkeypatch: pytest.MonkeyPatch, respx_mock: respx.MockRouter) -> None:  # noqa: ARG002
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+
+        class _NoProjectAuth:
+            def get_credentials(self) -> "Credentials":
+                return cast("Credentials", FakeCredentials())
+
+            async def aget_credentials(self) -> "Credentials":
+                return cast("Credentials", FakeCredentials())
+
+        provider = AnthropicVertexProvider(auth=_NoProjectAuth(), region="us-east5")
+        with pytest.raises(ProviderError, match="project_id"):
+            provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    def test_project_falls_back_to_auth(
+        self, monkeypatch: pytest.MonkeyPatch, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+        route = respx_mock.post(_vertex_url(MODEL, region="global", project="auth-project")).mock(
+            return_value=httpx.Response(200, json=_message())
+        )
+        provider = AnthropicVertexProvider(auth=vertex_auth, region="global")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
+
+    def test_env_project_beats_auth(
+        self, monkeypatch: pytest.MonkeyPatch, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "env-project")
+        route = respx_mock.post(_vertex_url(MODEL, region="global", project="env-project")).mock(
+            return_value=httpx.Response(200, json=_message())
+        )
+        provider = AnthropicVertexProvider(auth=vertex_auth, region="global")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
+
+    def test_bare_credentials_supported(self, monkeypatch: pytest.MonkeyPatch, respx_mock: respx.MockRouter) -> None:
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "env-project")
+        route = respx_mock.post(_vertex_url(MODEL, region="global", project="env-project")).mock(
+            return_value=httpx.Response(200, json=_message())
+        )
+        provider = AnthropicVertexProvider(auth=FakeBareVertexAuth(), region="global")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
+
+    async def test_bare_credentials_supported_async(
+        self, monkeypatch: pytest.MonkeyPatch, respx_mock: respx.MockRouter
+    ) -> None:
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "env-project")
+        route = respx_mock.post(_vertex_url(MODEL, region="global", project="env-project")).mock(
+            return_value=httpx.Response(200, json=_message())
+        )
+        provider = AnthropicVertexProvider(auth=FakeBareVertexAuth(), region="global")
+        await provider.achat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
+
+    def test_exception_reports_vertex_provider(
+        self, vertex_sync_provider: AnthropicVertexProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.post(_vertex_url(MODEL)).mock(return_value=httpx.Response(400, json={"error": {"message": "bad"}}))
         with pytest.raises(InvalidRequestError) as exc_info:
-            _ = foundry_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+            vertex_sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert exc_info.value.provider == "anthropic-vertex"
 
-        assert exc_info.value.provider == "anthropic-foundry"
+    def test_default_auth_is_adc(self) -> None:
+        provider = AnthropicVertexProvider()
+        assert isinstance(provider._vertex_auth, AnthropicVertexADCAuthProvider)
 
 
-class TestFoundryAchat:
-    async def test_basic_achat(
-        self,
-        foundry_async_provider: AnthropicFoundryProvider,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
+class TestVertexChatStream:
+    def test_stream_stamps_vertex_identity(
+        self, vertex_sync_provider: AnthropicVertexProvider, respx_mock: respx.MockRouter
     ) -> None:
-        mock_async_client.messages.create.return_value = message_response
+        respx_mock.post(_vertex_url(MODEL, stream=True)).mock(
+            return_value=httpx.Response(200, content=_default_stream())
+        )
+        chunks = list(vertex_sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+        assert chunks[-1].finish_reason == "stop"
+        assert chunks[-1].model == MODEL
+        assert chunks[-1].provider == "anthropic-vertex"
+        assert chunks[-1].cost is not None
 
-        result = await foundry_async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
+    async def test_async_stream(self, vertex_auth: FakeVertexAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_vertex_url(MODEL, stream=True)).mock(
+            return_value=httpx.Response(200, content=_default_stream())
+        )
+        provider = AnthropicVertexProvider(auth=vertex_auth, project_id="my-proj", region="us-east5")
+        chunks = [c async for c in provider.achat_stream(MODEL, [UserMessage(content="Hi")])]
+        assert chunks[-1].provider == "anthropic-vertex"
 
+
+# MARK: Foundry
+
+
+def _foundry_url(*, resource: str = "my-resource") -> str:
+    return f"https://{resource}.services.ai.azure.com/anthropic/v1/messages"
+
+
+@pytest.fixture
+def foundry_sync_provider() -> AnthropicFoundryProvider:
+    return AnthropicFoundryProvider(auth=FakeFoundryAuth(), resource="my-resource")
+
+
+class TestFoundryChat:
+    def test_basic(self, foundry_sync_provider: AnthropicFoundryProvider, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
+        result = foundry_sync_provider.chat(MODEL, [UserMessage(content="Hi")])
         assert result.content == "Hello!"
         assert result.provider == "anthropic-foundry"
-        mock_async_client.messages.create.assert_awaited_once()
+        assert result.cost is not None
+        request = route.calls.last.request
+        assert request.headers["api-key"] == "foundry-key"
+        assert json.loads(request.content)["model"] == MODEL
 
+    async def test_basic_achat(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
+        provider = AnthropicFoundryProvider(auth=FakeFoundryAuth(), resource="my-resource")
+        result = await provider.achat(MODEL, [UserMessage(content="Hi")])
+        assert result.provider == "anthropic-foundry"
 
-class TestFoundryChatStream:
-    def test_stream_stamps_endpoint_identity(
-        self,
-        foundry_sync_provider: AnthropicFoundryProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[MagicMock],
+    def test_token_auth_uses_bearer(self, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
+        provider = AnthropicFoundryProvider(auth=FakeFoundryTokenAuth(), resource="my-resource")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.calls.last.request.headers["authorization"] == "Bearer entra-token"
+
+    def test_api_only_params_dropped(
+        self, foundry_sync_provider: AnthropicFoundryProvider, respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.messages.create.return_value = iter(stream_events)
-
-        chunks = list(foundry_sync_provider.chat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")]))
-
-        assert chunks[-1].finish_reason == "stop"
-        # The terminal chunk reports the Foundry endpoint identity, not the base provider name.
-        assert chunks[-1].model == "claude-sonnet-4-6"
-        assert chunks[-1].provider == "anthropic-foundry"
-
-    async def test_async_stream_stamps_endpoint_identity(
-        self,
-        mock_async_foundry_create: MagicMock,
-        mock_async_client: MagicMock,
-        stream_events: list[MagicMock],
-    ) -> None:
-        assert mock_async_foundry_create  # fixture activates the patch
-        token_auth = FakeFoundryTokenAuth()
-        provider = AnthropicFoundryProvider(auth=token_auth, resource="my-resource")
-
-        async def _async_iter() -> Any:  # noqa: ANN401
-            for event in stream_events:
-                yield event
-
-        mock_async_client.messages.create.return_value = _async_iter()
-
-        chunks = [chunk async for chunk in provider.achat_stream("claude-sonnet-4-6", [UserMessage(content="Hi")])]
-
-        assert chunks[-1].finish_reason == "stop"
-        assert chunks[-1].model == "claude-sonnet-4-6"
-        assert chunks[-1].provider == "anthropic-foundry"
-
-
-class TestFoundryClientManagement:
-    def test_factory_receives_api_key_auth(
-        self,
-        foundry_sync_provider: AnthropicFoundryProvider,
-        mock_sync_foundry_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-
-        _ = foundry_sync_provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_foundry_create.assert_called_once_with(
-            api_key="foundry-key",
-            azure_ad_token_provider=None,
-            resource="my-resource",
-            base_url=None,
-            timeout=None,
-            max_retries=None,
+        route = respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
+        foundry_sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            provider_params=AnthropicParams(top_k=40, service_tier="auto", inference_geo="us"),
         )
+        body = json.loads(route.calls.last.request.content)
+        assert body["top_k"] == 40
+        assert "service_tier" not in body
+        assert "inference_geo" not in body
 
-    def test_factory_receives_token_provider_auth(
-        self,
-        mock_sync_foundry_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
+    def test_inference_geo_multiplier_not_applied(
+        self, foundry_sync_provider: AnthropicFoundryProvider, respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-        token_auth = FakeFoundryTokenAuth()
-        provider = AnthropicFoundryProvider(auth=token_auth, resource="my-resource")
-
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_foundry_create.assert_called_once_with(
-            api_key=None,
-            azure_ad_token_provider=token_auth.token_provider,
-            resource="my-resource",
-            base_url=None,
-            timeout=None,
-            max_retries=None,
+        respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
+        standard = foundry_sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        us = foundry_sync_provider.chat(
+            MODEL, [UserMessage(content="Hi")], provider_params=AnthropicParams(inference_geo="us")
         )
+        assert standard.cost is not None
+        assert us.cost is not None
+        assert standard.cost.total_cost == us.cost.total_cost
 
-    def test_factory_receives_overrides(
-        self,
-        fake_foundry_auth: FakeFoundryAuth,
-        mock_sync_foundry_create: MagicMock,
-        mock_sync_client: MagicMock,
-        message_response: MagicMock,
+    def test_exception_reports_foundry_provider(
+        self, foundry_sync_provider: AnthropicFoundryProvider, respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.messages.create.return_value = message_response
-        provider = AnthropicFoundryProvider(
-            auth=fake_foundry_auth,
-            base_url="https://example-resource.services.ai.azure.com/anthropic/",
-            timeout=30.0,
-            max_retries=5,
-        )
-
-        _ = provider.chat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_sync_foundry_create.assert_called_once_with(
-            api_key="foundry-key",
-            azure_ad_token_provider=None,
-            resource=None,
-            base_url="https://example-resource.services.ai.azure.com/anthropic/",
-            timeout=30.0,
-            max_retries=5,
-        )
-
-    async def test_async_factory_receives_api_key_auth(
-        self,
-        foundry_async_provider: AnthropicFoundryProvider,
-        mock_async_foundry_create: MagicMock,
-        mock_async_client: MagicMock,
-        message_response: MagicMock,
-    ) -> None:
-        mock_async_client.messages.create.return_value = message_response
-
-        _ = await foundry_async_provider.achat("claude-sonnet-4-6", [UserMessage(content="Hi")])
-
-        mock_async_foundry_create.assert_called_once_with(
-            api_key="foundry-key",
-            azure_ad_token_provider=None,
-            resource="my-resource",
-            base_url=None,
-            timeout=None,
-            max_retries=None,
-        )
+        respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(400, json={"error": {"message": "bad"}}))
+        with pytest.raises(InvalidRequestError) as exc_info:
+            foundry_sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert exc_info.value.provider == "anthropic-foundry"
 
     def test_default_auth_is_env(self) -> None:
-        provider = AnthropicFoundryProvider()
+        provider = AnthropicFoundryProvider(resource="my-resource")
         assert isinstance(provider._foundry_auth, AnthropicFoundryEnvAuthProvider)

--- a/uv.lock
+++ b/uv.lock
@@ -159,30 +159,6 @@ wheels = [
 ]
 
 [[package]]
-name = "anthropic"
-version = "0.116.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/a2/d31f14e28d49bae983a3634e38dfb4b31c50110b5e403596c5c6a20b23f8/anthropic-0.116.0.tar.gz", hash = "sha256:5fc248fbb9fe03ef686f8a774f81586bca31a043260aab88b387ea3660f4a396", size = 949149, upload-time = "2026-07-02T19:08:10.534Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/dd/2a1e81cf1b163acc340afc4ec74ed1d86f5eed1a809fabdeed3e0997b346/anthropic-0.116.0-py3-none-any.whl", hash = "sha256:6c0a7698e8d652455da3499978279bb2588c7264d0a35be3666009a4258c8256", size = 956896, upload-time = "2026-07-02T19:08:08.756Z" },
-]
-
-[package.optional-dependencies]
-vertex = [
-    { name = "google-auth", extra = ["requests"] },
-]
-
-[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -545,15 +521,6 @@ wheels = [
 ]
 
 [[package]]
-name = "docstring-parser"
-version = "0.18.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
-]
-
-[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -721,56 +688,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jiter"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
-    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
-    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
-    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
-    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
-    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
-    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
-    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
-    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
-    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
-    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
-    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
-    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
-    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
-    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
-    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
-]
-
-[[package]]
 name = "jmespath"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -795,19 +712,19 @@ name = "lmux-anthropic"
 version = "0.10.0"
 source = { editable = "packages/lmux-anthropic" }
 dependencies = [
-    { name = "anthropic" },
+    { name = "httpx" },
     { name = "lmux" },
 ]
 
 [package.optional-dependencies]
 vertex = [
-    { name = "anthropic", extra = ["vertex"] },
+    { name = "google-auth" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = "~=0.83" },
-    { name = "anthropic", extras = ["vertex"], marker = "extra == 'vertex'", specifier = "~=0.83" },
+    { name = "google-auth", marker = "extra == 'vertex'", specifier = "~=2.0" },
+    { name = "httpx", specifier = "~=0.28" },
     { name = "lmux", editable = "packages/lmux" },
 ]
 provides-extras = ["vertex"]


### PR DESCRIPTION
Converts the Anthropic provider (direct API + Vertex + Foundry) off the SDK to a direct httpx transport, following the earlier conversions (#91, #92, #94).

- **SDK-lite**: httpx instead of the `anthropic` SDK — lazy client creation, no SDK dependency. Vertex still uses `google-auth` for credential resolution via the `[vertex]` extra.
- **Wire models**: the Messages response and streaming events parse into validated Pydantic models. Content blocks and stream deltas are discriminated unions with an unknown-tag fallback, preserving the "ignore unrecognized types" behavior.
- **Per-request cloud auth**: Vertex/Foundry tokens are resolved and attached on every request (not baked into the cached client), so a long-lived provider refreshes rather than 401-ing after token expiry. Includes Vertex `us`/`eu` multi-region routing, Foundry `x-api-key`+`api-key`, and Foundry endpoint env-var fallback.
- Mid-stream error events surface as errors; HTTP 403 maps to `PermissionDeniedError`.

https://claude.ai/code/session_01AZdTzDJPra791brXt1Qf9W
