### PR TITLE
feat(google): SDK-lite httpx transport with Pydantic wire models

### DIFF
--- a/packages/lmux-google/README.md
+++ b/packages/lmux-google/README.md
@@ -1,6 +1,6 @@
 # lmux-google
 
-Google (Gemini) provider for [lmux](https://github.com/cluebbehusen/lmux). Wraps the [google-genai](https://pypi.org/project/google-genai/) SDK, which serves Google's models through either backend:
+Google (Gemini) provider for [lmux](https://github.com/cluebbehusen/lmux). Talks to the Google Gemini REST API directly over [httpx](https://pypi.org/project/httpx/), using [google-auth](https://pypi.org/project/google-auth/) to resolve Vertex AI credentials. Serves Google's models through either backend:
 
 - **Vertex AI** (default) — authenticated with Google Cloud credentials
 - **Gemini Developer API** (AI Studio) — authenticated with an API key (`vertexai=False`)

--- a/packages/lmux-google/pyproject.toml
+++ b/packages/lmux-google/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "lmux~=0.9",
+  "lmux~=0.10",
   "httpx~=0.28",
   "google-auth~=2.0",
 ]

--- a/packages/lmux-google/pyproject.toml
+++ b/packages/lmux-google/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
 ]
 dependencies = [
   "lmux~=0.9",
-  "google-genai~=1.0",
+  "httpx~=0.28",
+  "google-auth~=2.0",
 ]
 
 [project.urls]

--- a/packages/lmux-google/src/lmux_google/__init__.py
+++ b/packages/lmux-google/src/lmux_google/__init__.py
@@ -33,5 +33,6 @@ __all__ = [
 
 
 def preload() -> None:
-    """Eagerly import the google-genai SDK."""
-    import google.genai  # noqa: PLC0415, F401
+    """Eagerly import the HTTP client and google-auth."""
+    import google.auth  # noqa: PLC0415, F401
+    import httpx  # noqa: PLC0415, F401

--- a/packages/lmux-google/src/lmux_google/_exceptions.py
+++ b/packages/lmux-google/src/lmux_google/_exceptions.py
@@ -1,6 +1,6 @@
 """Map HTTP responses and transport errors to the lmux exception hierarchy."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lmux.exceptions import (
     AuthenticationError,
@@ -29,6 +29,26 @@ def raise_for_status(response: "httpx.Response") -> None:
     """Raise the mapped lmux error for a non-streamed error response."""
     if response.status_code >= _BAD_REQUEST:
         raise error_from_response(response)
+
+
+def parse_json(response: "httpx.Response") -> dict[str, Any]:
+    """Return the JSON object body of a success response, mapping a malformed or non-object body to a ProviderError."""
+    try:
+        data = response.json()
+    except ValueError as e:
+        msg = "malformed response body"
+        raise ProviderError(msg, provider=PROVIDER, status_code=response.status_code) from e
+    if not isinstance(data, dict):
+        msg = "expected a JSON object response body"
+        raise ProviderError(msg, provider=PROVIDER, status_code=response.status_code)
+    return data
+
+
+def error_from_stream(payload: dict[str, Any]) -> LmuxError:
+    """Map an error object embedded in a streamed response to an lmux error."""
+    error = payload.get("error")
+    message = error.get("message") if isinstance(error, dict) else error
+    return ProviderError(str(message), provider=PROVIDER)
 
 
 def error_from_response(response: "httpx.Response") -> LmuxError:

--- a/packages/lmux-google/src/lmux_google/_exceptions.py
+++ b/packages/lmux-google/src/lmux_google/_exceptions.py
@@ -2,6 +2,8 @@
 
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel, ValidationError
+
 from lmux.exceptions import (
     AuthenticationError,
     InvalidRequestError,
@@ -32,17 +34,13 @@ def raise_for_status(response: "httpx.Response") -> None:
         raise error_from_response(response)
 
 
-def parse_json(response: "httpx.Response") -> dict[str, Any]:
-    """Return the JSON object body of a success response, mapping a malformed or non-object body to a ProviderError."""
+def parse_body[T: BaseModel](response: "httpx.Response", model: type[T]) -> T:
+    """Validate a success body into the given wire model, mapping a malformed or mis-shaped body to a ProviderError."""
     try:
-        data = response.json()
-    except ValueError as e:
+        return model.model_validate_json(response.content)
+    except ValidationError as e:
         msg = "malformed response body"
         raise ProviderError(msg, provider=PROVIDER, status_code=response.status_code) from e
-    if not isinstance(data, dict):
-        msg = "expected a JSON object response body"
-        raise ProviderError(msg, provider=PROVIDER, status_code=response.status_code)
-    return data
 
 
 def error_from_stream(payload: dict[str, Any]) -> LmuxError:

--- a/packages/lmux-google/src/lmux_google/_exceptions.py
+++ b/packages/lmux-google/src/lmux_google/_exceptions.py
@@ -7,6 +7,7 @@ from lmux.exceptions import (
     InvalidRequestError,
     LmuxError,
     NotFoundError,
+    PermissionDeniedError,
     ProviderError,
     RateLimitError,
     TimeoutError,  # noqa: A004
@@ -55,8 +56,10 @@ def error_from_response(response: "httpx.Response") -> LmuxError:
     """Map an HTTP error response to an lmux exception (body must be readable)."""
     code = response.status_code
     msg = _message(response)
-    if code in (_AUTH, _FORBIDDEN):
+    if code == _AUTH:
         return AuthenticationError(msg, provider=PROVIDER, status_code=code)
+    if code == _FORBIDDEN:
+        return PermissionDeniedError(msg, provider=PROVIDER, status_code=code)
     if code == _RATE_LIMIT:
         return RateLimitError(msg, provider=PROVIDER, status_code=code)
     if code == _BAD_REQUEST:

--- a/packages/lmux-google/src/lmux_google/_exceptions.py
+++ b/packages/lmux-google/src/lmux_google/_exceptions.py
@@ -52,7 +52,7 @@ def error_from_stream(payload: dict[str, Any]) -> LmuxError:
     return ProviderError(str(message), provider=PROVIDER)
 
 
-def error_from_response(response: "httpx.Response") -> LmuxError:
+def error_from_response(response: "httpx.Response") -> LmuxError:  # noqa: PLR0911 — one return per mapped status
     """Map an HTTP error response to an lmux exception (body must be readable)."""
     code = response.status_code
     msg = _message(response)

--- a/packages/lmux-google/src/lmux_google/_exceptions.py
+++ b/packages/lmux-google/src/lmux_google/_exceptions.py
@@ -44,29 +44,40 @@ def parse_body[T: BaseModel](response: "httpx.Response", model: type[T]) -> T:
 
 
 def error_from_stream(payload: dict[str, Any]) -> LmuxError:
-    """Map an error object embedded in a streamed response to an lmux error."""
+    """Map an error object embedded in a streamed (HTTP 200) response to an lmux error.
+
+    A mid-stream error carries an RPC status code (e.g. ``{"error": {"code": 429, ...}}``); routing
+    it through the same classifier as non-streamed errors keeps RateLimitError/AuthenticationError/etc.
+    catchable instead of collapsing every mid-stream failure into a generic ProviderError.
+    """
     error = payload.get("error")
-    message = error.get("message") if isinstance(error, dict) else error
-    return ProviderError(str(message), provider=PROVIDER)
+    if isinstance(error, dict):
+        code = error.get("code")
+        message = str(error.get("message") or error)
+        return _error_for_code(code if isinstance(code, int) else None, message)
+    return ProviderError(str(error), provider=PROVIDER)
 
 
-def error_from_response(response: "httpx.Response") -> LmuxError:  # noqa: PLR0911 — one return per mapped status
+def error_from_response(response: "httpx.Response") -> LmuxError:
     """Map an HTTP error response to an lmux exception (body must be readable)."""
-    code = response.status_code
-    msg = _message(response)
+    return _error_for_code(response.status_code, _message(response))
+
+
+def _error_for_code(code: int | None, message: str) -> LmuxError:  # noqa: PLR0911 — one return per mapped status
+    """Map an HTTP/RPC status code to the lmux exception hierarchy."""
     if code == _AUTH:
-        return AuthenticationError(msg, provider=PROVIDER, status_code=code)
+        return AuthenticationError(message, provider=PROVIDER, status_code=code)
     if code == _FORBIDDEN:
-        return PermissionDeniedError(msg, provider=PROVIDER, status_code=code)
+        return PermissionDeniedError(message, provider=PROVIDER, status_code=code)
     if code == _RATE_LIMIT:
-        return RateLimitError(msg, provider=PROVIDER, status_code=code)
+        return RateLimitError(message, provider=PROVIDER, status_code=code)
     if code == _BAD_REQUEST:
-        return InvalidRequestError(msg, provider=PROVIDER, status_code=code)
+        return InvalidRequestError(message, provider=PROVIDER, status_code=code)
     if code == _NOT_FOUND:
-        return NotFoundError(msg, provider=PROVIDER, status_code=code)
+        return NotFoundError(message, provider=PROVIDER, status_code=code)
     if code == _TIMEOUT:
-        return TimeoutError(msg, provider=PROVIDER, status_code=code)
-    return ProviderError(msg, provider=PROVIDER, status_code=code)
+        return TimeoutError(message, provider=PROVIDER, status_code=code)
+    return ProviderError(message, provider=PROVIDER, status_code=code)
 
 
 def map_transport_error(error: Exception) -> LmuxError:

--- a/packages/lmux-google/src/lmux_google/_exceptions.py
+++ b/packages/lmux-google/src/lmux_google/_exceptions.py
@@ -1,4 +1,6 @@
-"""Map google-genai SDK exceptions to lmux exception hierarchy."""
+"""Map HTTP responses and transport errors to the lmux exception hierarchy."""
+
+from typing import TYPE_CHECKING
 
 from lmux.exceptions import (
     AuthenticationError,
@@ -10,32 +12,49 @@ from lmux.exceptions import (
     TimeoutError,  # noqa: A004
 )
 
+if TYPE_CHECKING:
+    import httpx
+
 PROVIDER = "google"
 
-_STATUS_CODE_MAP: dict[int, type[LmuxError]] = {
-    400: InvalidRequestError,
-    401: AuthenticationError,
-    403: AuthenticationError,
-    404: NotFoundError,
-    408: TimeoutError,
-    429: RateLimitError,
-}
+_BAD_REQUEST = 400
+_AUTH = 401
+_FORBIDDEN = 403
+_NOT_FOUND = 404
+_TIMEOUT = 408
+_RATE_LIMIT = 429
 
 
-def map_google_error(error: Exception) -> LmuxError:
-    """Convert a google-genai SDK exception to the corresponding lmux exception."""
-    from google.genai import errors as genai_errors  # noqa: PLC0415
+def raise_for_status(response: "httpx.Response") -> None:
+    """Raise the mapped lmux error for a non-streamed error response."""
+    if response.status_code >= _BAD_REQUEST:
+        raise error_from_response(response)
 
-    if isinstance(error, genai_errors.ClientError):
-        return _map_client_error(error)
 
-    if isinstance(error, genai_errors.ServerError):
-        return ProviderError(str(error), provider=PROVIDER, status_code=error.code)
+def error_from_response(response: "httpx.Response") -> LmuxError:
+    """Map an HTTP error response to an lmux exception (body must be readable)."""
+    code = response.status_code
+    msg = _message(response)
+    if code in (_AUTH, _FORBIDDEN):
+        return AuthenticationError(msg, provider=PROVIDER, status_code=code)
+    if code == _RATE_LIMIT:
+        return RateLimitError(msg, provider=PROVIDER, status_code=code)
+    if code == _BAD_REQUEST:
+        return InvalidRequestError(msg, provider=PROVIDER, status_code=code)
+    if code == _NOT_FOUND:
+        return NotFoundError(msg, provider=PROVIDER, status_code=code)
+    if code == _TIMEOUT:
+        return TimeoutError(msg, provider=PROVIDER, status_code=code)
+    return ProviderError(msg, provider=PROVIDER, status_code=code)
 
-    if isinstance(error, genai_errors.APIError):
-        return ProviderError(str(error), provider=PROVIDER, status_code=error.code)
 
-    # google.auth errors
+def map_transport_error(error: Exception) -> LmuxError:
+    """Map an httpx transport error, or a google-auth credential failure, to an lmux error."""
+    import httpx  # noqa: PLC0415
+
+    if isinstance(error, httpx.TimeoutException):
+        return TimeoutError(str(error), provider=PROVIDER)
+
     auth_error = _check_auth_error(error)
     if auth_error is not None:
         return auth_error
@@ -43,24 +62,20 @@ def map_google_error(error: Exception) -> LmuxError:
     return ProviderError(str(error), provider=PROVIDER)
 
 
-def _map_client_error(error: Exception) -> LmuxError:
-    """Map a google-genai ClientError based on its HTTP status code."""
-    code: int | None = getattr(error, "code", None)
-
-    exc_cls = _STATUS_CODE_MAP.get(code) if code is not None else None
-    if exc_cls is not None:
-        if exc_cls is RateLimitError:
-            return RateLimitError(str(error), provider=PROVIDER, status_code=code)
-        return exc_cls(str(error), provider=PROVIDER, status_code=code)
-
-    return ProviderError(str(error), provider=PROVIDER, status_code=code)
-
-
 def _check_auth_error(error: Exception) -> AuthenticationError | None:
-    """Check if the error is a google.auth exception and map it."""
+    """Map a google-auth credential/refresh failure to an AuthenticationError."""
     import google.auth.exceptions  # noqa: PLC0415
 
     if isinstance(error, google.auth.exceptions.DefaultCredentialsError | google.auth.exceptions.RefreshError):
         return AuthenticationError(str(error), provider=PROVIDER)
-
     return None
+
+
+def _message(response: "httpx.Response") -> str:
+    try:
+        data = response.json()
+    except ValueError:
+        return response.text
+    if isinstance(data, dict) and isinstance(data.get("error"), dict):
+        return str(data["error"].get("message") or response.text)
+    return response.text

--- a/packages/lmux-google/src/lmux_google/_lazy.py
+++ b/packages/lmux-google/src/lmux_google/_lazy.py
@@ -23,10 +23,17 @@ if TYPE_CHECKING:
     from google.auth.credentials import Credentials
 
 GEMINI_BASE_URL = "https://generativelanguage.googleapis.com"
+_REFRESH_TIMEOUT = 120.0
 
 
 def vertex_base_url(location: str | None) -> str:
-    """Resolve the Vertex AI regional (or global) base URL for a location."""
+    """Resolve the Vertex AI base URL for a location.
+
+    ``global`` has no region prefix; the ``us`` and ``eu`` multi-regions use their dedicated
+    ``rep`` endpoints; anything else is a standard regional host.
+    """
+    if location in ("us", "eu"):
+        return f"https://aiplatform.{location}.rep.googleapis.com"
     if location and location != "global":
         return f"https://{location}-aiplatform.googleapis.com"
     return "https://aiplatform.googleapis.com"
@@ -42,12 +49,57 @@ def bearer_headers(token: str) -> Mapping[str, str]:
     return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
 
+class _HttpxAuthResponse:
+    """Adapt an httpx response to the ``google.auth.transport.Response`` interface."""
+
+    def __init__(self, response: "httpx.Response") -> None:
+        self._response = response
+
+    @property
+    def status(self) -> int:
+        return self._response.status_code
+
+    @property
+    def headers(self) -> "httpx.Headers":
+        return self._response.headers
+
+    @property
+    def data(self) -> bytes:
+        return self._response.content
+
+
+class HttpxAuthRequest:
+    """Minimal ``google.auth.transport.Request`` backed by httpx.
+
+    Lets credential refresh reuse httpx instead of pulling in the ``requests`` library that
+    ``google.auth.transport.requests`` (and the ``google-auth[requests]`` extra) needs.
+    """
+
+    def __call__(
+        self,
+        url: str,
+        method: str = "GET",
+        body: bytes | None = None,
+        headers: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        **kwargs: object,  # noqa: ARG002
+    ) -> _HttpxAuthResponse:
+        import httpx  # noqa: PLC0415
+
+        response = httpx.request(
+            method,
+            url,
+            content=body,
+            headers=dict(headers) if headers else None,
+            timeout=timeout if timeout is not None else _REFRESH_TIMEOUT,
+        )
+        return _HttpxAuthResponse(response)
+
+
 def bearer_token(credentials: "Credentials") -> str:
     """Return a valid access token from google-auth credentials, refreshing if needed."""
-    from google.auth.transport.requests import Request  # noqa: PLC0415
-
     if not credentials.valid:
-        credentials.refresh(Request())
+        credentials.refresh(HttpxAuthRequest())
     return cast("str", credentials.token)
 
 

--- a/packages/lmux-google/src/lmux_google/_lazy.py
+++ b/packages/lmux-google/src/lmux_google/_lazy.py
@@ -1,34 +1,73 @@
-"""Lazy google-genai SDK loading internals.
+"""HTTP client factories and endpoint resolution for the Google provider.
 
-Client creation is isolated here so tests can easily mock it
-without patching sys.modules or using TYPE_CHECKING tricks.
+The Gemini REST API is reachable through two transports that share the same
+request/response JSON shape but differ in base URL and authentication:
+
+* **Gemini Developer API** — ``https://generativelanguage.googleapis.com`` with
+  an API key sent in the ``x-goog-api-key`` header. Model paths look like
+  ``/v1beta/models/<model>:generateContent``.
+* **Vertex AI** — ``https://<location>-aiplatform.googleapis.com`` (or the global
+  ``https://aiplatform.googleapis.com``) with a google-auth bearer token. Model
+  paths look like
+  ``/v1/projects/<project>/locations/<location>/publishers/google/models/<model>:generateContent``.
 """
 
-from typing import TYPE_CHECKING, Any
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, cast
+
+from lmux._http import create_async_client as _create_async
+from lmux._http import create_sync_client as _create_sync
 
 if TYPE_CHECKING:
+    import httpx
     from google.auth.credentials import Credentials
-    from google.genai import Client
+
+GEMINI_BASE_URL = "https://generativelanguage.googleapis.com"
 
 
-def create_client(
+def vertex_base_url(location: str | None) -> str:
+    """Resolve the Vertex AI regional (or global) base URL for a location."""
+    if location and location != "global":
+        return f"https://{location}-aiplatform.googleapis.com"
+    return "https://aiplatform.googleapis.com"
+
+
+def api_key_headers(api_key: str) -> Mapping[str, str]:
+    """Auth headers for the Gemini Developer API (API-key transport)."""
+    return {"x-goog-api-key": api_key, "Content-Type": "application/json"}
+
+
+def bearer_headers(token: str) -> Mapping[str, str]:
+    """Auth headers for the Vertex AI transport (OAuth bearer token)."""
+    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+
+def bearer_token(credentials: "Credentials") -> str:
+    """Return a valid access token from google-auth credentials, refreshing if needed."""
+    from google.auth.transport.requests import Request  # noqa: PLC0415
+
+    if not credentials.valid:
+        credentials.refresh(Request())
+    return cast("str", credentials.token)
+
+
+def create_sync_client(
     *,
-    vertexai: bool = True,
-    project: str | None = None,
-    location: str | None = None,
-    credentials: "Credentials | None" = None,
-    api_key: str | None = None,
-) -> "Client":
-    """Create a google-genai Client."""
-    from google import genai  # noqa: PLC0415
+    base_url: str,
+    headers: Mapping[str, str],
+    timeout: float | None = None,
+    max_retries: int | None = None,
+) -> "httpx.Client":
+    """Create an httpx client for the Gemini REST API."""
+    return _create_sync(base_url=base_url, headers=headers, timeout=timeout, max_retries=max_retries)
 
-    kwargs: dict[str, Any] = {"vertexai": vertexai}
-    if project is not None:
-        kwargs["project"] = project
-    if location is not None:
-        kwargs["location"] = location
-    if credentials is not None:
-        kwargs["credentials"] = credentials
-    if api_key is not None:
-        kwargs["api_key"] = api_key
-    return genai.Client(**kwargs)
+
+def create_async_client(
+    *,
+    base_url: str,
+    headers: Mapping[str, str],
+    timeout: float | None = None,
+    max_retries: int | None = None,
+) -> "httpx.AsyncClient":
+    """Create an async httpx client for the Gemini REST API."""
+    return _create_async(base_url=base_url, headers=headers, timeout=timeout, max_retries=max_retries)

--- a/packages/lmux-google/src/lmux_google/_lazy.py
+++ b/packages/lmux-google/src/lmux_google/_lazy.py
@@ -44,9 +44,17 @@ def api_key_headers(api_key: str) -> Mapping[str, str]:
     return {"x-goog-api-key": api_key, "Content-Type": "application/json"}
 
 
-def bearer_headers(token: str) -> Mapping[str, str]:
-    """Auth headers for the Vertex AI transport (OAuth bearer token)."""
-    return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+def bearer_headers(token: str, quota_project: str | None = None) -> Mapping[str, str]:
+    """Auth headers for the Vertex AI transport (OAuth bearer token).
+
+    ADC credentials that carry a ``quota_project_id`` must send it as ``x-goog-user-project`` so
+    quota and billing are attributed to the configured project (this is what ``Credentials.apply``
+    would add); omitting it can cause a quota-related 403 for user ADC.
+    """
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    if quota_project is not None:
+        headers["x-goog-user-project"] = quota_project
+    return headers
 
 
 class _HttpxAuthResponse:

--- a/packages/lmux-google/src/lmux_google/_mappers.py
+++ b/packages/lmux-google/src/lmux_google/_mappers.py
@@ -1,23 +1,15 @@
-"""Internal mappers between lmux types and google-genai types."""
+"""Internal mappers between lmux types and Gemini REST JSON.
 
-import base64
+Input mappers emit plain ``dict`` bodies in the camelCase shape the Gemini REST
+API expects (``contents``/``parts``, ``functionDeclarations``, ``toolConfig`` …).
+Output mappers consume the raw JSON dicts the API returns (``candidates``,
+``usageMetadata`` …) — there is no SDK object in between.
+"""
+
 import json
 import re
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from google.genai.types import (
-        Candidate,
-        ContentDict,
-        EmbedContentResponse,
-        FinishReason,
-        FunctionDeclarationDict,
-        GenerateContentResponse,
-        GenerateContentResponseUsageMetadata,
-        PartDict,
-        ToolDict,
-    )
+from typing import Any
 
 from lmux.types import (
     AssistantMessage,
@@ -50,6 +42,7 @@ from lmux.types import (
 )
 
 type CostCalculator = Callable[[str, Usage], Cost | None]
+type Json = dict[str, Any]
 
 _DATA_URI_PATTERN = re.compile(r"^data:image/([^;]+);base64,(.+)$", re.DOTALL)
 
@@ -68,18 +61,18 @@ _FINISH_REASON_MAP: dict[str, str] = {
 }
 
 
-# MARK: Input Mappers (lmux -> google-genai)
+# MARK: Input Mappers (lmux -> Gemini JSON)
 
 
-def map_messages(messages: Sequence[Message]) -> tuple[str | None, list["ContentDict"]]:
-    """Convert lmux Messages to google-genai format.
+def map_messages(messages: Sequence[Message]) -> tuple[str | None, list[Json]]:
+    """Convert lmux Messages to Gemini REST format.
 
-    Returns ``(system_instruction, contents)`` where ``system_instruction``
-    is a concatenated string for the config parameter, and ``contents`` is
-    the conversation history in google-genai Content dict format.
+    Returns ``(system_instruction, contents)`` where ``system_instruction`` is a
+    concatenated string (the caller wraps it in a Content object), and ``contents``
+    is the conversation history in Gemini Content dict format.
     """
     system_parts: list[str] = []
-    contents: list[ContentDict] = []
+    contents: list[Json] = []
 
     # Build tool_call_id -> function_name mapping for ToolMessage translation
     tool_call_names: dict[str, str] = {}
@@ -105,37 +98,37 @@ def map_messages(messages: Sequence[Message]) -> tuple[str | None, list["Content
     return system, contents
 
 
-def _map_user_content(content: str | list[ContentPart]) -> list["PartDict"]:
+def _map_user_content(content: str | list[ContentPart]) -> list[Json]:
     if isinstance(content, str):
         return [{"text": content}]
     # Cache points are dropped: this provider caches implicitly and has no explicit representation.
     return [_map_content_part(part) for part in content if not isinstance(part, CachePointContent)]
 
 
-def _map_content_part(part: TextContent | ImageContent) -> "PartDict":
+def _map_content_part(part: TextContent | ImageContent) -> Json:
     if isinstance(part, TextContent):
         return {"text": part.text}
     return _map_image_content(part)
 
 
-def _map_image_content(img: ImageContent) -> "PartDict":
+def _map_image_content(img: ImageContent) -> Json:
     match = _DATA_URI_PATTERN.match(img.url)
     if match:
         mime_type = f"image/{match.group(1)}"
-        data = base64.b64decode(match.group(2))
-        return {"inline_data": {"data": data, "mime_type": mime_type}}
-    # Plain URL — use file_data (works for GCS URIs and HTTP URLs)
-    return {"file_data": {"file_uri": img.url, "mime_type": "image/*"}}
+        # REST expects the base64 string as-is (not decoded bytes).
+        return {"inlineData": {"data": match.group(2), "mimeType": mime_type}}
+    # Plain URL — use fileData (works for GCS URIs and HTTP URLs)
+    return {"fileData": {"fileUri": img.url, "mimeType": "image/*"}}
 
 
-def _map_assistant_message(msg: AssistantMessage) -> "ContentDict":
-    parts: list[PartDict] = []
+def _map_assistant_message(msg: AssistantMessage) -> Json:
+    parts: list[Json] = []
     if msg.content is not None:
         parts.append({"text": msg.content})
     if msg.tool_calls:
         parts.extend(
             {
-                "function_call": {
+                "functionCall": {
                     "id": tc.id,
                     "name": tc.function.name,
                     "args": json.loads(tc.function.arguments),
@@ -146,7 +139,7 @@ def _map_assistant_message(msg: AssistantMessage) -> "ContentDict":
     return {"role": "model", "parts": parts}
 
 
-def _map_tool_message(msg: ToolMessage, tool_call_names: dict[str, str]) -> "ContentDict":
+def _map_tool_message(msg: ToolMessage, tool_call_names: dict[str, str]) -> Json:
     name = tool_call_names.get(msg.tool_call_id, msg.tool_call_id)
     try:
         response_data = json.loads(msg.content)
@@ -156,7 +149,7 @@ def _map_tool_message(msg: ToolMessage, tool_call_names: dict[str, str]) -> "Con
         "role": "user",
         "parts": [
             {
-                "function_response": {
+                "functionResponse": {
                     "id": msg.tool_call_id,
                     "name": name,
                     "response": response_data,
@@ -166,33 +159,29 @@ def _map_tool_message(msg: ToolMessage, tool_call_names: dict[str, str]) -> "Con
     }
 
 
-def map_tools(tools: list[Tool]) -> list["ToolDict"]:
-    """Convert lmux Tools to google-genai tool dicts."""
-    declarations: list[FunctionDeclarationDict] = []
+def map_tools(tools: list[Tool]) -> list[Json]:
+    """Convert lmux Tools to Gemini tool dicts."""
+    declarations: list[Json] = []
     for tool in tools:
-        decl: FunctionDeclarationDict = {"name": tool.function.name}
+        decl: Json = {"name": tool.function.name}
         if tool.function.description is not None:
             decl["description"] = tool.function.description
         if tool.function.parameters is not None:
-            decl["parameters_json_schema"] = tool.function.parameters
+            decl["parametersJsonSchema"] = tool.function.parameters
         declarations.append(decl)
-    return [{"function_declarations": declarations}]
+    return [{"functionDeclarations": declarations}]
 
 
-def map_tool_choice(tc: ToolChoice) -> dict[str, object]:
-    """Convert lmux ToolChoice to google-genai ``tool_config`` dict."""
+def map_tool_choice(tc: ToolChoice) -> Json:
+    """Convert lmux ToolChoice to a Gemini ``toolConfig`` dict."""
     if isinstance(tc, ToolChoiceFunction):
-        return {"function_calling_config": {"mode": "ANY", "allowed_function_names": [tc.name]}}
+        return {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": [tc.name]}}
     mode = {"auto": "AUTO", "required": "ANY", "none": "NONE"}[tc]
-    return {"function_calling_config": {"mode": mode}}
+    return {"functionCallingConfig": {"mode": mode}}
 
 
-def map_response_format(rf: ResponseFormat) -> tuple[str | None, dict[str, object] | None]:
-    """Convert lmux ResponseFormat to google-genai config fields.
-
-    Returns ``(response_mime_type, response_schema)`` to be merged into
-    the ``GenerateContentConfig``.
-    """
+def map_response_format(rf: ResponseFormat) -> tuple[str | None, Json | None]:
+    """Convert lmux ResponseFormat to ``(responseMimeType, responseSchema)`` config fields."""
     if isinstance(rf, TextResponseFormat):
         return None, None
     if isinstance(rf, JsonObjectResponseFormat):
@@ -201,19 +190,19 @@ def map_response_format(rf: ResponseFormat) -> tuple[str | None, dict[str, objec
     return "application/json", rf.json_schema
 
 
-# MARK: Output Mappers (google-genai -> lmux)
+# MARK: Output Mappers (Gemini JSON -> lmux)
 
 
 def map_generate_content_response(
-    response: "GenerateContentResponse",
+    response: Json,
     model: str,
     provider_name: str,
     cost_fn: CostCalculator,
 ) -> ChatResponse:
-    """Convert google-genai GenerateContentResponse to lmux ChatResponse."""
+    """Convert a Gemini ``generateContent`` JSON body to an lmux ChatResponse."""
     candidate = _get_candidate(response)
     if candidate is None:
-        usage = _map_usage(response.usage_metadata)
+        usage = _map_usage(response.get("usageMetadata"))
         cost = cost_fn(model, usage) if usage else None
         return ChatResponse(content=None, tool_calls=None, usage=usage, cost=cost, model=model, provider=provider_name)
 
@@ -222,49 +211,43 @@ def map_generate_content_response(
     tool_calls: list[ToolCall] = []
     server_tool_results: list[ServerToolResult] = []
 
-    if candidate.content and candidate.content.parts:
-        pending_code_input: dict[str, str | None] | None = None
-        for i, part in enumerate(candidate.content.parts):
-            if part.thought:
-                if part.text is not None:
-                    thinking_parts.append(part.text)
-                continue
-            if part.text is not None:
-                text_parts.append(part.text)
-            if part.function_call is not None:
-                fc = part.function_call
-                tool_calls.append(
-                    ToolCall(
-                        id=fc.id or f"call_{i}",
-                        function=FunctionCallResult(
-                            name=fc.name or "",
-                            arguments=json.dumps(dict(fc.args) if fc.args else {}),
-                        ),
-                    )
+    parts = (candidate.get("content") or {}).get("parts") or []
+    pending_code_input: dict[str, str | None] | None = None
+    for i, part in enumerate(parts):
+        if part.get("thought"):
+            if part.get("text") is not None:
+                thinking_parts.append(part["text"])
+            continue
+        if part.get("text") is not None:
+            text_parts.append(part["text"])
+        fc = part.get("functionCall")
+        if fc is not None:
+            tool_calls.append(
+                ToolCall(
+                    id=fc.get("id") or f"call_{i}",
+                    function=FunctionCallResult(name=fc.get("name") or "", arguments=json.dumps(fc.get("args") or {})),
                 )
-            ec = getattr(part, "executable_code", None)
-            if ec is not None:
-                pending_code_input = {
-                    "code": ec.code,
-                    "language": ec.language.value if hasattr(ec.language, "value") else ec.language,
-                }
-            cer = getattr(part, "code_execution_result", None)
-            if cer is not None:
-                outcome = cer.outcome.value if hasattr(cer.outcome, "value") else cer.outcome
-                server_tool_results.append(
-                    ServerToolResult(
-                        name="code_execution",
-                        input=pending_code_input,
-                        output=cer.output,
-                        provider_specific_fields={"outcome": outcome} if outcome else None,
-                    )
+            )
+        ec = part.get("executableCode")
+        if ec is not None:
+            pending_code_input = {"code": ec.get("code"), "language": ec.get("language")}
+        cer = part.get("codeExecutionResult")
+        if cer is not None:
+            outcome = cer.get("outcome")
+            server_tool_results.append(
+                ServerToolResult(
+                    name="code_execution",
+                    input=pending_code_input,
+                    output=cer.get("output"),
+                    provider_specific_fields={"outcome": outcome} if outcome else None,
                 )
-                pending_code_input = None
+            )
+            pending_code_input = None
 
     content = "\n".join(text_parts) if text_parts else None
     reasoning = "\n".join(thinking_parts) if thinking_parts else None
-    finish_reason = _map_finish_reason(candidate.finish_reason, bool(tool_calls))
-    usage = _map_usage(response.usage_metadata)
+    finish_reason = _map_finish_reason(candidate.get("finishReason"), bool(tool_calls))
+    usage = _map_usage(response.get("usageMetadata"))
     cost = cost_fn(model, usage) if usage else None
 
     return ChatResponse(
@@ -280,107 +263,95 @@ def map_generate_content_response(
     )
 
 
-def map_generate_content_chunk(  # noqa: PLR0912
-    chunk: "GenerateContentResponse",
+def map_generate_content_chunk(
+    chunk: Json,
     model: str,
     provider_name: str,
 ) -> ChatChunk:
-    """Convert a streaming chunk to lmux ChatChunk."""
+    """Convert a streaming ``generateContent`` chunk JSON to an lmux ChatChunk."""
     delta: str | None = None
+    reasoning_delta: str | None = None
     tool_call_deltas: list[ToolCallDelta] | None = None
     server_tool_deltas: list[ServerToolDelta] | None = None
     finish_reason: str | None = None
-    usage: Usage | None = None
 
-    reasoning_delta: str | None = None
     candidate = _get_candidate(chunk)
     if candidate is not None:
-        if candidate.content and candidate.content.parts:
-            text_pieces: list[str] = []
-            thinking_pieces: list[str] = []
-            tcd_list: list[ToolCallDelta] = []
-            std_list: list[ServerToolDelta] = []
-            std_index = 0
-            for i, part in enumerate(candidate.content.parts):
-                if part.thought:
-                    if part.text is not None:
-                        thinking_pieces.append(part.text)
-                    continue
-                if part.text is not None:
-                    text_pieces.append(part.text)
-                if part.function_call is not None:
-                    fc = part.function_call
-                    tcd_list.append(
-                        ToolCallDelta(
-                            index=i,
-                            id=fc.id or f"call_{i}",
-                            type="function",
-                            function=FunctionCallDelta(
-                                name=fc.name,
-                                arguments=json.dumps(dict(fc.args) if fc.args else {}),
-                            ),
-                        )
+        parts = (candidate.get("content") or {}).get("parts") or []
+        text_pieces: list[str] = []
+        thinking_pieces: list[str] = []
+        tcd_list: list[ToolCallDelta] = []
+        std_list: list[ServerToolDelta] = []
+        std_index = 0
+        for i, part in enumerate(parts):
+            if part.get("thought"):
+                if part.get("text") is not None:
+                    thinking_pieces.append(part["text"])
+                continue
+            if part.get("text") is not None:
+                text_pieces.append(part["text"])
+            fc = part.get("functionCall")
+            if fc is not None:
+                tcd_list.append(
+                    ToolCallDelta(
+                        index=i,
+                        id=fc.get("id") or f"call_{i}",
+                        type="function",
+                        function=FunctionCallDelta(name=fc.get("name"), arguments=json.dumps(fc.get("args") or {})),
                     )
-                ec = getattr(part, "executable_code", None)
-                if ec is not None:
-                    language = ec.language.value if hasattr(ec.language, "value") else ec.language
-                    std_list.append(
-                        ServerToolDelta(
-                            index=std_index,
-                            name="code_execution",
-                            input_delta=json.dumps({"code": ec.code, "language": language}),
-                        )
+                )
+            ec = part.get("executableCode")
+            if ec is not None:
+                std_list.append(
+                    ServerToolDelta(
+                        index=std_index,
+                        name="code_execution",
+                        input_delta=json.dumps({"code": ec.get("code"), "language": ec.get("language")}),
                     )
-                cer = getattr(part, "code_execution_result", None)
-                if cer is not None:
-                    std_list.append(
-                        ServerToolDelta(
-                            index=std_index,
-                            output_delta=cer.output,
-                        )
-                    )
-                    std_index += 1
-            if text_pieces:
-                delta = "".join(text_pieces)
-            if thinking_pieces:
-                reasoning_delta = "".join(thinking_pieces)
-            if tcd_list:
-                tool_call_deltas = tcd_list
-            if std_list:
-                server_tool_deltas = std_list
-        finish_reason = _map_finish_reason(candidate.finish_reason, tool_call_deltas is not None)
-
-    usage = _map_usage(chunk.usage_metadata)
+                )
+            cer = part.get("codeExecutionResult")
+            if cer is not None:
+                std_list.append(ServerToolDelta(index=std_index, output_delta=cer.get("output")))
+                std_index += 1
+        if text_pieces:
+            delta = "".join(text_pieces)
+        if thinking_pieces:
+            reasoning_delta = "".join(thinking_pieces)
+        if tcd_list:
+            tool_call_deltas = tcd_list
+        if std_list:
+            server_tool_deltas = std_list
+        finish_reason = _map_finish_reason(candidate.get("finishReason"), tool_call_deltas is not None)
 
     return ChatChunk(
         delta=delta,
         reasoning_delta=reasoning_delta,
         tool_call_deltas=tool_call_deltas,
         server_tool_deltas=server_tool_deltas,
-        usage=usage,
+        usage=_map_usage(chunk.get("usageMetadata")),
         finish_reason=finish_reason,
         model=model,
         provider=provider_name,
     )
 
 
-def map_embed_content_response(
-    response: "EmbedContentResponse",
+def map_batch_embeddings_response(
+    response: Json,
     model: str,
     provider_name: str,
     cost_fn: CostCalculator,
 ) -> EmbeddingResponse:
-    """Convert google-genai EmbedContentResponse to lmux EmbeddingResponse."""
-    embeddings: list[list[float]] = (
-        [list(emb.values) if emb.values else [] for emb in response.embeddings] if response.embeddings else []
-    )
+    """Convert a Gemini ``batchEmbedContents`` JSON body to an lmux EmbeddingResponse."""
+    raw = response.get("embeddings") or []
+    embeddings: list[list[float]] = [list(emb.get("values") or []) for emb in raw]
 
-    # The embedding API does not return token counts — only billable_character_count
+    # The embedding API does not return token counts — only ``billableCharacterCount``
     # in metadata (Vertex AI only). We approximate tokens as chars / 4, consistent
     # with how litellm handles this. This is an approximation, not exact token usage.
     input_tokens = 0
-    if response.metadata is not None and response.metadata.billable_character_count is not None:
-        input_tokens = response.metadata.billable_character_count // 4
+    billable = (response.get("metadata") or {}).get("billableCharacterCount")
+    if billable is not None:
+        input_tokens = billable // 4
     usage = Usage(input_tokens=input_tokens, output_tokens=0)
     cost = cost_fn(model, usage)
 
@@ -396,31 +367,27 @@ def map_embed_content_response(
 # MARK: Internal Helpers
 
 
-def _get_candidate(response: "GenerateContentResponse") -> "Candidate | None":
-    if response.candidates:
-        return response.candidates[0]
+def _get_candidate(response: Json) -> Json | None:
+    candidates = response.get("candidates")
+    if candidates:
+        return candidates[0]
     return None
 
 
-def _map_finish_reason(reason: "FinishReason | None", has_tool_calls: bool) -> str | None:
+def _map_finish_reason(reason: str | None, has_tool_calls: bool) -> str | None:
     if reason is None:
         return None
     if has_tool_calls:
         return "tool_calls"
-    reason_str: str = reason.value if hasattr(reason, "value") else str(reason)
-    return _FINISH_REASON_MAP.get(reason_str, reason_str)
+    return _FINISH_REASON_MAP.get(reason, reason)
 
 
-def _map_usage(usage_metadata: "GenerateContentResponseUsageMetadata | None") -> Usage | None:
+def _map_usage(usage_metadata: Json | None) -> Usage | None:
     if usage_metadata is None:
         return None
-    input_tokens = usage_metadata.prompt_token_count or 0
-    output_tokens = usage_metadata.candidates_token_count or 0
-    cache_read = usage_metadata.cached_content_token_count or None
-    reasoning_tokens = getattr(usage_metadata, "thoughts_token_count", None) or None
     return Usage(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        cache_read_tokens=cache_read,
-        reasoning_tokens=reasoning_tokens,
+        input_tokens=usage_metadata.get("promptTokenCount") or 0,
+        output_tokens=usage_metadata.get("candidatesTokenCount") or 0,
+        cache_read_tokens=usage_metadata.get("cachedContentTokenCount") or None,
+        reasoning_tokens=usage_metadata.get("thoughtsTokenCount") or None,
     )

--- a/packages/lmux-google/src/lmux_google/_mappers.py
+++ b/packages/lmux-google/src/lmux_google/_mappers.py
@@ -45,6 +45,7 @@ from lmux_google._wire import (
     WireCandidate,
     WireGenerateContentResponse,
     WireUsageMetadata,
+    WireVertexPredictResponse,
 )
 
 type CostCalculator = Callable[[str, Usage], Cost | None]
@@ -358,6 +359,26 @@ def map_batch_embeddings_response(
     usage = Usage(input_tokens=input_tokens, output_tokens=0)
     cost = cost_fn(model, usage)
 
+    return EmbeddingResponse(
+        embeddings=embeddings,
+        usage=usage,
+        cost=cost,
+        model=model,
+        provider=provider_name,
+    )
+
+
+def map_vertex_embed_response(
+    response: WireVertexPredictResponse,
+    model: str,
+    provider_name: str,
+    cost_fn: CostCalculator,
+) -> EmbeddingResponse:
+    """Convert a validated Vertex AI ``:predict`` embeddings response to an lmux EmbeddingResponse."""
+    embeddings: list[list[float]] = [list(p.embeddings.values) for p in response.predictions]
+    input_tokens = sum(p.embeddings.statistics.token_count for p in response.predictions)
+    usage = Usage(input_tokens=input_tokens, output_tokens=0)
+    cost = cost_fn(model, usage)
     return EmbeddingResponse(
         embeddings=embeddings,
         usage=usage,

--- a/packages/lmux-google/src/lmux_google/_mappers.py
+++ b/packages/lmux-google/src/lmux_google/_mappers.py
@@ -40,6 +40,12 @@ from lmux.types import (
     Usage,
     UserMessage,
 )
+from lmux_google._wire import (
+    WireBatchEmbeddingsResponse,
+    WireCandidate,
+    WireGenerateContentResponse,
+    WireUsageMetadata,
+)
 
 type CostCalculator = Callable[[str, Usage], Cost | None]
 type Json = dict[str, Any]
@@ -194,15 +200,15 @@ def map_response_format(rf: ResponseFormat) -> tuple[str | None, Json | None]:
 
 
 def map_generate_content_response(
-    response: Json,
+    response: WireGenerateContentResponse,
     model: str,
     provider_name: str,
     cost_fn: CostCalculator,
 ) -> ChatResponse:
-    """Convert a Gemini ``generateContent`` JSON body to an lmux ChatResponse."""
+    """Convert a validated Gemini ``generateContent`` response to an lmux ChatResponse."""
     candidate = _get_candidate(response)
     if candidate is None:
-        usage = _map_usage(response.get("usageMetadata"))
+        usage = _map_usage(response.usage_metadata)
         cost = cost_fn(model, usage) if usage else None
         return ChatResponse(content=None, tool_calls=None, usage=usage, cost=cost, model=model, provider=provider_name)
 
@@ -211,43 +217,42 @@ def map_generate_content_response(
     tool_calls: list[ToolCall] = []
     server_tool_results: list[ServerToolResult] = []
 
-    parts = (candidate.get("content") or {}).get("parts") or []
+    parts = candidate.content.parts if candidate.content and candidate.content.parts else []
     pending_code_input: dict[str, str | None] | None = None
     for i, part in enumerate(parts):
-        if part.get("thought"):
-            if part.get("text") is not None:
-                thinking_parts.append(part["text"])
+        if part.thought:
+            if part.text is not None:
+                thinking_parts.append(part.text)
             continue
-        if part.get("text") is not None:
-            text_parts.append(part["text"])
-        fc = part.get("functionCall")
-        if fc is not None:
+        if part.text is not None:
+            text_parts.append(part.text)
+        if part.function_call is not None:
+            fc = part.function_call
             tool_calls.append(
                 ToolCall(
-                    id=fc.get("id") or f"call_{i}",
-                    function=FunctionCallResult(name=fc.get("name") or "", arguments=json.dumps(fc.get("args") or {})),
+                    id=fc.id or f"call_{i}",
+                    function=FunctionCallResult(name=fc.name or "", arguments=json.dumps(fc.args or {})),
                 )
             )
-        ec = part.get("executableCode")
-        if ec is not None:
-            pending_code_input = {"code": ec.get("code"), "language": ec.get("language")}
-        cer = part.get("codeExecutionResult")
-        if cer is not None:
-            outcome = cer.get("outcome")
+        if part.executable_code is not None:
+            ec = part.executable_code
+            pending_code_input = {"code": ec.code, "language": ec.language}
+        if part.code_execution_result is not None:
+            cer = part.code_execution_result
             server_tool_results.append(
                 ServerToolResult(
                     name="code_execution",
                     input=pending_code_input,
-                    output=cer.get("output"),
-                    provider_specific_fields={"outcome": outcome} if outcome else None,
+                    output=cer.output,
+                    provider_specific_fields={"outcome": cer.outcome} if cer.outcome else None,
                 )
             )
             pending_code_input = None
 
     content = "\n".join(text_parts) if text_parts else None
     reasoning = "\n".join(thinking_parts) if thinking_parts else None
-    finish_reason = _map_finish_reason(candidate.get("finishReason"), bool(tool_calls))
-    usage = _map_usage(response.get("usageMetadata"))
+    finish_reason = _map_finish_reason(candidate.finish_reason, bool(tool_calls))
+    usage = _map_usage(response.usage_metadata)
     cost = cost_fn(model, usage) if usage else None
 
     return ChatResponse(
@@ -264,11 +269,11 @@ def map_generate_content_response(
 
 
 def map_generate_content_chunk(
-    chunk: Json,
+    chunk: WireGenerateContentResponse,
     model: str,
     provider_name: str,
 ) -> ChatChunk:
-    """Convert a streaming ``generateContent`` chunk JSON to an lmux ChatChunk."""
+    """Convert a validated streaming ``generateContent`` chunk to an lmux ChatChunk."""
     delta: str | None = None
     reasoning_delta: str | None = None
     tool_call_deltas: list[ToolCallDelta] | None = None
@@ -277,41 +282,40 @@ def map_generate_content_chunk(
 
     candidate = _get_candidate(chunk)
     if candidate is not None:
-        parts = (candidate.get("content") or {}).get("parts") or []
+        parts = candidate.content.parts if candidate.content and candidate.content.parts else []
         text_pieces: list[str] = []
         thinking_pieces: list[str] = []
         tcd_list: list[ToolCallDelta] = []
         std_list: list[ServerToolDelta] = []
         std_index = 0
         for i, part in enumerate(parts):
-            if part.get("thought"):
-                if part.get("text") is not None:
-                    thinking_pieces.append(part["text"])
+            if part.thought:
+                if part.text is not None:
+                    thinking_pieces.append(part.text)
                 continue
-            if part.get("text") is not None:
-                text_pieces.append(part["text"])
-            fc = part.get("functionCall")
-            if fc is not None:
+            if part.text is not None:
+                text_pieces.append(part.text)
+            if part.function_call is not None:
+                fc = part.function_call
                 tcd_list.append(
                     ToolCallDelta(
                         index=i,
-                        id=fc.get("id") or f"call_{i}",
+                        id=fc.id or f"call_{i}",
                         type="function",
-                        function=FunctionCallDelta(name=fc.get("name"), arguments=json.dumps(fc.get("args") or {})),
+                        function=FunctionCallDelta(name=fc.name, arguments=json.dumps(fc.args or {})),
                     )
                 )
-            ec = part.get("executableCode")
-            if ec is not None:
+            if part.executable_code is not None:
+                ec = part.executable_code
                 std_list.append(
                     ServerToolDelta(
                         index=std_index,
                         name="code_execution",
-                        input_delta=json.dumps({"code": ec.get("code"), "language": ec.get("language")}),
+                        input_delta=json.dumps({"code": ec.code, "language": ec.language}),
                     )
                 )
-            cer = part.get("codeExecutionResult")
-            if cer is not None:
-                std_list.append(ServerToolDelta(index=std_index, output_delta=cer.get("output")))
+            if part.code_execution_result is not None:
+                std_list.append(ServerToolDelta(index=std_index, output_delta=part.code_execution_result.output))
                 std_index += 1
         if text_pieces:
             delta = "".join(text_pieces)
@@ -321,14 +325,14 @@ def map_generate_content_chunk(
             tool_call_deltas = tcd_list
         if std_list:
             server_tool_deltas = std_list
-        finish_reason = _map_finish_reason(candidate.get("finishReason"), tool_call_deltas is not None)
+        finish_reason = _map_finish_reason(candidate.finish_reason, tool_call_deltas is not None)
 
     return ChatChunk(
         delta=delta,
         reasoning_delta=reasoning_delta,
         tool_call_deltas=tool_call_deltas,
         server_tool_deltas=server_tool_deltas,
-        usage=_map_usage(chunk.get("usageMetadata")),
+        usage=_map_usage(chunk.usage_metadata),
         finish_reason=finish_reason,
         model=model,
         provider=provider_name,
@@ -336,20 +340,19 @@ def map_generate_content_chunk(
 
 
 def map_batch_embeddings_response(
-    response: Json,
+    response: WireBatchEmbeddingsResponse,
     model: str,
     provider_name: str,
     cost_fn: CostCalculator,
 ) -> EmbeddingResponse:
-    """Convert a Gemini ``batchEmbedContents`` JSON body to an lmux EmbeddingResponse."""
-    raw = response.get("embeddings") or []
-    embeddings: list[list[float]] = [list(emb.get("values") or []) for emb in raw]
+    """Convert a validated Gemini ``batchEmbedContents`` response to an lmux EmbeddingResponse."""
+    embeddings: list[list[float]] = [list(emb.values or []) for emb in response.embeddings or []]
 
     # The embedding API does not return token counts — only ``billableCharacterCount``
     # in metadata (Vertex AI only). We approximate tokens as chars / 4, consistent
     # with how litellm handles this. This is an approximation, not exact token usage.
     input_tokens = 0
-    billable = (response.get("metadata") or {}).get("billableCharacterCount")
+    billable = response.metadata.billable_character_count if response.metadata else None
     if billable is not None:
         input_tokens = billable // 4
     usage = Usage(input_tokens=input_tokens, output_tokens=0)
@@ -367,10 +370,9 @@ def map_batch_embeddings_response(
 # MARK: Internal Helpers
 
 
-def _get_candidate(response: Json) -> Json | None:
-    candidates = response.get("candidates")
-    if candidates:
-        return candidates[0]
+def _get_candidate(response: WireGenerateContentResponse) -> WireCandidate | None:
+    if response.candidates:
+        return response.candidates[0]
     return None
 
 
@@ -382,12 +384,12 @@ def _map_finish_reason(reason: str | None, has_tool_calls: bool) -> str | None:
     return _FINISH_REASON_MAP.get(reason, reason)
 
 
-def _map_usage(usage_metadata: Json | None) -> Usage | None:
+def _map_usage(usage_metadata: WireUsageMetadata | None) -> Usage | None:
     if usage_metadata is None:
         return None
     return Usage(
-        input_tokens=usage_metadata.get("promptTokenCount") or 0,
-        output_tokens=usage_metadata.get("candidatesTokenCount") or 0,
-        cache_read_tokens=usage_metadata.get("cachedContentTokenCount") or None,
-        reasoning_tokens=usage_metadata.get("thoughtsTokenCount") or None,
+        input_tokens=usage_metadata.prompt_token_count or 0,
+        output_tokens=usage_metadata.candidates_token_count or 0,
+        cache_read_tokens=usage_metadata.cached_content_token_count or None,
+        reasoning_tokens=usage_metadata.thoughts_token_count or None,
     )

--- a/packages/lmux-google/src/lmux_google/_mappers.py
+++ b/packages/lmux-google/src/lmux_google/_mappers.py
@@ -43,6 +43,7 @@ from lmux.types import (
 from lmux_google._wire import (
     WireBatchEmbeddingsResponse,
     WireCandidate,
+    WireEmbedContentResponse,
     WireGenerateContentResponse,
     WireUsageMetadata,
     WireVertexPredictResponse,
@@ -349,13 +350,12 @@ def map_batch_embeddings_response(
     """Convert a validated Gemini ``batchEmbedContents`` response to an lmux EmbeddingResponse."""
     embeddings: list[list[float]] = [list(emb.values or []) for emb in response.embeddings or []]
 
-    # The embedding API does not return token counts — only ``billableCharacterCount``
-    # in metadata (Vertex AI only). We approximate tokens as chars / 4, consistent
-    # with how litellm handles this. This is an approximation, not exact token usage.
+    # The Developer API reports input tokens in usageMetadata.promptTokenCount; older API versions
+    # omit it entirely, in which case token usage (and therefore cost) is left at zero.
     input_tokens = 0
-    billable = response.metadata.billable_character_count if response.metadata else None
-    if billable is not None:
-        input_tokens = billable // 4
+    prompt_tokens = response.usage_metadata.prompt_token_count if response.usage_metadata else None
+    if prompt_tokens is not None:
+        input_tokens = prompt_tokens
     usage = Usage(input_tokens=input_tokens, output_tokens=0)
     cost = cost_fn(model, usage)
 
@@ -366,6 +366,11 @@ def map_batch_embeddings_response(
         model=model,
         provider=provider_name,
     )
+
+
+def map_embed_content_response(response: WireEmbedContentResponse) -> tuple[list[float], int]:
+    """Extract (embedding values, prompt tokens) from one Vertex ``:embedContent`` response."""
+    return list(response.embedding.values), response.usage_metadata.prompt_token_count
 
 
 def map_vertex_embed_response(

--- a/packages/lmux-google/src/lmux_google/_wire.py
+++ b/packages/lmux-google/src/lmux_google/_wire.py
@@ -9,7 +9,7 @@ shape lmux reads as optional fields and the mapper dispatches on which are prese
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
 
 
@@ -79,3 +79,23 @@ class WireEmbeddingsMetadata(_GeminiModel):
 class WireBatchEmbeddingsResponse(_GeminiModel):
     embeddings: list[WireEmbedding] | None = None
     metadata: WireEmbeddingsMetadata | None = None
+
+
+# MARK: Vertex AI embeddings (:predict — instances/predictions shape)
+
+
+class WireVertexEmbedStatistics(_GeminiModel):
+    token_count: int = 0
+
+
+class WireVertexEmbedding(_GeminiModel):
+    values: list[float] = Field(default_factory=list)
+    statistics: WireVertexEmbedStatistics = Field(default_factory=WireVertexEmbedStatistics)
+
+
+class WireVertexPrediction(_GeminiModel):
+    embeddings: WireVertexEmbedding = Field(default_factory=WireVertexEmbedding)
+
+
+class WireVertexPredictResponse(_GeminiModel):
+    predictions: list[WireVertexPrediction] = Field(default_factory=list)

--- a/packages/lmux-google/src/lmux_google/_wire.py
+++ b/packages/lmux-google/src/lmux_google/_wire.py
@@ -72,13 +72,25 @@ class WireEmbedding(_GeminiModel):
     values: list[float] | None = None
 
 
-class WireEmbeddingsMetadata(_GeminiModel):
-    billable_character_count: int | None = None
-
-
 class WireBatchEmbeddingsResponse(_GeminiModel):
     embeddings: list[WireEmbedding] | None = None
-    metadata: WireEmbeddingsMetadata | None = None
+    usage_metadata: WireUsageMetadata | None = None
+
+
+# MARK: embedContent (Vertex Gemini Embedding 2 — single content per request)
+
+
+class WireEmbedContentEmbedding(_GeminiModel):
+    values: list[float] = Field(default_factory=list)
+
+
+class WireEmbedContentUsage(_GeminiModel):
+    prompt_token_count: int = 0
+
+
+class WireEmbedContentResponse(_GeminiModel):
+    embedding: WireEmbedContentEmbedding = Field(default_factory=WireEmbedContentEmbedding)
+    usage_metadata: WireEmbedContentUsage = Field(default_factory=WireEmbedContentUsage)
 
 
 # MARK: Vertex AI embeddings (:predict — instances/predictions shape)

--- a/packages/lmux-google/src/lmux_google/_wire.py
+++ b/packages/lmux-google/src/lmux_google/_wire.py
@@ -1,0 +1,81 @@
+"""Pydantic wire models for Gemini REST response bodies.
+
+Only the fields lmux consumes are declared; unknown fields are ignored (Pydantic's default),
+so new server fields do not break parsing. Gemini uses camelCase on the wire, so a shared
+alias generator maps snake_case field names to their camelCase aliases (``function_call`` ->
+``functionCall``). A part is a field-bag (no ``type`` tag), so ``WirePart`` carries every part
+shape lmux reads as optional fields and the mapper dispatches on which are present.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+
+class _GeminiModel(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+
+# MARK: generateContent (response + streaming chunk share this shape)
+
+
+class WireFunctionCall(_GeminiModel):
+    id: str | None = None
+    name: str | None = None
+    args: dict[str, Any] | None = None
+
+
+class WireExecutableCode(_GeminiModel):
+    code: str | None = None
+    language: str | None = None
+
+
+class WireCodeExecutionResult(_GeminiModel):
+    outcome: str | None = None
+    output: str | None = None
+
+
+class WirePart(_GeminiModel):
+    text: str | None = None
+    thought: bool | None = None
+    function_call: WireFunctionCall | None = None
+    executable_code: WireExecutableCode | None = None
+    code_execution_result: WireCodeExecutionResult | None = None
+
+
+class WireContent(_GeminiModel):
+    parts: list[WirePart] | None = None
+
+
+class WireCandidate(_GeminiModel):
+    content: WireContent | None = None
+    finish_reason: str | None = None
+
+
+class WireUsageMetadata(_GeminiModel):
+    prompt_token_count: int | None = None
+    candidates_token_count: int | None = None
+    cached_content_token_count: int | None = None
+    thoughts_token_count: int | None = None
+
+
+class WireGenerateContentResponse(_GeminiModel):
+    candidates: list[WireCandidate] | None = None
+    usage_metadata: WireUsageMetadata | None = None
+
+
+# MARK: batchEmbedContents
+
+
+class WireEmbedding(_GeminiModel):
+    values: list[float] | None = None
+
+
+class WireEmbeddingsMetadata(_GeminiModel):
+    billable_character_count: int | None = None
+
+
+class WireBatchEmbeddingsResponse(_GeminiModel):
+    embeddings: list[WireEmbedding] | None = None
+    metadata: WireEmbeddingsMetadata | None = None

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -43,6 +43,7 @@ from lmux_google._lazy import (
 from lmux_google._mappers import (
     Json,
     map_batch_embeddings_response,
+    map_embed_content_response,
     map_generate_content_chunk,
     map_generate_content_response,
     map_messages,
@@ -53,6 +54,7 @@ from lmux_google._mappers import (
 )
 from lmux_google._wire import (
     WireBatchEmbeddingsResponse,
+    WireEmbedContentResponse,
     WireGenerateContentResponse,
     WireVertexPredictResponse,
 )
@@ -125,14 +127,14 @@ class GoogleProvider(
     def _request_headers(self) -> Mapping[str, str]:
         if self._credentials is None:
             return {}
-        return bearer_headers(bearer_token(self._credentials))
+        return bearer_headers(bearer_token(self._credentials), self._credentials.quota_project_id)
 
     async def _arequest_headers(self) -> Mapping[str, str]:
         if self._credentials is None:
             return {}
         # Credential refresh does blocking HTTP; run it off the event loop.
         token = await asyncio.to_thread(bearer_token, self._credentials)
-        return bearer_headers(token)
+        return bearer_headers(token, self._credentials.quota_project_id)
 
     def _path(self, model: str, method: str, *, sse: bool = False) -> str:
         suffix = "?alt=sse" if sse else ""
@@ -335,6 +337,8 @@ class GoogleProvider(
         dimensions: int | None = None,
         provider_params: GoogleParams | None = None,
     ) -> EmbeddingResponse:
+        if self._vertexai and _uses_embed_content(model):
+            return self._embed_content(model, input, dimensions)
         path, body = self._embed_path_and_body(model, input, dimensions, provider_params)
         try:
             client = self._get_sync_client()
@@ -353,6 +357,8 @@ class GoogleProvider(
         dimensions: int | None = None,
         provider_params: GoogleParams | None = None,
     ) -> EmbeddingResponse:
+        if self._vertexai and _uses_embed_content(model):
+            return await self._aembed_content(model, input, dimensions)
         path, body = self._embed_path_and_body(model, input, dimensions, provider_params)
         try:
             client = await self._get_async_client()
@@ -361,6 +367,58 @@ class GoogleProvider(
             raise map_transport_error(e) from e
         raise_for_status(response)
         return self._map_embed_response(response, model)
+
+    def _embed_content(self, model: str, input: str | list[str], dimensions: int | None) -> EmbeddingResponse:  # noqa: A002
+        # Vertex serves Gemini Embedding 2 models only through :embedContent, which takes a single
+        # content per request (no batch) and rejects task_type — so a list is issued one item at a time.
+        texts = input if isinstance(input, list) else [input]
+        path = self._path(model, "embedContent")
+        embeddings: list[list[float]] = []
+        input_tokens = 0
+        try:
+            client = self._get_sync_client()
+            for text in texts:
+                headers = self._request_headers()
+                response = client.post(path, json=_embed_content_body(text, dimensions), headers=headers)
+                raise_for_status(response)
+                values, tokens = map_embed_content_response(parse_body(response, WireEmbedContentResponse))
+                embeddings.append(values)
+                input_tokens += tokens
+        except LmuxError:
+            raise
+        except Exception as e:
+            raise map_transport_error(e) from e
+        return self._embedding_response(model, embeddings, input_tokens)
+
+    async def _aembed_content(self, model: str, input: str | list[str], dimensions: int | None) -> EmbeddingResponse:  # noqa: A002
+        texts = input if isinstance(input, list) else [input]
+        path = self._path(model, "embedContent")
+        embeddings: list[list[float]] = []
+        input_tokens = 0
+        try:
+            client = await self._get_async_client()
+            for text in texts:
+                headers = await self._arequest_headers()
+                response = await client.post(path, json=_embed_content_body(text, dimensions), headers=headers)
+                raise_for_status(response)
+                values, tokens = map_embed_content_response(parse_body(response, WireEmbedContentResponse))
+                embeddings.append(values)
+                input_tokens += tokens
+        except LmuxError:
+            raise
+        except Exception as e:
+            raise map_transport_error(e) from e
+        return self._embedding_response(model, embeddings, input_tokens)
+
+    def _embedding_response(self, model: str, embeddings: list[list[float]], input_tokens: int) -> EmbeddingResponse:
+        usage = Usage(input_tokens=input_tokens, output_tokens=0)
+        return EmbeddingResponse(
+            embeddings=embeddings,
+            usage=usage,
+            cost=self._calculate_cost(model, usage),
+            model=model,
+            provider=PROVIDER_NAME,
+        )
 
     # MARK: Internal Helpers
 
@@ -536,3 +594,15 @@ class GoogleProvider(
         if config.exclude_domains is not None:
             gs_dict["excludeDomains"] = config.exclude_domains
         return gs_dict
+
+
+def _uses_embed_content(model: str) -> bool:
+    """Gemini Embedding 2 models are served on Vertex only through :embedContent (not :predict)."""
+    return model.startswith("gemini-embedding-2")
+
+
+def _embed_content_body(text: str, dimensions: int | None) -> Json:
+    body: Json = {"content": {"parts": [{"text": text}]}}
+    if dimensions is not None:
+        body["outputDimensionality"] = dimensions
+    return body

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -339,14 +339,23 @@ class GoogleProvider(
     ) -> EmbeddingResponse:
         if self._vertexai and _uses_embed_content(model):
             return self._embed_content(model, input, dimensions)
-        path, body = self._embed_path_and_body(model, input, dimensions, provider_params)
+        texts = input if isinstance(input, list) else [input]
+        embeddings: list[list[float]] = []
+        input_tokens = 0
         try:
             client = self._get_sync_client()
-            response = client.post(path, json=body, headers=self._request_headers())
+            for chunk in _embed_batches(texts, _max_embed_batch(model)):
+                path, body = self._embed_path_and_body(model, chunk, dimensions, provider_params)
+                response = client.post(path, json=body, headers=self._request_headers())
+                raise_for_status(response)
+                result = self._map_embed_response(response, model)
+                embeddings.extend(result.embeddings)
+                input_tokens += result.usage.input_tokens
+        except LmuxError:
+            raise
         except Exception as e:
             raise map_transport_error(e) from e
-        raise_for_status(response)
-        return self._map_embed_response(response, model)
+        return self._embedding_response(model, embeddings, input_tokens)
 
     @override
     async def aembed(
@@ -359,14 +368,23 @@ class GoogleProvider(
     ) -> EmbeddingResponse:
         if self._vertexai and _uses_embed_content(model):
             return await self._aembed_content(model, input, dimensions)
-        path, body = self._embed_path_and_body(model, input, dimensions, provider_params)
+        texts = input if isinstance(input, list) else [input]
+        embeddings: list[list[float]] = []
+        input_tokens = 0
         try:
             client = await self._get_async_client()
-            response = await client.post(path, json=body, headers=await self._arequest_headers())
+            for chunk in _embed_batches(texts, _max_embed_batch(model)):
+                path, body = self._embed_path_and_body(model, chunk, dimensions, provider_params)
+                response = await client.post(path, json=body, headers=await self._arequest_headers())
+                raise_for_status(response)
+                result = self._map_embed_response(response, model)
+                embeddings.extend(result.embeddings)
+                input_tokens += result.usage.input_tokens
+        except LmuxError:
+            raise
         except Exception as e:
             raise map_transport_error(e) from e
-        raise_for_status(response)
-        return self._map_embed_response(response, model)
+        return self._embedding_response(model, embeddings, input_tokens)
 
     def _embed_content(self, model: str, input: str | list[str], dimensions: int | None) -> EmbeddingResponse:  # noqa: A002
         # Vertex serves Gemini Embedding 2 models only through :embedContent, which takes a single
@@ -599,6 +617,28 @@ class GoogleProvider(
 def _uses_embed_content(model: str) -> bool:
     """Gemini Embedding 2 models are served on Vertex only through :embedContent (not :predict)."""
     return model.startswith("gemini-embedding-2")
+
+
+def _max_embed_batch(model: str) -> int | None:
+    """Max inputs per embedding request, or None for no limit (send the whole batch at once).
+
+    The Gemini Embedding family (gemini-embedding-001, gemini-embedding-2, ...) accepts exactly one
+    input per request; a multi-input request is not batched — on the Developer API it silently returns
+    a single aggregated embedding, and on Vertex :predict it is rejected. So a list is split into
+    single-input requests. (On Vertex the gemini-embedding-2 models take the :embedContent path and
+    never reach here; this covers gemini-embedding-001 on both transports and gemini-embedding-2 on
+    the Developer API.) The text-embedding-* / text-multilingual-embedding-* models batch normally.
+    """
+    return 1 if model.startswith("gemini-embedding-") else None
+
+
+def _embed_batches(texts: list[str], limit: int | None) -> Iterator[list[str]]:
+    """Yield ``texts`` as request-sized batches: one batch of all texts when ``limit`` is None."""
+    if limit is None:
+        yield texts
+        return
+    for start in range(0, len(texts), limit):
+        yield texts[start : start + limit]
 
 
 def _embed_content_body(text: str, dimensions: int | None) -> Json:

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -344,7 +344,7 @@ class GoogleProvider(
         input_tokens = 0
         try:
             client = self._get_sync_client()
-            for chunk in _embed_batches(texts, _max_embed_batch(model)):
+            for chunk in _embed_batches(texts, self._max_embed_batch(model)):
                 path, body = self._embed_path_and_body(model, chunk, dimensions, provider_params)
                 response = client.post(path, json=body, headers=self._request_headers())
                 raise_for_status(response)
@@ -373,7 +373,7 @@ class GoogleProvider(
         input_tokens = 0
         try:
             client = await self._get_async_client()
-            for chunk in _embed_batches(texts, _max_embed_batch(model)):
+            for chunk in _embed_batches(texts, self._max_embed_batch(model)):
                 path, body = self._embed_path_and_body(model, chunk, dimensions, provider_params)
                 response = await client.post(path, json=body, headers=await self._arequest_headers())
                 raise_for_status(response)
@@ -437,6 +437,19 @@ class GoogleProvider(
             model=model,
             provider=PROVIDER_NAME,
         )
+
+    def _max_embed_batch(self, model: str) -> int | None:
+        """Max inputs per embedding request, or None to send the whole list in one request.
+
+        Vertex's :predict endpoint serves gemini-embedding-001 one input at a time, so a list is split
+        into single-input requests there. The Developer API's :batchEmbedContents accepts the whole
+        list and returns one embedding per request (its single-aggregated-embedding behavior only
+        applies to multiple inputs within one Content, which is never how these requests are built),
+        and the text-embedding-* models batch normally — so every other path sends one request.
+        """
+        if self._vertexai and model.startswith("gemini-embedding-001"):
+            return 1
+        return None
 
     # MARK: Internal Helpers
 
@@ -617,19 +630,6 @@ class GoogleProvider(
 def _uses_embed_content(model: str) -> bool:
     """Gemini Embedding 2 models are served on Vertex only through :embedContent (not :predict)."""
     return model.startswith("gemini-embedding-2")
-
-
-def _max_embed_batch(model: str) -> int | None:
-    """Max inputs per embedding request, or None for no limit (send the whole batch at once).
-
-    The Gemini Embedding family (gemini-embedding-001, gemini-embedding-2, ...) accepts exactly one
-    input per request; a multi-input request is not batched — on the Developer API it silently returns
-    a single aggregated embedding, and on Vertex :predict it is rejected. So a list is split into
-    single-input requests. (On Vertex the gemini-embedding-2 models take the :embedContent path and
-    never reach here; this covers gemini-embedding-001 on both transports and gemini-embedding-2 on
-    the Developer API.) The text-embedding-* / text-multilingual-embedding-* models batch normally.
-    """
-    return 1 if model.startswith("gemini-embedding-") else None
 
 
 def _embed_batches(texts: list[str], limit: int | None) -> Iterator[list[str]]:

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -49,10 +49,12 @@ from lmux_google._mappers import (
     map_response_format,
     map_tool_choice,
     map_tools,
+    map_vertex_embed_response,
 )
 from lmux_google._wire import (
     WireBatchEmbeddingsResponse,
     WireGenerateContentResponse,
+    WireVertexPredictResponse,
 )
 from lmux_google.auth import GoogleADCAuthProvider
 from lmux_google.cost import calculate_google_cost
@@ -92,6 +94,7 @@ class GoogleProvider(
         self._sync_client: httpx.Client | None = None
         self._async_client: httpx.AsyncClient | None = None
         self._async_loop: asyncio.AbstractEventLoop | None = None
+        self._credentials: Credentials | None = None
         self._custom_pricing: dict[str, ModelPricing] = {}
 
     # MARK: Pricing
@@ -111,10 +114,25 @@ class GoogleProvider(
     def _base_url(self) -> str:
         return vertex_base_url(self._location) if self._vertexai else GEMINI_BASE_URL
 
-    def _headers(self, auth_result: "Credentials | str") -> Mapping[str, str]:
+    def _static_headers(self, auth_result: "Credentials | str") -> Mapping[str, str]:
+        # API keys are static and baked into the cached client; Vertex bearer tokens are
+        # short-lived and applied per request (see _request_headers) so they refresh rather
+        # than freeze on a long-lived provider.
         if isinstance(auth_result, str):
             return api_key_headers(auth_result)
-        return bearer_headers(bearer_token(auth_result))
+        return {"Content-Type": "application/json"}
+
+    def _request_headers(self) -> Mapping[str, str]:
+        if self._credentials is None:
+            return {}
+        return bearer_headers(bearer_token(self._credentials))
+
+    async def _arequest_headers(self) -> Mapping[str, str]:
+        if self._credentials is None:
+            return {}
+        # Credential refresh does blocking HTTP; run it off the event loop.
+        token = await asyncio.to_thread(bearer_token, self._credentials)
+        return bearer_headers(token)
 
     def _path(self, model: str, method: str, *, sse: bool = False) -> str:
         suffix = "?alt=sse" if sse else ""
@@ -130,9 +148,10 @@ class GoogleProvider(
     def _get_sync_client(self) -> "httpx.Client":
         if self._sync_client is None:
             auth_result = self._auth.get_credentials()
+            self._credentials = auth_result if not isinstance(auth_result, str) else None
             self._sync_client = create_sync_client(
                 base_url=self._base_url(),
-                headers=self._headers(auth_result),
+                headers=self._static_headers(auth_result),
                 timeout=self._timeout,
                 max_retries=self._max_retries,
             )
@@ -142,9 +161,10 @@ class GoogleProvider(
         loop = asyncio.get_running_loop()
         if self._async_client is None or self._async_loop is not loop:
             auth_result = await self._auth.aget_credentials()
+            self._credentials = auth_result if not isinstance(auth_result, str) else None
             self._async_client = create_async_client(
                 base_url=self._base_url(),
-                headers=self._headers(auth_result),
+                headers=self._static_headers(auth_result),
                 timeout=self._timeout,
                 max_retries=self._max_retries,
             )
@@ -183,7 +203,7 @@ class GoogleProvider(
         path = self._path(model, "generateContent")
         try:
             client = self._get_sync_client()
-            response = client.post(path, json=body)
+            response = client.post(path, json=body, headers=self._request_headers())
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
@@ -214,7 +234,7 @@ class GoogleProvider(
         path = self._path(model, "generateContent")
         try:
             client = await self._get_async_client()
-            response = await client.post(path, json=body)
+            response = await client.post(path, json=body, headers=await self._arequest_headers())
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
@@ -245,10 +265,11 @@ class GoogleProvider(
         path = self._path(model, "streamGenerateContent", sse=True)
         try:
             client = self._get_sync_client()
+            headers = self._request_headers()
         except Exception as e:
             raise map_transport_error(e) from e
         try:
-            with client.stream("POST", path, json=body) as response:
+            with client.stream("POST", path, json=body, headers=headers) as response:
                 if response.status_code >= _HTTP_ERROR:
                     response.read()
                     raise error_from_response(response)  # noqa: TRY301
@@ -285,10 +306,11 @@ class GoogleProvider(
         path = self._path(model, "streamGenerateContent", sse=True)
         try:
             client = await self._get_async_client()
+            headers = await self._arequest_headers()
         except Exception as e:
             raise map_transport_error(e) from e
         try:
-            async with client.stream("POST", path, json=body) as response:
+            async with client.stream("POST", path, json=body, headers=headers) as response:
                 if response.status_code >= _HTTP_ERROR:
                     await response.aread()
                     raise error_from_response(response)  # noqa: TRY301
@@ -313,17 +335,14 @@ class GoogleProvider(
         dimensions: int | None = None,
         provider_params: GoogleParams | None = None,
     ) -> EmbeddingResponse:
-        body = self._build_embed_body(model, input, dimensions, provider_params)
-        path = self._path(model, "batchEmbedContents")
+        path, body = self._embed_path_and_body(model, input, dimensions, provider_params)
         try:
             client = self._get_sync_client()
-            response = client.post(path, json=body)
+            response = client.post(path, json=body, headers=self._request_headers())
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_batch_embeddings_response(
-            parse_body(response, WireBatchEmbeddingsResponse), model, PROVIDER_NAME, self._calculate_cost
-        )
+        return self._map_embed_response(response, model)
 
     @override
     async def aembed(
@@ -334,17 +353,14 @@ class GoogleProvider(
         dimensions: int | None = None,
         provider_params: GoogleParams | None = None,
     ) -> EmbeddingResponse:
-        body = self._build_embed_body(model, input, dimensions, provider_params)
-        path = self._path(model, "batchEmbedContents")
+        path, body = self._embed_path_and_body(model, input, dimensions, provider_params)
         try:
             client = await self._get_async_client()
-            response = await client.post(path, json=body)
+            response = await client.post(path, json=body, headers=await self._arequest_headers())
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_batch_embeddings_response(
-            parse_body(response, WireBatchEmbeddingsResponse), model, PROVIDER_NAME, self._calculate_cost
-        )
+        return self._map_embed_response(response, model)
 
     # MARK: Internal Helpers
 
@@ -353,6 +369,29 @@ class GoogleProvider(
         if mapped.usage is not None:
             mapped = mapped.model_copy(update={"cost": self._calculate_cost(model, mapped.usage)})
         return mapped
+
+    def _embed_path_and_body(
+        self,
+        model: str,
+        input: str | list[str],  # noqa: A002
+        dimensions: int | None,
+        provider_params: GoogleParams | None,
+    ) -> tuple[str, Json]:
+        # Vertex AI serves embeddings through the generic ``:predict`` endpoint (instances/parameters),
+        # while the Gemini Developer API uses ``:batchEmbedContents`` (requests/content).
+        if self._vertexai:
+            return self._path(model, "predict"), self._build_vertex_embed_body(input, dimensions, provider_params)
+        body = self._build_embed_body(model, input, dimensions, provider_params)
+        return self._path(model, "batchEmbedContents"), body
+
+    def _map_embed_response(self, response: "httpx.Response", model: str) -> EmbeddingResponse:
+        if self._vertexai:
+            return map_vertex_embed_response(
+                parse_body(response, WireVertexPredictResponse), model, PROVIDER_NAME, self._calculate_cost
+            )
+        return map_batch_embeddings_response(
+            parse_body(response, WireBatchEmbeddingsResponse), model, PROVIDER_NAME, self._calculate_cost
+        )
 
     @staticmethod
     def _build_embed_body(
@@ -371,6 +410,24 @@ class GoogleProvider(
                 req["taskType"] = provider_params.task_type
             requests.append(req)
         return {"requests": requests}
+
+    @staticmethod
+    def _build_vertex_embed_body(
+        input: str | list[str],  # noqa: A002
+        dimensions: int | None,
+        provider_params: GoogleParams | None,
+    ) -> Json:
+        texts = input if isinstance(input, list) else [input]
+        instances: list[Json] = []
+        for text in texts:
+            instance: Json = {"content": text}
+            if provider_params is not None and provider_params.task_type is not None:
+                instance["task_type"] = provider_params.task_type
+            instances.append(instance)
+        body: Json = {"instances": instances}
+        if dimensions is not None:
+            body["parameters"] = {"outputDimensionality": dimensions}
+        return body
 
     @staticmethod
     def _build_body(  # noqa: PLR0913, PLR0912
@@ -403,7 +460,9 @@ class GoogleProvider(
             if mime_type is not None:
                 gen["responseMimeType"] = mime_type
             if schema is not None:
-                gen["responseSchema"] = schema
+                # responseJsonSchema accepts full JSON Schema (incl. $defs/$ref); responseSchema
+                # is the narrower OpenAPI-style shape that rejects those constructs.
+                gen["responseJsonSchema"] = schema
         if reasoning_effort is not None:
             gen["thinkingConfig"] = {"thinkingBudget": _THINKING_BUDGETS[reasoning_effort], "includeThoughts": True}
         if tools is not None:

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -28,7 +28,7 @@ from lmux_google._exceptions import (
     error_from_response,
     error_from_stream,
     map_transport_error,
-    parse_json,
+    parse_body,
     raise_for_status,
 )
 from lmux_google._lazy import (
@@ -49,6 +49,10 @@ from lmux_google._mappers import (
     map_response_format,
     map_tool_choice,
     map_tools,
+)
+from lmux_google._wire import (
+    WireBatchEmbeddingsResponse,
+    WireGenerateContentResponse,
 )
 from lmux_google.auth import GoogleADCAuthProvider
 from lmux_google.cost import calculate_google_cost
@@ -183,7 +187,9 @@ class GoogleProvider(
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_generate_content_response(parse_json(response), model, PROVIDER_NAME, self._calculate_cost)
+        return map_generate_content_response(
+            parse_body(response, WireGenerateContentResponse), model, PROVIDER_NAME, self._calculate_cost
+        )
 
     @override
     async def achat(
@@ -212,7 +218,9 @@ class GoogleProvider(
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_generate_content_response(parse_json(response), model, PROVIDER_NAME, self._calculate_cost)
+        return map_generate_content_response(
+            parse_body(response, WireGenerateContentResponse), model, PROVIDER_NAME, self._calculate_cost
+        )
 
     @override
     def chat_stream(
@@ -313,7 +321,9 @@ class GoogleProvider(
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_batch_embeddings_response(parse_json(response), model, PROVIDER_NAME, self._calculate_cost)
+        return map_batch_embeddings_response(
+            parse_body(response, WireBatchEmbeddingsResponse), model, PROVIDER_NAME, self._calculate_cost
+        )
 
     @override
     async def aembed(
@@ -332,12 +342,14 @@ class GoogleProvider(
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_batch_embeddings_response(parse_json(response), model, PROVIDER_NAME, self._calculate_cost)
+        return map_batch_embeddings_response(
+            parse_body(response, WireBatchEmbeddingsResponse), model, PROVIDER_NAME, self._calculate_cost
+        )
 
     # MARK: Internal Helpers
 
     def _map_stream_chunk(self, chunk: Json, model: str) -> ChatChunk:
-        mapped = map_generate_content_chunk(chunk, model, PROVIDER_NAME)
+        mapped = map_generate_content_chunk(WireGenerateContentResponse.model_validate(chunk), model, PROVIDER_NAME)
         if mapped.usage is not None:
             mapped = mapped.model_copy(update={"cost": self._calculate_cost(model, mapped.usage)})
         return mapped

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -24,7 +24,13 @@ from lmux.types import (
     ToolChoice,
     Usage,
 )
-from lmux_google._exceptions import error_from_response, map_transport_error, raise_for_status
+from lmux_google._exceptions import (
+    error_from_response,
+    error_from_stream,
+    map_transport_error,
+    parse_json,
+    raise_for_status,
+)
 from lmux_google._lazy import (
     GEMINI_BASE_URL,
     api_key_headers,
@@ -177,7 +183,7 @@ class GoogleProvider(
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_generate_content_response(response.json(), model, PROVIDER_NAME, self._calculate_cost)
+        return map_generate_content_response(parse_json(response), model, PROVIDER_NAME, self._calculate_cost)
 
     @override
     async def achat(
@@ -206,7 +212,7 @@ class GoogleProvider(
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_generate_content_response(response.json(), model, PROVIDER_NAME, self._calculate_cost)
+        return map_generate_content_response(parse_json(response), model, PROVIDER_NAME, self._calculate_cost)
 
     @override
     def chat_stream(
@@ -239,7 +245,10 @@ class GoogleProvider(
                     response.read()
                     raise error_from_response(response)  # noqa: TRY301
                 for _event, data in iter_sse(response):
-                    yield self._map_stream_chunk(json.loads(data), model)
+                    chunk = json.loads(data)
+                    if "error" in chunk:
+                        raise error_from_stream(chunk)  # noqa: TRY301
+                    yield self._map_stream_chunk(chunk, model)
         except LmuxError:
             raise
         except Exception as e:
@@ -276,7 +285,10 @@ class GoogleProvider(
                     await response.aread()
                     raise error_from_response(response)  # noqa: TRY301
                 async for _event, data in aiter_sse(response):
-                    yield self._map_stream_chunk(json.loads(data), model)
+                    chunk = json.loads(data)
+                    if "error" in chunk:
+                        raise error_from_stream(chunk)  # noqa: TRY301
+                    yield self._map_stream_chunk(chunk, model)
         except LmuxError:
             raise
         except Exception as e:
@@ -301,7 +313,7 @@ class GoogleProvider(
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_batch_embeddings_response(response.json(), model, PROVIDER_NAME, self._calculate_cost)
+        return map_batch_embeddings_response(parse_json(response), model, PROVIDER_NAME, self._calculate_cost)
 
     @override
     async def aembed(
@@ -320,7 +332,7 @@ class GoogleProvider(
         except Exception as e:
             raise map_transport_error(e) from e
         raise_for_status(response)
-        return map_batch_embeddings_response(response.json(), model, PROVIDER_NAME, self._calculate_cost)
+        return map_batch_embeddings_response(parse_json(response), model, PROVIDER_NAME, self._calculate_cost)
 
     # MARK: Internal Helpers
 

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -1,14 +1,17 @@
-"""Google provider implementation."""
+"""Google (Gemini) provider implementation (SDK-lite, httpx transport)."""
 
 import asyncio
-from collections.abc import AsyncIterator, Iterator, Sequence
-from typing import TYPE_CHECKING, Any, Literal, override
+import json
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Literal, override
 
 if TYPE_CHECKING:
+    import httpx
     from google.auth.credentials import Credentials
-    from google.genai import Client
 
+from lmux._http import aiter_sse, iter_sse
 from lmux.cost import ModelPricing, calculate_cost
+from lmux.exceptions import LmuxError, ProviderError
 from lmux.protocols import AuthProvider, CompletionProvider, EmbeddingProvider, PricingProvider
 from lmux.types import (
     ChatChunk,
@@ -21,10 +24,19 @@ from lmux.types import (
     ToolChoice,
     Usage,
 )
-from lmux_google._exceptions import map_google_error
-from lmux_google._lazy import create_client
+from lmux_google._exceptions import error_from_response, map_transport_error, raise_for_status
+from lmux_google._lazy import (
+    GEMINI_BASE_URL,
+    api_key_headers,
+    bearer_headers,
+    bearer_token,
+    create_async_client,
+    create_sync_client,
+    vertex_base_url,
+)
 from lmux_google._mappers import (
-    map_embed_content_response,
+    Json,
+    map_batch_embeddings_response,
     map_generate_content_chunk,
     map_generate_content_response,
     map_messages,
@@ -40,27 +52,35 @@ type GoogleAuth = AuthProvider["Credentials | str", "Credentials | str"]
 
 PROVIDER_NAME = "google"
 
+_HTTP_ERROR = 400
+_THINKING_BUDGETS: dict[str, int] = {"low": 1024, "medium": 8192, "high": 32768}
+
 
 class GoogleProvider(
     CompletionProvider[GoogleParams],
     EmbeddingProvider[GoogleParams],
     PricingProvider,
 ):
-    """Google provider using the google-genai SDK (Vertex AI or the Gemini Developer API)."""
+    """Google provider over httpx (Vertex AI or the Gemini Developer API)."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         auth: GoogleAuth | None = None,
         project: str | None = None,
         location: str | None = None,
         vertexai: bool = True,
+        timeout: float | None = None,
+        max_retries: int | None = None,
     ) -> None:
         self._auth: GoogleAuth = auth or GoogleADCAuthProvider()
         self._project: str | None = project
         self._location: str | None = location
         self._vertexai: bool = vertexai
-        self._client: Client | None = None
+        self._timeout: float | None = timeout
+        self._max_retries: int | None = max_retries
+        self._sync_client: httpx.Client | None = None
+        self._async_client: httpx.AsyncClient | None = None
         self._async_loop: asyncio.AbstractEventLoop | None = None
         self._custom_pricing: dict[str, ModelPricing] = {}
 
@@ -78,40 +98,54 @@ class GoogleProvider(
 
     # MARK: Client Management
 
-    def _get_client(self) -> "Client":
-        if self._client is None:
-            auth_result = self._auth.get_credentials()
-            credentials, api_key = (None, auth_result) if isinstance(auth_result, str) else (auth_result, None)
-            self._client = create_client(
-                vertexai=self._vertexai,
-                project=self._project,
-                location=self._location,
-                credentials=credentials,
-                api_key=api_key,
-            )
-        return self._client
+    def _base_url(self) -> str:
+        return vertex_base_url(self._location) if self._vertexai else GEMINI_BASE_URL
 
-    async def _aget_client(self) -> "Client":
+    def _headers(self, auth_result: "Credentials | str") -> Mapping[str, str]:
+        if isinstance(auth_result, str):
+            return api_key_headers(auth_result)
+        return bearer_headers(bearer_token(auth_result))
+
+    def _path(self, model: str, method: str, *, sse: bool = False) -> str:
+        suffix = "?alt=sse" if sse else ""
+        if self._vertexai:
+            if self._project is None:
+                msg = "Vertex AI requires a project; pass project=... to GoogleProvider or use vertexai=False"
+                raise ProviderError(msg, provider=PROVIDER_NAME)
+            location = self._location or "global"
+            base = f"/v1/projects/{self._project}/locations/{location}/publishers/google/models"
+            return f"{base}/{model}:{method}{suffix}"
+        return f"/v1beta/models/{model}:{method}{suffix}"
+
+    def _get_sync_client(self) -> "httpx.Client":
+        if self._sync_client is None:
+            auth_result = self._auth.get_credentials()
+            self._sync_client = create_sync_client(
+                base_url=self._base_url(),
+                headers=self._headers(auth_result),
+                timeout=self._timeout,
+                max_retries=self._max_retries,
+            )
+        return self._sync_client
+
+    async def _get_async_client(self) -> "httpx.AsyncClient":
         loop = asyncio.get_running_loop()
-        if self._client is None or self._async_loop is not loop:
-            self._client = None
+        if self._async_client is None or self._async_loop is not loop:
             auth_result = await self._auth.aget_credentials()
-            credentials, api_key = (None, auth_result) if isinstance(auth_result, str) else (auth_result, None)
-            self._client = create_client(
-                vertexai=self._vertexai,
-                project=self._project,
-                location=self._location,
-                credentials=credentials,
-                api_key=api_key,
+            self._async_client = create_async_client(
+                base_url=self._base_url(),
+                headers=self._headers(auth_result),
+                timeout=self._timeout,
+                max_retries=self._max_retries,
             )
             self._async_loop = loop
-        return self._client
+        return self._async_client
 
     async def aclose(self) -> None:
         """Close the underlying async HTTP client."""
-        if self._client is not None:
-            await self._client.aio.aclose()
-            self._client = None
+        if self._async_client is not None:
+            await self._async_client.aclose()
+            self._async_client = None
             self._async_loop = None
 
     # MARK: Chat
@@ -132,29 +166,18 @@ class GoogleProvider(
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         provider_params: GoogleParams | None = None,
     ) -> ChatResponse:
-        system, contents = map_messages(messages)
-        config = self._build_config(
-            system,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+        body = self._build_body(
+            messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params,
+        )  # fmt: skip
+        path = self._path(model, "generateContent")
         try:
-            client = self._get_client()
-            response = client.models.generate_content(
-                model=model,
-                contents=contents,
-                config=config,  # ty: ignore[invalid-argument-type]
-            )
+            client = self._get_sync_client()
+            response = client.post(path, json=body)
         except Exception as e:
-            raise map_google_error(e) from e
-        return map_generate_content_response(response, model, PROVIDER_NAME, self._calculate_cost)
+            raise map_transport_error(e) from e
+        raise_for_status(response)
+        return map_generate_content_response(response.json(), model, PROVIDER_NAME, self._calculate_cost)
 
     @override
     async def achat(
@@ -172,29 +195,18 @@ class GoogleProvider(
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         provider_params: GoogleParams | None = None,
     ) -> ChatResponse:
-        system, contents = map_messages(messages)
-        config = self._build_config(
-            system,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+        body = self._build_body(
+            messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params,
+        )  # fmt: skip
+        path = self._path(model, "generateContent")
         try:
-            client = await self._aget_client()
-            response = await client.aio.models.generate_content(
-                model=model,
-                contents=contents,
-                config=config,  # ty: ignore[invalid-argument-type]
-            )
+            client = await self._get_async_client()
+            response = await client.post(path, json=body)
         except Exception as e:
-            raise map_google_error(e) from e
-        return map_generate_content_response(response, model, PROVIDER_NAME, self._calculate_cost)
+            raise map_transport_error(e) from e
+        raise_for_status(response)
+        return map_generate_content_response(response.json(), model, PROVIDER_NAME, self._calculate_cost)
 
     @override
     def chat_stream(
@@ -212,37 +224,26 @@ class GoogleProvider(
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         provider_params: GoogleParams | None = None,
     ) -> Iterator[ChatChunk]:
-        system, contents = map_messages(messages)
-        config = self._build_config(
-            system,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+        body = self._build_body(
+            messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params,
+        )  # fmt: skip
+        path = self._path(model, "streamGenerateContent", sse=True)
         try:
-            client = self._get_client()
-            stream = client.models.generate_content_stream(
-                model=model,
-                contents=contents,
-                config=config,  # ty: ignore[invalid-argument-type]
-            )
+            client = self._get_sync_client()
         except Exception as e:
-            raise map_google_error(e) from e
-
+            raise map_transport_error(e) from e
         try:
-            for chunk in stream:
-                mapped = map_generate_content_chunk(chunk, model, PROVIDER_NAME)
-                if mapped.usage is not None:
-                    mapped = mapped.model_copy(update={"cost": self._calculate_cost(model, mapped.usage)})
-                yield mapped
+            with client.stream("POST", path, json=body) as response:
+                if response.status_code >= _HTTP_ERROR:
+                    response.read()
+                    raise error_from_response(response)  # noqa: TRY301
+                for _event, data in iter_sse(response):
+                    yield self._map_stream_chunk(json.loads(data), model)
+        except LmuxError:
+            raise
         except Exception as e:
-            raise map_google_error(e) from e
+            raise map_transport_error(e) from e
 
     @override
     async def achat_stream(
@@ -260,33 +261,26 @@ class GoogleProvider(
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         provider_params: GoogleParams | None = None,
     ) -> AsyncIterator[ChatChunk]:
-        system, contents = map_messages(messages)
-        config = self._build_config(
-            system,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+        body = self._build_body(
+            messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params,
+        )  # fmt: skip
+        path = self._path(model, "streamGenerateContent", sse=True)
         try:
-            client = await self._aget_client()
-            stream = client.aio.models.generate_content_stream(
-                model=model,
-                contents=contents,
-                config=config,  # ty: ignore[invalid-argument-type]
-            )
-            async for chunk in await stream:
-                mapped = map_generate_content_chunk(chunk, model, PROVIDER_NAME)
-                if mapped.usage is not None:
-                    mapped = mapped.model_copy(update={"cost": self._calculate_cost(model, mapped.usage)})
-                yield mapped
+            client = await self._get_async_client()
         except Exception as e:
-            raise map_google_error(e) from e
+            raise map_transport_error(e) from e
+        try:
+            async with client.stream("POST", path, json=body) as response:
+                if response.status_code >= _HTTP_ERROR:
+                    await response.aread()
+                    raise error_from_response(response)  # noqa: TRY301
+                async for _event, data in aiter_sse(response):
+                    yield self._map_stream_chunk(json.loads(data), model)
+        except LmuxError:
+            raise
+        except Exception as e:
+            raise map_transport_error(e) from e
 
     # MARK: Embeddings
 
@@ -299,14 +293,15 @@ class GoogleProvider(
         dimensions: int | None = None,
         provider_params: GoogleParams | None = None,
     ) -> EmbeddingResponse:
-        contents = input if isinstance(input, list) else [input]
-        config = self._build_embed_config(dimensions, provider_params)
+        body = self._build_embed_body(model, input, dimensions, provider_params)
+        path = self._path(model, "batchEmbedContents")
         try:
-            client = self._get_client()
-            response = client.models.embed_content(model=model, contents=contents, config=config)  # ty: ignore[invalid-argument-type]
+            client = self._get_sync_client()
+            response = client.post(path, json=body)
         except Exception as e:
-            raise map_google_error(e) from e
-        return map_embed_content_response(response, model, PROVIDER_NAME, self._calculate_cost)
+            raise map_transport_error(e) from e
+        raise_for_status(response)
+        return map_batch_embeddings_response(response.json(), model, PROVIDER_NAME, self._calculate_cost)
 
     @override
     async def aembed(
@@ -317,32 +312,45 @@ class GoogleProvider(
         dimensions: int | None = None,
         provider_params: GoogleParams | None = None,
     ) -> EmbeddingResponse:
-        contents = input if isinstance(input, list) else [input]
-        config = self._build_embed_config(dimensions, provider_params)
+        body = self._build_embed_body(model, input, dimensions, provider_params)
+        path = self._path(model, "batchEmbedContents")
         try:
-            client = await self._aget_client()
-            response = await client.aio.models.embed_content(model=model, contents=contents, config=config)  # ty: ignore[invalid-argument-type]
+            client = await self._get_async_client()
+            response = await client.post(path, json=body)
         except Exception as e:
-            raise map_google_error(e) from e
-        return map_embed_content_response(response, model, PROVIDER_NAME, self._calculate_cost)
+            raise map_transport_error(e) from e
+        raise_for_status(response)
+        return map_batch_embeddings_response(response.json(), model, PROVIDER_NAME, self._calculate_cost)
 
     # MARK: Internal Helpers
 
-    @staticmethod
-    def _build_embed_config(
-        dimensions: int | None,
-        provider_params: GoogleParams | None,
-    ) -> dict[str, Any] | None:
-        config: dict[str, Any] = {}
-        if dimensions is not None:
-            config["output_dimensionality"] = dimensions
-        if provider_params is not None and provider_params.task_type is not None:
-            config["task_type"] = provider_params.task_type
-        return config or None
+    def _map_stream_chunk(self, chunk: Json, model: str) -> ChatChunk:
+        mapped = map_generate_content_chunk(chunk, model, PROVIDER_NAME)
+        if mapped.usage is not None:
+            mapped = mapped.model_copy(update={"cost": self._calculate_cost(model, mapped.usage)})
+        return mapped
 
     @staticmethod
-    def _build_config(  # noqa: PLR0913, PLR0912
-        system_instruction: str | None,
+    def _build_embed_body(
+        model: str,
+        input: str | list[str],  # noqa: A002
+        dimensions: int | None,
+        provider_params: GoogleParams | None,
+    ) -> Json:
+        texts = input if isinstance(input, list) else [input]
+        requests: list[Json] = []
+        for text in texts:
+            req: Json = {"model": f"models/{model}", "content": {"parts": [{"text": text}]}}
+            if dimensions is not None:
+                req["outputDimensionality"] = dimensions
+            if provider_params is not None and provider_params.task_type is not None:
+                req["taskType"] = provider_params.task_type
+            requests.append(req)
+        return {"requests": requests}
+
+    @staticmethod
+    def _build_body(  # noqa: PLR0913, PLR0912
+        messages: Sequence[Message],
         temperature: float | None,
         max_tokens: int | None,
         top_p: float | None,
@@ -352,95 +360,96 @@ class GoogleProvider(
         response_format: ResponseFormat | None,
         reasoning_effort: Literal["low", "medium", "high"] | None,
         provider_params: GoogleParams | None,
-    ) -> dict[str, Any]:
-        config: dict[str, Any] = {}
-        if system_instruction is not None:
-            config["system_instruction"] = system_instruction
+    ) -> Json:
+        system, contents = map_messages(messages)
+        body: Json = {"contents": contents}
+        if system is not None:
+            body["systemInstruction"] = {"parts": [{"text": system}]}
+        gen: Json = {}
         if temperature is not None:
-            config["temperature"] = temperature
+            gen["temperature"] = temperature
         if max_tokens is not None:
-            config["max_output_tokens"] = max_tokens
+            gen["maxOutputTokens"] = max_tokens
         if top_p is not None:
-            config["top_p"] = top_p
+            gen["topP"] = top_p
         if stop is not None:
-            config["stop_sequences"] = [stop] if isinstance(stop, str) else stop
-        if tools is not None:
-            config["tools"] = map_tools(tools)
-        if tool_choice is not None:
-            config["tool_config"] = map_tool_choice(tool_choice)
+            gen["stopSequences"] = [stop] if isinstance(stop, str) else stop
         if response_format is not None:
             mime_type, schema = map_response_format(response_format)
             if mime_type is not None:
-                config["response_mime_type"] = mime_type
+                gen["responseMimeType"] = mime_type
             if schema is not None:
-                config["response_schema"] = schema
+                gen["responseSchema"] = schema
         if reasoning_effort is not None:
-            budget = {"low": 1024, "medium": 8192, "high": 32768}[reasoning_effort]
-            config["thinking_config"] = {"thinking_budget": budget, "include_thoughts": True}
+            gen["thinkingConfig"] = {"thinkingBudget": _THINKING_BUDGETS[reasoning_effort], "includeThoughts": True}
+        if tools is not None:
+            body["tools"] = map_tools(tools)
+        if tool_choice is not None:
+            body["toolConfig"] = map_tool_choice(tool_choice)
         if provider_params is not None:
-            config.update(GoogleProvider._provider_params_kwargs(provider_params))
-            special_tools = GoogleProvider._build_special_tools(provider_params)
-            if special_tools:
-                config.setdefault("tools", []).extend(special_tools)
-        return config
+            GoogleProvider._apply_provider_params(body, gen, provider_params)
+        if gen:
+            body["generationConfig"] = gen
+        return body
 
     @staticmethod
-    def _provider_params_kwargs(params: GoogleParams) -> dict[str, Any]:
-        """Convert GoogleParams to kwargs for GenerateContentConfig."""
-        kwargs: dict[str, Any] = {}
+    def _apply_provider_params(body: Json, gen: Json, params: GoogleParams) -> None:
+        """Merge GoogleParams into the request ``body`` and ``generationConfig`` in place."""
         if params.safety_settings is not None:
-            kwargs["safety_settings"] = [
+            body["safetySettings"] = [
                 {"category": s.category, "threshold": s.threshold} for s in params.safety_settings
             ]
         if params.presence_penalty is not None:
-            kwargs["presence_penalty"] = params.presence_penalty
+            gen["presencePenalty"] = params.presence_penalty
         if params.frequency_penalty is not None:
-            kwargs["frequency_penalty"] = params.frequency_penalty
+            gen["frequencyPenalty"] = params.frequency_penalty
         if params.seed is not None:
-            kwargs["seed"] = params.seed
+            gen["seed"] = params.seed
         if params.labels is not None:
-            kwargs["labels"] = params.labels
+            body["labels"] = params.labels
         if params.thinking_config is not None:
-            kwargs["thinking_config"] = params.thinking_config
-        return kwargs
+            gen["thinkingConfig"] = params.thinking_config
+        special_tools = GoogleProvider._build_special_tools(params)
+        if special_tools:
+            body.setdefault("tools", []).extend(special_tools)
 
     @staticmethod
-    def _build_special_tools(params: GoogleParams) -> list[dict[str, Any]]:
-        """Convert special tool params to google-genai tool dicts."""
-        tools: list[dict[str, Any]] = []
+    def _build_special_tools(params: GoogleParams) -> list[Json]:
+        """Convert special tool params to Gemini tool dicts."""
+        tools: list[Json] = []
         if params.google_search is not None:
             if params.google_search is True:
-                tools.append({"google_search": {}})
+                tools.append({"googleSearch": {}})
             elif isinstance(params.google_search, GoogleSearchConfig):
-                tools.append({"google_search": GoogleProvider._build_google_search_dict(params.google_search)})
+                tools.append({"googleSearch": GoogleProvider._build_google_search_dict(params.google_search)})
         if params.google_search_retrieval is not None:
-            gsr_dict: dict[str, Any] = {}
+            gsr_dict: Json = {}
             drc = params.google_search_retrieval.dynamic_retrieval_config
             if drc is not None:
-                drc_dict: dict[str, Any] = {}
+                drc_dict: Json = {}
                 if drc.mode is not None:
                     drc_dict["mode"] = drc.mode
                 if drc.dynamic_threshold is not None:
-                    drc_dict["dynamic_threshold"] = drc.dynamic_threshold
+                    drc_dict["dynamicThreshold"] = drc.dynamic_threshold
                 if drc_dict:
-                    gsr_dict["dynamic_retrieval_config"] = drc_dict
-            tools.append({"google_search_retrieval": gsr_dict})
+                    gsr_dict["dynamicRetrievalConfig"] = drc_dict
+            tools.append({"googleSearchRetrieval": gsr_dict})
         if params.code_execution is True:
-            tools.append({"code_execution": {}})
+            tools.append({"codeExecution": {}})
         return tools
 
     @staticmethod
-    def _build_google_search_dict(config: GoogleSearchConfig) -> dict[str, Any]:
-        """Convert GoogleSearchConfig to a google-genai tool dict."""
-        gs_dict: dict[str, Any] = {}
+    def _build_google_search_dict(config: GoogleSearchConfig) -> Json:
+        """Convert GoogleSearchConfig to a Gemini tool dict."""
+        gs_dict: Json = {}
         if config.search_types is not None:
-            st_dict: dict[str, Any] = {}
+            st_dict: Json = {}
             if config.search_types.web_search is True:
-                st_dict["web_search"] = {}
+                st_dict["webSearch"] = {}
             if config.search_types.image_search is True:
-                st_dict["image_search"] = {}
+                st_dict["imageSearch"] = {}
             if st_dict:
-                gs_dict["search_types"] = st_dict
+                gs_dict["searchTypes"] = st_dict
         if config.exclude_domains is not None:
-            gs_dict["exclude_domains"] = config.exclude_domains
+            gs_dict["excludeDomains"] = config.exclude_domains
         return gs_dict

--- a/packages/lmux-google/tests/test_exceptions.py
+++ b/packages/lmux-google/tests/test_exceptions.py
@@ -17,9 +17,10 @@ from lmux_google._exceptions import (
     error_from_response,
     error_from_stream,
     map_transport_error,
-    parse_json,
+    parse_body,
     raise_for_status,
 )
+from lmux_google._wire import WireGenerateContentResponse
 
 
 def _resp(status: int, *, json: object = None, text: str = "", headers: dict[str, str] | None = None) -> httpx.Response:
@@ -92,17 +93,19 @@ class TestMapTransportError:
         assert isinstance(map_transport_error(Exception("boom")), ProviderError)
 
 
-class TestParseJson:
+class TestParseBody:
     def test_valid_body(self) -> None:
-        assert parse_json(_resp(200, json={"ok": 1})) == {"ok": 1}
+        body = {"candidates": [{"content": {"parts": [{"text": "hi"}]}, "finishReason": "STOP"}]}
+        result = parse_body(_resp(200, json=body), WireGenerateContentResponse)
+        assert result == WireGenerateContentResponse.model_validate(body)
 
     def test_malformed_body_maps_to_provider_error(self) -> None:
         with pytest.raises(ProviderError):
-            parse_json(_resp(200, text="not json"))
+            parse_body(_resp(200, text="not json"), WireGenerateContentResponse)
 
     def test_non_object_body_maps_to_provider_error(self) -> None:
         with pytest.raises(ProviderError):
-            parse_json(_resp(200, json=["not", "an", "object"]))
+            parse_body(_resp(200, json=["not", "an", "object"]), WireGenerateContentResponse)
 
 
 class TestErrorFromStream:

--- a/packages/lmux-google/tests/test_exceptions.py
+++ b/packages/lmux-google/tests/test_exceptions.py
@@ -118,3 +118,10 @@ class TestErrorFromStream:
         err = error_from_stream({"error": "raw string error"})
         assert isinstance(err, ProviderError)
         assert "raw string error" in str(err)
+
+    def test_embedded_code_maps_to_typed_error(self) -> None:
+        # A mid-stream 429 must stay catchable as RateLimitError, not collapse to a bare ProviderError.
+        err = error_from_stream({"error": {"code": 429, "message": "slow down"}})
+        assert isinstance(err, RateLimitError)
+        assert err.status_code == 429
+        assert "slow down" in str(err)

--- a/packages/lmux-google/tests/test_exceptions.py
+++ b/packages/lmux-google/tests/test_exceptions.py
@@ -1,169 +1,85 @@
-"""Tests for Google exception mapping."""
+"""Tests for Google HTTP error mapping."""
 
+import httpx
 import pytest
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
-from google.genai.errors import APIError, ClientError, ServerError
 
 from lmux.exceptions import (
     AuthenticationError,
     InvalidRequestError,
-    LmuxError,
     NotFoundError,
     ProviderError,
     RateLimitError,
     TimeoutError,  # noqa: A004
 )
-from lmux_google._exceptions import map_google_error
-
-# MARK: Fixtures
+from lmux_google._exceptions import error_from_response, map_transport_error, raise_for_status
 
 
-@pytest.fixture
-def client_error_400() -> ClientError:
-    return ClientError(code=400, response_json={"error": {"message": "bad request"}})
+def _resp(status: int, *, json: object = None, text: str = "", headers: dict[str, str] | None = None) -> httpx.Response:
+    if json is not None:
+        return httpx.Response(status, json=json, headers=headers or {})
+    return httpx.Response(status, text=text, headers=headers or {})
 
 
-@pytest.fixture
-def client_error_401() -> ClientError:
-    return ClientError(code=401, response_json={"error": {"message": "unauthenticated"}})
+class TestRaiseForStatus:
+    def test_ok_does_not_raise(self) -> None:
+        raise_for_status(_resp(200, json={}))
+
+    def test_error_raises(self) -> None:
+        with pytest.raises(InvalidRequestError):
+            raise_for_status(_resp(400, json={"error": {"message": "bad"}}))
 
 
-@pytest.fixture
-def client_error_403() -> ClientError:
-    return ClientError(code=403, response_json={"error": {"message": "permission denied"}})
-
-
-@pytest.fixture
-def client_error_404() -> ClientError:
-    return ClientError(code=404, response_json={"error": {"message": "not found"}})
-
-
-@pytest.fixture
-def client_error_408() -> ClientError:
-    return ClientError(code=408, response_json={"error": {"message": "timeout"}})
-
-
-@pytest.fixture
-def client_error_429() -> ClientError:
-    return ClientError(code=429, response_json={"error": {"message": "rate limited"}})
-
-
-@pytest.fixture
-def client_error_unknown() -> ClientError:
-    return ClientError(code=418, response_json={"error": {"message": "teapot"}})
-
-
-@pytest.fixture
-def server_error_500() -> ServerError:
-    return ServerError(code=500, response_json={"error": {"message": "internal error"}})
-
-
-@pytest.fixture
-def api_error_502() -> APIError:
-    return APIError(code=502, response_json={"error": {"message": "bad gateway"}})
-
-
-@pytest.fixture
-def default_credentials_error() -> DefaultCredentialsError:
-    return DefaultCredentialsError("Could not find default credentials")
-
-
-@pytest.fixture
-def refresh_error() -> RefreshError:
-    return RefreshError("Token refresh failed")
-
-
-# MARK: Tests
-
-
-class TestMapGoogleError:
-    def test_client_error_400(self, client_error_400: ClientError) -> None:
-        result = map_google_error(client_error_400)
-        assert isinstance(result, InvalidRequestError)
-        assert result.provider == "google"
-        assert result.status_code == 400
-
-    def test_client_error_401(self, client_error_401: ClientError) -> None:
-        result = map_google_error(client_error_401)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "google"
-        assert result.status_code == 401
-
-    def test_client_error_403(self, client_error_403: ClientError) -> None:
-        result = map_google_error(client_error_403)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "google"
-        assert result.status_code == 403
-
-    def test_client_error_404(self, client_error_404: ClientError) -> None:
-        result = map_google_error(client_error_404)
-        assert isinstance(result, NotFoundError)
-        assert result.provider == "google"
-        assert result.status_code == 404
-
-    def test_client_error_408(self, client_error_408: ClientError) -> None:
-        result = map_google_error(client_error_408)
-        assert isinstance(result, TimeoutError)
-        assert result.provider == "google"
-        assert result.status_code == 408
-
-    def test_client_error_429(self, client_error_429: ClientError) -> None:
-        result = map_google_error(client_error_429)
-        assert isinstance(result, RateLimitError)
-        assert result.provider == "google"
-        assert result.status_code == 429
-
-    def test_client_error_unknown_code(self, client_error_unknown: ClientError) -> None:
-        result = map_google_error(client_error_unknown)
-        assert isinstance(result, ProviderError)
-        assert result.provider == "google"
-        assert result.status_code == 418
-
-    def test_server_error(self, server_error_500: ServerError) -> None:
-        result = map_google_error(server_error_500)
-        assert isinstance(result, ProviderError)
-        assert result.provider == "google"
-        assert result.status_code == 500
-
-    def test_api_error(self, api_error_502: APIError) -> None:
-        result = map_google_error(api_error_502)
-        assert isinstance(result, ProviderError)
-        assert result.provider == "google"
-        assert result.status_code == 502
-
-    def test_default_credentials_error(self, default_credentials_error: DefaultCredentialsError) -> None:
-        result = map_google_error(default_credentials_error)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "google"
-
-    def test_refresh_error(self, refresh_error: RefreshError) -> None:
-        result = map_google_error(refresh_error)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "google"
-
-    def test_generic_exception(self) -> None:
-        error = RuntimeError("something broke")
-        result = map_google_error(error)
-        assert isinstance(result, ProviderError)
-        assert result.provider == "google"
-
+class TestErrorFromResponse:
     @pytest.mark.parametrize(
-        "error",
+        ("status", "exc"),
         [
-            pytest.param(ClientError(code=400, response_json={}), id="bad_request"),
-            pytest.param(ClientError(code=401, response_json={}), id="unauthenticated"),
-            pytest.param(ClientError(code=403, response_json={}), id="permission_denied"),
-            pytest.param(ClientError(code=404, response_json={}), id="not_found"),
-            pytest.param(ClientError(code=408, response_json={}), id="timeout"),
-            pytest.param(ClientError(code=429, response_json={}), id="rate_limited"),
-            pytest.param(ClientError(code=418, response_json={}), id="unknown_client"),
-            pytest.param(ServerError(code=500, response_json={}), id="server"),
-            pytest.param(DefaultCredentialsError(""), id="no_credentials"),
-            pytest.param(RefreshError(""), id="refresh"),
-            pytest.param(RuntimeError("fallback"), id="runtime"),
+            (400, InvalidRequestError),
+            (401, AuthenticationError),
+            (403, AuthenticationError),
+            (404, NotFoundError),
+            (408, TimeoutError),
+            (429, RateLimitError),
+            (500, ProviderError),
+            (418, ProviderError),
         ],
     )
-    def test_all_errors_are_lmux_errors(self, error: Exception) -> None:
-        result = map_google_error(error)
-        assert isinstance(result, LmuxError)
-        assert result.provider == "google"
+    def test_status_mapping(self, status: int, exc: type[Exception]) -> None:
+        err = error_from_response(_resp(status, json={"error": {"message": "m"}}))
+        assert isinstance(err, exc)
+        assert getattr(err, "status_code", None) == status
+        assert getattr(err, "provider", None) == "google"
+
+
+class TestErrorMessage:
+    def test_error_dict_with_message(self) -> None:
+        assert "the message" in str(error_from_response(_resp(400, json={"error": {"message": "the message"}})))
+
+    def test_error_dict_without_message_falls_back(self) -> None:
+        assert isinstance(error_from_response(_resp(400, json={"error": {"code": "x"}})), InvalidRequestError)
+
+    def test_json_but_not_error_dict(self) -> None:
+        assert isinstance(error_from_response(_resp(400, json=["not", "a", "dict"])), InvalidRequestError)
+
+    def test_non_json_body(self) -> None:
+        assert "plain text error" in str(error_from_response(_resp(400, text="plain text error")))
+
+
+class TestMapTransportError:
+    def test_timeout(self) -> None:
+        assert isinstance(map_transport_error(httpx.ReadTimeout("timed out")), TimeoutError)
+
+    def test_connect_error(self) -> None:
+        assert isinstance(map_transport_error(httpx.ConnectError("refused")), ProviderError)
+
+    def test_default_credentials_error(self) -> None:
+        err = map_transport_error(DefaultCredentialsError("no creds"))
+        assert isinstance(err, AuthenticationError)
+        assert err.provider == "google"
+
+    def test_refresh_error(self) -> None:
+        err = map_transport_error(RefreshError("refresh failed"))
+        assert isinstance(err, AuthenticationError)
+
+    def test_generic_exception(self) -> None:
+        assert isinstance(map_transport_error(Exception("boom")), ProviderError)

--- a/packages/lmux-google/tests/test_exceptions.py
+++ b/packages/lmux-google/tests/test_exceptions.py
@@ -8,6 +8,7 @@ from lmux.exceptions import (
     AuthenticationError,
     InvalidRequestError,
     NotFoundError,
+    PermissionDeniedError,
     ProviderError,
     RateLimitError,
     TimeoutError,  # noqa: A004
@@ -42,7 +43,7 @@ class TestErrorFromResponse:
         [
             (400, InvalidRequestError),
             (401, AuthenticationError),
-            (403, AuthenticationError),
+            (403, PermissionDeniedError),
             (404, NotFoundError),
             (408, TimeoutError),
             (429, RateLimitError),

--- a/packages/lmux-google/tests/test_exceptions.py
+++ b/packages/lmux-google/tests/test_exceptions.py
@@ -12,7 +12,13 @@ from lmux.exceptions import (
     RateLimitError,
     TimeoutError,  # noqa: A004
 )
-from lmux_google._exceptions import error_from_response, map_transport_error, raise_for_status
+from lmux_google._exceptions import (
+    error_from_response,
+    error_from_stream,
+    map_transport_error,
+    parse_json,
+    raise_for_status,
+)
 
 
 def _resp(status: int, *, json: object = None, text: str = "", headers: dict[str, str] | None = None) -> httpx.Response:
@@ -83,3 +89,28 @@ class TestMapTransportError:
 
     def test_generic_exception(self) -> None:
         assert isinstance(map_transport_error(Exception("boom")), ProviderError)
+
+
+class TestParseJson:
+    def test_valid_body(self) -> None:
+        assert parse_json(_resp(200, json={"ok": 1})) == {"ok": 1}
+
+    def test_malformed_body_maps_to_provider_error(self) -> None:
+        with pytest.raises(ProviderError):
+            parse_json(_resp(200, text="not json"))
+
+    def test_non_object_body_maps_to_provider_error(self) -> None:
+        with pytest.raises(ProviderError):
+            parse_json(_resp(200, json=["not", "an", "object"]))
+
+
+class TestErrorFromStream:
+    def test_error_object_with_message(self) -> None:
+        err = error_from_stream({"error": {"message": "stream boom"}})
+        assert isinstance(err, ProviderError)
+        assert "stream boom" in str(err)
+
+    def test_error_not_a_dict(self) -> None:
+        err = error_from_stream({"error": "raw string error"})
+        assert isinstance(err, ProviderError)
+        assert "raw string error" in str(err)

--- a/packages/lmux-google/tests/test_lazy.py
+++ b/packages/lmux-google/tests/test_lazy.py
@@ -1,0 +1,91 @@
+"""Tests for the Google HTTP client factories, endpoint resolution, and Vertex auth glue."""
+
+from typing import TYPE_CHECKING, cast
+
+import httpx
+import respx
+
+from lmux_google._lazy import (
+    HttpxAuthRequest,
+    api_key_headers,
+    bearer_headers,
+    bearer_token,
+    vertex_base_url,
+)
+
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials
+
+
+class _Credentials:
+    def __init__(self, *, valid: bool, token: str | None = "live-token") -> None:  # noqa: S107
+        self.valid = valid
+        self.token = token
+        self.refreshed = False
+
+    def refresh(self, request: object) -> None:  # noqa: ARG002
+        self.refreshed = True
+        self.valid = True
+        self.token = "refreshed"  # noqa: S105
+
+
+class TestVertexBaseUrl:
+    def test_regional(self) -> None:
+        assert vertex_base_url("us-central1") == "https://us-central1-aiplatform.googleapis.com"
+
+    def test_global(self) -> None:
+        assert vertex_base_url("global") == "https://aiplatform.googleapis.com"
+
+    def test_none(self) -> None:
+        assert vertex_base_url(None) == "https://aiplatform.googleapis.com"
+
+    def test_us_multi_region(self) -> None:
+        assert vertex_base_url("us") == "https://aiplatform.us.rep.googleapis.com"
+
+    def test_eu_multi_region(self) -> None:
+        assert vertex_base_url("eu") == "https://aiplatform.eu.rep.googleapis.com"
+
+
+class TestApiKeyHeaders:
+    def test_builds_headers(self) -> None:
+        assert api_key_headers("secret") == {"x-goog-api-key": "secret", "Content-Type": "application/json"}
+
+
+class TestBearerHeaders:
+    def test_builds_headers(self) -> None:
+        assert bearer_headers("tok") == {"Authorization": "Bearer tok", "Content-Type": "application/json"}
+
+
+class TestBearerToken:
+    def test_returns_valid_token_without_refresh(self) -> None:
+        creds = _Credentials(valid=True)
+        assert bearer_token(cast("Credentials", creds)) == "live-token"
+        assert creds.refreshed is False
+
+    def test_refreshes_when_invalid(self) -> None:
+        creds = _Credentials(valid=False)
+        assert bearer_token(cast("Credentials", creds)) == "refreshed"
+        assert creds.refreshed is True
+
+
+class TestHttpxAuthRequest:
+    def test_performs_http_request(self, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post("https://oauth2.example/token").mock(
+            return_value=httpx.Response(200, json={"access_token": "t"}, headers={"x-test": "1"})
+        )
+        response = HttpxAuthRequest()(
+            "https://oauth2.example/token",
+            method="POST",
+            body=b"grant=x",
+            headers={"content-type": "text/plain"},
+            timeout=5.0,
+        )
+        assert response.status == 200
+        assert response.headers["x-test"] == "1"
+        assert b"access_token" in response.data
+        assert route.called
+
+    def test_default_get(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.get("https://oauth2.example/ping").mock(return_value=httpx.Response(204))
+        response = HttpxAuthRequest()("https://oauth2.example/ping")
+        assert response.status == 204

--- a/packages/lmux-google/tests/test_lazy.py
+++ b/packages/lmux-google/tests/test_lazy.py
@@ -55,6 +55,13 @@ class TestBearerHeaders:
     def test_builds_headers(self) -> None:
         assert bearer_headers("tok") == {"Authorization": "Bearer tok", "Content-Type": "application/json"}
 
+    def test_includes_quota_project(self) -> None:
+        assert bearer_headers("tok", "quota-proj") == {
+            "Authorization": "Bearer tok",
+            "Content-Type": "application/json",
+            "x-goog-user-project": "quota-proj",
+        }
+
 
 class TestBearerToken:
     def test_returns_valid_token_without_refresh(self) -> None:

--- a/packages/lmux-google/tests/test_mappers.py
+++ b/packages/lmux-google/tests/test_mappers.py
@@ -43,6 +43,7 @@ from lmux_google._mappers import (
     map_tool_choice,
     map_tools,
 )
+from lmux_google._wire import WireBatchEmbeddingsResponse, WireGenerateContentResponse
 
 # MARK: Fixtures
 
@@ -288,7 +289,9 @@ class TestMapToolChoice:
 class TestMapGenerateContentResponse:
     def test_text_response(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"text": "Hello!"}])
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result == ChatResponse(
             content="Hello!",
             tool_calls=None,
@@ -301,7 +304,9 @@ class TestMapGenerateContentResponse:
 
     def test_tool_call_response(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"functionCall": {"id": "call_0", "name": "get_weather", "args": {"city": "NYC"}}}])
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.tool_calls == [
             ToolCall(id="call_0", function=FunctionCallResult(name="get_weather", arguments='{"city": "NYC"}'))
         ]
@@ -309,87 +314,117 @@ class TestMapGenerateContentResponse:
 
     def test_function_call_without_id(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"functionCall": {"name": "search", "args": {}}}])
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.tool_calls is not None
         assert result.tool_calls[0].id.startswith("call_")
 
     def test_function_call_without_args(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"functionCall": {"id": "c1", "name": "ping"}}])
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.tool_calls is not None
         assert result.tool_calls[0].function.arguments == "{}"
 
     def test_function_call_without_name(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"functionCall": {"id": "c1", "args": {}}}])
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.tool_calls is not None
         assert result.tool_calls[0].function.name == ""
 
     def test_no_candidates(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = {"candidates": None, "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 0}}
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.content is None
         assert result.tool_calls is None
         assert result.usage is not None
 
     def test_empty_candidates(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        result = map_generate_content_response({"candidates": []}, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate({"candidates": []}), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.content is None
         assert result.usage is None
         assert result.cost is None
 
     def test_cache_tokens(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"text": "cached"}], cached_tokens=50)
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.usage is not None
         assert result.usage.cache_read_tokens == 50
 
     def test_no_usage(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"text": "Hi"}], usage=False)
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.usage is None
         assert result.cost is None
 
     def test_cost_none_for_unknown_model(self, none_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"text": "Hi"}])
-        result = map_generate_content_response(response, "unknown-model", "google", none_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "unknown-model", "google", none_cost_fn
+        )
         assert result.cost is None
 
     def test_safety_finish_reason(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[], finish_reason="SAFETY")
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.finish_reason == "content_filter"
 
     def test_max_tokens_finish_reason(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"text": "truncated"}], finish_reason="MAX_TOKENS")
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.finish_reason == "length"
 
     def test_none_finish_reason(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"text": "Hi"}], finish_reason=None)
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.finish_reason is None
 
     def test_unknown_finish_reason_passthrough(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"text": "Hi"}], finish_reason="SOME_NEW_REASON")
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.finish_reason == "SOME_NEW_REASON"
 
     def test_thought_parts_extracted(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"thought": True, "text": "Thinking..."}, {"text": "Answer"}])
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.content == "Answer"
         assert result.reasoning == "Thinking..."
 
     def test_thought_part_with_none_text(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"thought": True}, {"text": "Answer"}])
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.content == "Answer"
         assert result.reasoning is None
 
     def test_no_content_on_candidate(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(has_content=False)
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.content is None
         assert result.tool_calls is None
 
@@ -401,7 +436,9 @@ class TestMapGenerateContentResponse:
                 {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "42\n"}},
             ]
         )
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.content == "The answer is 42."
         assert result.server_tool_results == [
             ServerToolResult(
@@ -419,7 +456,9 @@ class TestMapGenerateContentResponse:
                 {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "42\n"}},
             ]
         )
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.content is None
         assert result.server_tool_results is not None
 
@@ -430,7 +469,9 @@ class TestMapGenerateContentResponse:
                 {"codeExecutionResult": {}},
             ]
         )
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.server_tool_results is not None
         assert result.server_tool_results[0].input == {"code": "x = 1", "language": None}
         assert result.server_tool_results[0].output is None
@@ -445,13 +486,17 @@ class TestMapGenerateContentResponse:
                 {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "2\n"}},
             ]
         )
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.server_tool_results is not None
         assert [r.output for r in result.server_tool_results] == ["1\n", "2\n"]
 
     def test_no_code_execution_returns_none(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = _response(parts=[{"text": "Hello!"}])
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response(
+            WireGenerateContentResponse.model_validate(response), "gemini-2.0-flash", "google", noop_cost_fn
+        )
         assert result.server_tool_results is None
 
 
@@ -461,7 +506,9 @@ class TestMapGenerateContentResponse:
 class TestMapGenerateContentChunk:
     def test_text_chunk(self) -> None:
         chunk = _response(parts=[{"text": "Hello"}], finish_reason=None, usage=False)
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result == ChatChunk(delta="Hello", model="gemini-2.0-flash", provider="google")
 
     def test_function_call_chunk(self) -> None:
@@ -470,7 +517,9 @@ class TestMapGenerateContentChunk:
             finish_reason=None,
             usage=False,
         )
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.tool_call_deltas == [
             ToolCallDelta(
                 index=0,
@@ -482,39 +531,53 @@ class TestMapGenerateContentChunk:
 
     def test_function_call_chunk_without_id(self) -> None:
         chunk = _response(parts=[{"functionCall": {"name": "f", "args": {}}}], finish_reason=None, usage=False)
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.tool_call_deltas is not None
         assert result.tool_call_deltas[0].id == "call_0"
 
     def test_finish_reason_chunk(self) -> None:
         chunk = _response(has_content=False, finish_reason="STOP", usage=False)
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.finish_reason == "stop"
 
     def test_usage_chunk(self) -> None:
         chunk = _response(parts=[], finish_reason=None)
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.usage == Usage(input_tokens=10, output_tokens=5)
 
     def test_empty_chunk(self) -> None:
-        result = map_generate_content_chunk({"candidates": None}, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate({"candidates": None}), "gemini-2.0-flash", "google"
+        )
         assert result == ChatChunk(model="gemini-2.0-flash", provider="google")
 
     def test_thought_parts_extracted_in_chunk(self) -> None:
         chunk = _response(parts=[{"thought": True, "text": "Thinking..."}], finish_reason=None, usage=False)
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.delta is None
         assert result.reasoning_delta == "Thinking..."
 
     def test_thought_part_with_none_text_in_chunk(self) -> None:
         chunk = _response(parts=[{"thought": True}], finish_reason=None, usage=False)
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.delta is None
         assert result.reasoning_delta is None
 
     def test_function_call_without_args_in_chunk(self) -> None:
         chunk = _response(parts=[{"functionCall": {"id": "c1", "name": "ping"}}], finish_reason=None, usage=False)
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.tool_call_deltas is not None
         assert result.tool_call_deltas[0].function is not None
         assert result.tool_call_deltas[0].function.arguments == "{}"
@@ -523,14 +586,18 @@ class TestMapGenerateContentChunk:
         chunk = _response(
             parts=[{"functionCall": {"id": "c1", "name": "f", "args": {}}}], finish_reason="STOP", usage=False
         )
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.finish_reason == "tool_calls"
 
     def test_nonterminal_tool_call_chunk_preserves_null_finish_reason(self) -> None:
         chunk = _response(
             parts=[{"functionCall": {"id": "c1", "name": "f", "args": {}}}], finish_reason=None, usage=False
         )
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.finish_reason is None
 
     def test_code_execution_chunk(self) -> None:
@@ -542,7 +609,9 @@ class TestMapGenerateContentChunk:
             finish_reason=None,
             usage=False,
         )
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.server_tool_deltas == [
             ServerToolDelta(index=0, name="code_execution", input_delta='{"code": "print(42)", "language": "PYTHON"}'),
             ServerToolDelta(index=0, output_delta="42\n"),
@@ -550,7 +619,9 @@ class TestMapGenerateContentChunk:
 
     def test_code_execution_chunk_no_server_tool_deltas_when_absent(self) -> None:
         chunk = _response(parts=[{"text": "Hello"}], finish_reason=None, usage=False)
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.server_tool_deltas is None
 
     def test_multiple_code_executions_in_chunk(self) -> None:
@@ -564,7 +635,9 @@ class TestMapGenerateContentChunk:
             finish_reason=None,
             usage=False,
         )
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk(
+            WireGenerateContentResponse.model_validate(chunk), "gemini-2.0-flash", "google"
+        )
         assert result.server_tool_deltas is not None
         assert len(result.server_tool_deltas) == 4
         assert result.server_tool_deltas[1].index == 0
@@ -578,7 +651,9 @@ class TestMapGenerateContentChunk:
 class TestMapBatchEmbeddingsResponse:
     def test_single_embedding(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = {"embeddings": [{"values": [0.1, 0.2, 0.3]}]}
-        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
+        result = map_batch_embeddings_response(
+            WireBatchEmbeddingsResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
+        )
         assert result == EmbeddingResponse(
             embeddings=[[0.1, 0.2, 0.3]],
             usage=Usage(input_tokens=0, output_tokens=0),
@@ -589,29 +664,44 @@ class TestMapBatchEmbeddingsResponse:
 
     def test_multiple_embeddings(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = {"embeddings": [{"values": [0.1, 0.2]}, {"values": [0.3, 0.4]}]}
-        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
+        result = map_batch_embeddings_response(
+            WireBatchEmbeddingsResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
+        )
         assert result.embeddings == [[0.1, 0.2], [0.3, 0.4]]
 
     def test_empty_embeddings(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        result = map_batch_embeddings_response({"embeddings": None}, "text-embedding-005", "google", noop_cost_fn)
+        result = map_batch_embeddings_response(
+            WireBatchEmbeddingsResponse.model_validate({"embeddings": None}),
+            "text-embedding-005",
+            "google",
+            noop_cost_fn,
+        )
         assert result.embeddings == []
 
     def test_embedding_with_none_values(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = {"embeddings": [{"values": None}]}
-        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
+        result = map_batch_embeddings_response(
+            WireBatchEmbeddingsResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
+        )
         assert result.embeddings == [[]]
 
     def test_cost_none_for_unknown(self, none_cost_fn: Any) -> None:  # noqa: ANN401
         response = {"embeddings": [{"values": [0.1]}]}
-        result = map_batch_embeddings_response(response, "unknown-model", "google", none_cost_fn)
+        result = map_batch_embeddings_response(
+            WireBatchEmbeddingsResponse.model_validate(response), "unknown-model", "google", none_cost_fn
+        )
         assert result.cost is None
 
     def test_approximates_tokens_from_billable_characters(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = {"embeddings": [{"values": [0.1]}], "metadata": {"billableCharacterCount": 400}}
-        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
+        result = map_batch_embeddings_response(
+            WireBatchEmbeddingsResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
+        )
         assert result.usage == Usage(input_tokens=100, output_tokens=0)
 
     def test_billable_character_count_none_falls_back_to_zero(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         response = {"embeddings": [{"values": [0.1]}], "metadata": {"billableCharacterCount": None}}
-        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
+        result = map_batch_embeddings_response(
+            WireBatchEmbeddingsResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
+        )
         assert result.usage == Usage(input_tokens=0, output_tokens=0)

--- a/packages/lmux-google/tests/test_mappers.py
+++ b/packages/lmux-google/tests/test_mappers.py
@@ -1,8 +1,7 @@
-"""Tests for Google type mappers."""
+"""Tests for Google (Gemini REST) type mappers."""
 
 import base64
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -35,7 +34,8 @@ from lmux.types import (
     UserMessage,
 )
 from lmux_google._mappers import (
-    map_embed_content_response,
+    Json,
+    map_batch_embeddings_response,
     map_generate_content_chunk,
     map_generate_content_response,
     map_messages,
@@ -63,72 +63,28 @@ def none_cost_fn() -> Any:  # noqa: ANN401
     return _fn
 
 
-def _make_part(**attrs: Any) -> MagicMock:  # noqa: ANN401
-    """Create a mock Part with all code-execution attributes defaulted to None."""
-    part = MagicMock()
-    part.thought = False
-    part.text = None
-    part.function_call = None
-    part.executable_code = None
-    part.code_execution_result = None
-    for key, value in attrs.items():
-        setattr(part, key, value)
-    return part
-
-
-def _make_response(  # noqa: PLR0913
+def _response(  # noqa: PLR0913
     *,
-    text: str | None = None,
-    function_calls: list[dict[str, Any]] | None = None,
-    code_executions: list[dict[str, Any]] | None = None,
+    parts: list[Json] | None = None,
+    has_content: bool = True,
     finish_reason: str | None = "STOP",
     prompt_tokens: int = 10,
     output_tokens: int = 5,
     cached_tokens: int | None = None,
-    thoughts: list[str] | None = None,
-) -> MagicMock:
-    """Create a mock GenerateContentResponse."""
-    response = MagicMock()
-    candidate = MagicMock()
-
-    parts = []
-    if thoughts:
-        parts.extend(_make_part(thought=True, text=thought_text) for thought_text in thoughts)
-    if text is not None:
-        parts.append(_make_part(text=text))
-    if function_calls:
-        for fc in function_calls:
-            fc_mock = MagicMock()
-            fc_mock.id = fc.get("id")
-            fc_mock.name = fc.get("name")
-            fc_mock.args = fc.get("args")
-            parts.append(_make_part(function_call=fc_mock))
-    if code_executions:
-        for ce in code_executions:
-            ec_mock = MagicMock()
-            ec_mock.code = ce.get("code")
-            ec_mock.language = MagicMock(value=ce.get("language")) if ce.get("language") else None
-            parts.append(_make_part(executable_code=ec_mock))
-
-            cer_mock = MagicMock()
-            cer_mock.output = ce.get("output")
-            cer_mock.outcome = MagicMock(value=ce.get("outcome")) if ce.get("outcome") else None
-            parts.append(_make_part(code_execution_result=cer_mock))
-
-    content = MagicMock()
-    content.parts = parts or None
-    candidate.content = content if parts else None
-    candidate.finish_reason = MagicMock(value=finish_reason) if finish_reason else None
-
-    response.candidates = [candidate]
-
-    usage = MagicMock()
-    usage.prompt_token_count = prompt_tokens
-    usage.candidates_token_count = output_tokens
-    usage.cached_content_token_count = cached_tokens
-    usage.thoughts_token_count = None
-    response.usage_metadata = usage
-
+    usage: bool = True,
+) -> Json:
+    """Build a raw generateContent JSON body."""
+    candidate: Json = {}
+    if has_content:
+        candidate["content"] = {"role": "model", "parts": parts or []}
+    if finish_reason is not None:
+        candidate["finishReason"] = finish_reason
+    response: Json = {"candidates": [candidate]}
+    if usage:
+        meta: Json = {"promptTokenCount": prompt_tokens, "candidatesTokenCount": output_tokens}
+        if cached_tokens is not None:
+            meta["cachedContentTokenCount"] = cached_tokens
+        response["usageMetadata"] = meta
     return response
 
 
@@ -147,14 +103,10 @@ class TestMapMessages:
         assert contents == []
 
     def test_multiple_system_messages_concatenated(self) -> None:
-        system, contents = map_messages(
-            [
-                SystemMessage(content="Be helpful."),
-                DeveloperMessage(content="Be concise."),
-            ]
+        system, _contents = map_messages(
+            [SystemMessage(content="Be helpful."), DeveloperMessage(content="Be concise.")]
         )
         assert system == "Be helpful.\nBe concise."
-        assert contents == []
 
     def test_user_message_text(self) -> None:
         system, contents = map_messages([UserMessage(content="Hello")])
@@ -166,91 +118,65 @@ class TestMapMessages:
         assert contents == [{"role": "user", "parts": []}]
 
     def test_user_message_multimodal_base64(self) -> None:
-        raw_bytes = b"\x89PNG\r\n"
-        b64_data = base64.b64encode(raw_bytes).decode()
-        data_uri = f"data:image/png;base64,{b64_data}"
-        parts: list[ContentPart] = [TextContent(text="What is this?"), ImageContent(url=data_uri)]
-        system, contents = map_messages([UserMessage(content=parts)])
-
-        assert system is None
+        b64_data = base64.b64encode(b"\x89PNG\r\n").decode()
+        parts: list[ContentPart] = [
+            TextContent(text="What is this?"),
+            ImageContent(url=f"data:image/png;base64,{b64_data}"),
+        ]
+        _system, contents = map_messages([UserMessage(content=parts)])
         assert contents == [
             {
                 "role": "user",
                 "parts": [
                     {"text": "What is this?"},
-                    {"inline_data": {"data": raw_bytes, "mime_type": "image/png"}},
+                    {"inlineData": {"data": b64_data, "mimeType": "image/png"}},
                 ],
             }
         ]
 
     def test_user_message_multimodal_url(self) -> None:
         parts: list[ContentPart] = [ImageContent(url="https://example.com/image.png")]
-        system, contents = map_messages([UserMessage(content=parts)])
-
-        assert system is None
+        _system, contents = map_messages([UserMessage(content=parts)])
         assert contents == [
             {
                 "role": "user",
-                "parts": [{"file_data": {"file_uri": "https://example.com/image.png", "mime_type": "image/*"}}],
+                "parts": [{"fileData": {"fileUri": "https://example.com/image.png", "mimeType": "image/*"}}],
             }
         ]
 
     def test_assistant_message_text(self) -> None:
-        system, contents = map_messages([AssistantMessage(content="Hi!")])
-        assert system is None
+        _system, contents = map_messages([AssistantMessage(content="Hi!")])
         assert contents == [{"role": "model", "parts": [{"text": "Hi!"}]}]
 
     def test_assistant_message_with_tool_calls(self) -> None:
         tc = ToolCall(id="tc1", function=FunctionCallResult(name="get_weather", arguments='{"city": "NYC"}'))
-        system, contents = map_messages([AssistantMessage(content="Let me check.", tool_calls=[tc])])
-
-        assert system is None
+        _system, contents = map_messages([AssistantMessage(content="Let me check.", tool_calls=[tc])])
         assert contents == [
             {
                 "role": "model",
                 "parts": [
                     {"text": "Let me check."},
-                    {"function_call": {"id": "tc1", "name": "get_weather", "args": {"city": "NYC"}}},
+                    {"functionCall": {"id": "tc1", "name": "get_weather", "args": {"city": "NYC"}}},
                 ],
             }
         ]
 
     def test_assistant_message_tool_calls_no_content(self) -> None:
         tc = ToolCall(id="tc1", function=FunctionCallResult(name="f", arguments="{}"))
-        system, contents = map_messages([AssistantMessage(content=None, tool_calls=[tc])])
-
-        assert system is None
-        assert contents == [
-            {
-                "role": "model",
-                "parts": [
-                    {"function_call": {"id": "tc1", "name": "f", "args": {}}},
-                ],
-            }
-        ]
+        _system, contents = map_messages([AssistantMessage(content=None, tool_calls=[tc])])
+        assert contents == [{"role": "model", "parts": [{"functionCall": {"id": "tc1", "name": "f", "args": {}}}]}]
 
     def test_tool_message_json_content(self) -> None:
         tc = ToolCall(id="tc1", function=FunctionCallResult(name="get_weather", arguments="{}"))
-        system, contents = map_messages(
+        _system, contents = map_messages(
             [
                 AssistantMessage(content=None, tool_calls=[tc]),
                 ToolMessage(content='{"temperature": "72F"}', tool_call_id="tc1"),
             ]
         )
-
-        assert system is None
-        assert len(contents) == 2
         assert contents[1] == {
             "role": "user",
-            "parts": [
-                {
-                    "function_response": {
-                        "id": "tc1",
-                        "name": "get_weather",
-                        "response": {"temperature": "72F"},
-                    }
-                }
-            ],
+            "parts": [{"functionResponse": {"id": "tc1", "name": "get_weather", "response": {"temperature": "72F"}}}],
         }
 
     def test_tool_message_plain_text_content(self) -> None:
@@ -261,51 +187,20 @@ class TestMapMessages:
                 ToolMessage(content="not json", tool_call_id="tc1"),
             ]
         )
-
-        assert contents[1] == {
-            "role": "user",
-            "parts": [
-                {
-                    "function_response": {
-                        "id": "tc1",
-                        "name": "search",
-                        "response": {"result": "not json"},
-                    }
-                }
-            ],
-        }
+        assert contents[1]["parts"][0]["functionResponse"]["response"] == {"result": "not json"}
 
     def test_tool_message_unknown_id_uses_id_as_name(self) -> None:
-        _system, contents = map_messages(
-            [
-                ToolMessage(content='{"result": "ok"}', tool_call_id="unknown_id"),
-            ]
-        )
-
-        assert contents[0] == {
-            "role": "user",
-            "parts": [
-                {
-                    "function_response": {
-                        "id": "unknown_id",
-                        "name": "unknown_id",
-                        "response": {"result": "ok"},
-                    }
-                }
-            ],
-        }
+        _system, contents = map_messages([ToolMessage(content='{"result": "ok"}', tool_call_id="unknown_id")])
+        assert contents[0]["parts"][0]["functionResponse"]["name"] == "unknown_id"
 
     def test_no_system_returns_none(self) -> None:
         system, _contents = map_messages([UserMessage(content="hi")])
         assert system is None
 
     def test_mixed_messages(self) -> None:
-        msgs = [
-            SystemMessage(content="sys"),
-            UserMessage(content="hi"),
-            AssistantMessage(content="hello"),
-        ]
-        system, contents = map_messages(msgs)
+        system, contents = map_messages(
+            [SystemMessage(content="sys"), UserMessage(content="hi"), AssistantMessage(content="hello")]
+        )
         assert system == "sys"
         assert contents == [
             {"role": "user", "parts": [{"text": "hi"}]},
@@ -322,6 +217,8 @@ class TestMapMessages:
 
 
 # MARK: map_tools
+
+
 class TestMapTools:
     def test_full_tool(self) -> None:
         tools = [
@@ -333,26 +230,22 @@ class TestMapTools:
                 )
             )
         ]
-        result = map_tools(tools)
-        assert result == [
+        assert map_tools(tools) == [
             {
-                "function_declarations": [
+                "functionDeclarations": [
                     {
                         "name": "get_weather",
                         "description": "Get weather",
-                        "parameters_json_schema": {
-                            "type": "object",
-                            "properties": {"city": {"type": "string"}},
-                        },
+                        "parametersJsonSchema": {"type": "object", "properties": {"city": {"type": "string"}}},
                     }
                 ]
             }
         ]
 
     def test_minimal_tool(self) -> None:
-        tools = [Tool(function=FunctionDefinition(name="noop"))]
-        result = map_tools(tools)
-        assert result == [{"function_declarations": [{"name": "noop"}]}]
+        assert map_tools([Tool(function=FunctionDefinition(name="noop"))]) == [
+            {"functionDeclarations": [{"name": "noop"}]}
+        ]
 
 
 # MARK: map_response_format
@@ -360,20 +253,33 @@ class TestMapTools:
 
 class TestMapResponseFormat:
     def test_text_format(self) -> None:
-        mime_type, schema = map_response_format(TextResponseFormat())
-        assert mime_type is None
-        assert schema is None
+        assert map_response_format(TextResponseFormat()) == (None, None)
 
     def test_json_object_format(self) -> None:
-        mime_type, schema = map_response_format(JsonObjectResponseFormat())
-        assert mime_type == "application/json"
-        assert schema is None
+        assert map_response_format(JsonObjectResponseFormat()) == ("application/json", None)
 
     def test_json_schema_format(self) -> None:
         rf = JsonSchemaResponseFormat(name="test", json_schema={"type": "object"})
-        mime_type, schema = map_response_format(rf)
-        assert mime_type == "application/json"
-        assert schema == {"type": "object"}
+        assert map_response_format(rf) == ("application/json", {"type": "object"})
+
+
+# MARK: map_tool_choice
+
+
+class TestMapToolChoice:
+    def test_auto(self) -> None:
+        assert map_tool_choice("auto") == {"functionCallingConfig": {"mode": "AUTO"}}
+
+    def test_required(self) -> None:
+        assert map_tool_choice("required") == {"functionCallingConfig": {"mode": "ANY"}}
+
+    def test_none(self) -> None:
+        assert map_tool_choice("none") == {"functionCallingConfig": {"mode": "NONE"}}
+
+    def test_specific_function(self) -> None:
+        assert map_tool_choice(ToolChoiceFunction(name="get_weather")) == {
+            "functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["get_weather"]}
+        }
 
 
 # MARK: map_generate_content_response
@@ -381,7 +287,7 @@ class TestMapResponseFormat:
 
 class TestMapGenerateContentResponse:
     def test_text_response(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="Hello!")
+        response = _response(parts=[{"text": "Hello!"}])
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result == ChatResponse(
             content="Hello!",
@@ -394,143 +300,106 @@ class TestMapGenerateContentResponse:
         )
 
     def test_tool_call_response(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(
-            function_calls=[{"id": "call_0", "name": "get_weather", "args": {"city": "NYC"}}],
-            finish_reason="STOP",
-        )
+        response = _response(parts=[{"functionCall": {"id": "call_0", "name": "get_weather", "args": {"city": "NYC"}}}])
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
-        assert result == ChatResponse(
-            content=None,
-            tool_calls=[
-                ToolCall(
-                    id="call_0",
-                    function=FunctionCallResult(name="get_weather", arguments='{"city": "NYC"}'),
-                )
-            ],
-            usage=Usage(input_tokens=10, output_tokens=5),
-            cost=Cost(input_cost=0.0, output_cost=0.0, total_cost=0.0),
-            model="gemini-2.0-flash",
-            provider="google",
-            finish_reason="tool_calls",
-        )
+        assert result.tool_calls == [
+            ToolCall(id="call_0", function=FunctionCallResult(name="get_weather", arguments='{"city": "NYC"}'))
+        ]
+        assert result.finish_reason == "tool_calls"
 
     def test_function_call_without_id(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(
-            function_calls=[{"id": None, "name": "search", "args": {}}],
-        )
+        response = _response(parts=[{"functionCall": {"name": "search", "args": {}}}])
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.tool_calls is not None
-        # ID should be auto-generated as call_{index}
         assert result.tool_calls[0].id.startswith("call_")
 
     def test_function_call_without_args(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(
-            function_calls=[{"id": "c1", "name": "ping", "args": None}],
-        )
+        response = _response(parts=[{"functionCall": {"id": "c1", "name": "ping"}}])
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.tool_calls is not None
         assert result.tool_calls[0].function.arguments == "{}"
 
-    def test_no_candidates(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = MagicMock()
-        response.candidates = None
-        usage = MagicMock()
-        usage.prompt_token_count = 10
-        usage.candidates_token_count = 0
-        usage.cached_content_token_count = None
-        response.usage_metadata = usage
+    def test_function_call_without_name(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        response = _response(parts=[{"functionCall": {"id": "c1", "args": {}}}])
+        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        assert result.tool_calls is not None
+        assert result.tool_calls[0].function.name == ""
 
+    def test_no_candidates(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        response = {"candidates": None, "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 0}}
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.content is None
         assert result.tool_calls is None
+        assert result.usage is not None
 
     def test_empty_candidates(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = MagicMock()
-        response.candidates = []
-        response.usage_metadata = None
-
-        result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
+        result = map_generate_content_response({"candidates": []}, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.content is None
         assert result.usage is None
         assert result.cost is None
 
     def test_cache_tokens(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="cached", cached_tokens=50)
+        response = _response(parts=[{"text": "cached"}], cached_tokens=50)
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.usage is not None
         assert result.usage.cache_read_tokens == 50
 
     def test_no_usage(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="Hi")
-        response.usage_metadata = None
+        response = _response(parts=[{"text": "Hi"}], usage=False)
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.usage is None
         assert result.cost is None
 
     def test_cost_none_for_unknown_model(self, none_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="Hi")
+        response = _response(parts=[{"text": "Hi"}])
         result = map_generate_content_response(response, "unknown-model", "google", none_cost_fn)
         assert result.cost is None
 
     def test_safety_finish_reason(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text=None, finish_reason="SAFETY")
+        response = _response(parts=[], finish_reason="SAFETY")
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.finish_reason == "content_filter"
 
     def test_max_tokens_finish_reason(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="truncated", finish_reason="MAX_TOKENS")
+        response = _response(parts=[{"text": "truncated"}], finish_reason="MAX_TOKENS")
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.finish_reason == "length"
 
     def test_none_finish_reason(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="Hi", finish_reason=None)
+        response = _response(parts=[{"text": "Hi"}], finish_reason=None)
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.finish_reason is None
 
     def test_unknown_finish_reason_passthrough(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="Hi", finish_reason="SOME_NEW_REASON")
+        response = _response(parts=[{"text": "Hi"}], finish_reason="SOME_NEW_REASON")
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.finish_reason == "SOME_NEW_REASON"
 
     def test_thought_parts_extracted(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="Answer", thoughts=["Thinking..."])
+        response = _response(parts=[{"thought": True, "text": "Thinking..."}, {"text": "Answer"}])
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.content == "Answer"
         assert result.reasoning == "Thinking..."
 
     def test_thought_part_with_none_text(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        """A thought part with thought=True but text=None should be skipped without error."""
-        response = MagicMock()
-        candidate = MagicMock()
-
-        content = MagicMock()
-        content.parts = [_make_part(thought=True), _make_part(text="Answer")]
-        candidate.content = content
-        candidate.finish_reason = MagicMock(value="STOP")
-
-        response.candidates = [candidate]
-        usage = MagicMock()
-        usage.prompt_token_count = 10
-        usage.candidates_token_count = 5
-        usage.cached_content_token_count = None
-        usage.thoughts_token_count = None
-        response.usage_metadata = usage
-
+        response = _response(parts=[{"thought": True}, {"text": "Answer"}])
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.content == "Answer"
         assert result.reasoning is None
 
     def test_no_content_on_candidate(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="Hi")
-        response.candidates[0].content = None
+        response = _response(has_content=False)
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.content is None
         assert result.tool_calls is None
 
     def test_code_execution_response(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(
-            text="The answer is 42.",
-            code_executions=[{"code": "print(42)", "language": "PYTHON", "output": "42\n", "outcome": "OUTCOME_OK"}],
+        response = _response(
+            parts=[
+                {"text": "The answer is 42."},
+                {"executableCode": {"code": "print(42)", "language": "PYTHON"}},
+                {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "42\n"}},
+            ]
         )
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.content == "The answer is 42."
@@ -540,21 +409,26 @@ class TestMapGenerateContentResponse:
                 input={"code": "print(42)", "language": "PYTHON"},
                 output="42\n",
                 provider_specific_fields={"outcome": "OUTCOME_OK"},
-            ),
+            )
         ]
 
     def test_code_execution_without_text(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(
-            code_executions=[{"code": "print(42)", "language": "PYTHON", "output": "42\n", "outcome": "OUTCOME_OK"}],
+        response = _response(
+            parts=[
+                {"executableCode": {"code": "print(42)", "language": "PYTHON"}},
+                {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "42\n"}},
+            ]
         )
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.content is None
         assert result.server_tool_results is not None
-        assert len(result.server_tool_results) == 1
 
     def test_code_execution_no_outcome(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(
-            code_executions=[{"code": "x = 1", "language": None, "output": None, "outcome": None}],
+        response = _response(
+            parts=[
+                {"executableCode": {"code": "x = 1"}},
+                {"codeExecutionResult": {}},
+            ]
         )
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.server_tool_results is not None
@@ -563,20 +437,20 @@ class TestMapGenerateContentResponse:
         assert result.server_tool_results[0].provider_specific_fields is None
 
     def test_multiple_code_executions(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(
-            code_executions=[
-                {"code": "print(1)", "language": "PYTHON", "output": "1\n", "outcome": "OUTCOME_OK"},
-                {"code": "print(2)", "language": "PYTHON", "output": "2\n", "outcome": "OUTCOME_OK"},
-            ],
+        response = _response(
+            parts=[
+                {"executableCode": {"code": "print(1)", "language": "PYTHON"}},
+                {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "1\n"}},
+                {"executableCode": {"code": "print(2)", "language": "PYTHON"}},
+                {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "2\n"}},
+            ]
         )
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.server_tool_results is not None
-        assert len(result.server_tool_results) == 2
-        assert result.server_tool_results[0].output == "1\n"
-        assert result.server_tool_results[1].output == "2\n"
+        assert [r.output for r in result.server_tool_results] == ["1\n", "2\n"]
 
     def test_no_code_execution_returns_none(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = _make_response(text="Hello!")
+        response = _response(parts=[{"text": "Hello!"}])
         result = map_generate_content_response(response, "gemini-2.0-flash", "google", noop_cost_fn)
         assert result.server_tool_results is None
 
@@ -586,19 +460,17 @@ class TestMapGenerateContentResponse:
 
 class TestMapGenerateContentChunk:
     def test_text_chunk(self) -> None:
-        chunk = _make_response(text="Hello", finish_reason=None)
-        chunk.usage_metadata = None
+        chunk = _response(parts=[{"text": "Hello"}], finish_reason=None, usage=False)
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result == ChatChunk(delta="Hello", model="gemini-2.0-flash", provider="google")
 
     def test_function_call_chunk(self) -> None:
-        chunk = _make_response(
-            function_calls=[{"id": "call_0", "name": "get_weather", "args": {"city": "NYC"}}],
+        chunk = _response(
+            parts=[{"functionCall": {"id": "call_0", "name": "get_weather", "args": {"city": "NYC"}}}],
             finish_reason=None,
+            usage=False,
         )
-        chunk.usage_metadata = None
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
-        assert result.tool_call_deltas is not None
         assert result.tool_call_deltas == [
             ToolCallDelta(
                 index=0,
@@ -608,139 +480,105 @@ class TestMapGenerateContentChunk:
             )
         ]
 
+    def test_function_call_chunk_without_id(self) -> None:
+        chunk = _response(parts=[{"functionCall": {"name": "f", "args": {}}}], finish_reason=None, usage=False)
+        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        assert result.tool_call_deltas is not None
+        assert result.tool_call_deltas[0].id == "call_0"
+
     def test_finish_reason_chunk(self) -> None:
-        chunk = _make_response(finish_reason="STOP")
-        chunk.candidates[0].content = None
-        chunk.usage_metadata = None
+        chunk = _response(has_content=False, finish_reason="STOP", usage=False)
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.finish_reason == "stop"
 
     def test_usage_chunk(self) -> None:
-        chunk = _make_response(text=None, finish_reason=None)
+        chunk = _response(parts=[], finish_reason=None)
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.usage == Usage(input_tokens=10, output_tokens=5)
 
     def test_empty_chunk(self) -> None:
-        chunk = MagicMock()
-        chunk.candidates = None
-        chunk.usage_metadata = None
-        result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
+        result = map_generate_content_chunk({"candidates": None}, "gemini-2.0-flash", "google")
         assert result == ChatChunk(model="gemini-2.0-flash", provider="google")
 
     def test_thought_parts_extracted_in_chunk(self) -> None:
-        chunk = _make_response(text=None, thoughts=["Thinking..."], finish_reason=None)
-        chunk.usage_metadata = None
+        chunk = _response(parts=[{"thought": True, "text": "Thinking..."}], finish_reason=None, usage=False)
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.delta is None
         assert result.reasoning_delta == "Thinking..."
 
     def test_thought_part_with_none_text_in_chunk(self) -> None:
-        """A thought part with thought=True but text=None should be skipped in streaming."""
-        chunk = MagicMock()
-        candidate = MagicMock()
-
-        content = MagicMock()
-        content.parts = [_make_part(thought=True)]
-        candidate.content = content
-        candidate.finish_reason = None
-
-        chunk.candidates = [candidate]
-        chunk.usage_metadata = None
-
+        chunk = _response(parts=[{"thought": True}], finish_reason=None, usage=False)
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.delta is None
         assert result.reasoning_delta is None
 
     def test_function_call_without_args_in_chunk(self) -> None:
-        chunk = _make_response(
-            function_calls=[{"id": "c1", "name": "ping", "args": None}],
-            finish_reason=None,
-        )
-        chunk.usage_metadata = None
+        chunk = _response(parts=[{"functionCall": {"id": "c1", "name": "ping"}}], finish_reason=None, usage=False)
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.tool_call_deltas is not None
         assert result.tool_call_deltas[0].function is not None
         assert result.tool_call_deltas[0].function.arguments == "{}"
 
     def test_chunk_with_tool_calls_has_tool_calls_finish_reason(self) -> None:
-        chunk = _make_response(
-            function_calls=[{"id": "c1", "name": "f", "args": {}}],
-            finish_reason="STOP",
+        chunk = _response(
+            parts=[{"functionCall": {"id": "c1", "name": "f", "args": {}}}], finish_reason="STOP", usage=False
         )
-        chunk.usage_metadata = None
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.finish_reason == "tool_calls"
 
     def test_nonterminal_tool_call_chunk_preserves_null_finish_reason(self) -> None:
-        chunk = _make_response(
-            function_calls=[{"id": "c1", "name": "f", "args": {}}],
-            finish_reason=None,
+        chunk = _response(
+            parts=[{"functionCall": {"id": "c1", "name": "f", "args": {}}}], finish_reason=None, usage=False
         )
-        chunk.usage_metadata = None
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.finish_reason is None
 
     def test_code_execution_chunk(self) -> None:
-        chunk = _make_response(
-            code_executions=[{"code": "print(42)", "language": "PYTHON", "output": "42\n", "outcome": "OUTCOME_OK"}],
+        chunk = _response(
+            parts=[
+                {"executableCode": {"code": "print(42)", "language": "PYTHON"}},
+                {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "42\n"}},
+            ],
             finish_reason=None,
+            usage=False,
         )
-        chunk.usage_metadata = None
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.server_tool_deltas == [
-            ServerToolDelta(
-                index=0,
-                name="code_execution",
-                input_delta='{"code": "print(42)", "language": "PYTHON"}',
-            ),
-            ServerToolDelta(
-                index=0,
-                output_delta="42\n",
-            ),
+            ServerToolDelta(index=0, name="code_execution", input_delta='{"code": "print(42)", "language": "PYTHON"}'),
+            ServerToolDelta(index=0, output_delta="42\n"),
         ]
 
     def test_code_execution_chunk_no_server_tool_deltas_when_absent(self) -> None:
-        chunk = _make_response(text="Hello", finish_reason=None)
-        chunk.usage_metadata = None
+        chunk = _response(parts=[{"text": "Hello"}], finish_reason=None, usage=False)
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.server_tool_deltas is None
 
     def test_multiple_code_executions_in_chunk(self) -> None:
-        chunk = _make_response(
-            code_executions=[
-                {"code": "print(1)", "language": "PYTHON", "output": "1\n", "outcome": "OUTCOME_OK"},
-                {"code": "print(2)", "language": "PYTHON", "output": "2\n", "outcome": "OUTCOME_OK"},
+        chunk = _response(
+            parts=[
+                {"executableCode": {"code": "print(1)", "language": "PYTHON"}},
+                {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "1\n"}},
+                {"executableCode": {"code": "print(2)", "language": "PYTHON"}},
+                {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "2\n"}},
             ],
             finish_reason=None,
+            usage=False,
         )
-        chunk.usage_metadata = None
         result = map_generate_content_chunk(chunk, "gemini-2.0-flash", "google")
         assert result.server_tool_deltas is not None
         assert len(result.server_tool_deltas) == 4
-        # First pair at index 0
-        assert result.server_tool_deltas[0].index == 0
-        assert result.server_tool_deltas[0].name == "code_execution"
         assert result.server_tool_deltas[1].index == 0
-        assert result.server_tool_deltas[1].output_delta == "1\n"
-        # Second pair at index 1
-        assert result.server_tool_deltas[2].index == 1
-        assert result.server_tool_deltas[2].name == "code_execution"
         assert result.server_tool_deltas[3].index == 1
         assert result.server_tool_deltas[3].output_delta == "2\n"
 
 
-# MARK: map_embed_content_response
+# MARK: map_batch_embeddings_response
 
 
-class TestMapEmbedContentResponse:
+class TestMapBatchEmbeddingsResponse:
     def test_single_embedding(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = MagicMock()
-        emb = MagicMock()
-        emb.values = [0.1, 0.2, 0.3]
-        response.embeddings = [emb]
-        response.metadata = None
-
-        result = map_embed_content_response(response, "text-embedding-005", "google", noop_cost_fn)
+        response = {"embeddings": [{"values": [0.1, 0.2, 0.3]}]}
+        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
         assert result == EmbeddingResponse(
             embeddings=[[0.1, 0.2, 0.3]],
             usage=Usage(input_tokens=0, output_tokens=0),
@@ -750,82 +588,30 @@ class TestMapEmbedContentResponse:
         )
 
     def test_multiple_embeddings(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = MagicMock()
-        emb1 = MagicMock()
-        emb1.values = [0.1, 0.2]
-        emb2 = MagicMock()
-        emb2.values = [0.3, 0.4]
-        response.embeddings = [emb1, emb2]
-        response.metadata = None
-
-        result = map_embed_content_response(response, "text-embedding-005", "google", noop_cost_fn)
+        response = {"embeddings": [{"values": [0.1, 0.2]}, {"values": [0.3, 0.4]}]}
+        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
         assert result.embeddings == [[0.1, 0.2], [0.3, 0.4]]
 
     def test_empty_embeddings(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = MagicMock()
-        response.embeddings = None
-        response.metadata = None
-
-        result = map_embed_content_response(response, "text-embedding-005", "google", noop_cost_fn)
+        result = map_batch_embeddings_response({"embeddings": None}, "text-embedding-005", "google", noop_cost_fn)
         assert result.embeddings == []
 
     def test_embedding_with_none_values(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = MagicMock()
-        emb = MagicMock()
-        emb.values = None
-        response.embeddings = [emb]
-        response.metadata = None
-
-        result = map_embed_content_response(response, "text-embedding-005", "google", noop_cost_fn)
+        response = {"embeddings": [{"values": None}]}
+        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
         assert result.embeddings == [[]]
 
     def test_cost_none_for_unknown(self, none_cost_fn: Any) -> None:  # noqa: ANN401
-        response = MagicMock()
-        response.embeddings = [MagicMock(values=[0.1])]
-        response.metadata = None
-
-        result = map_embed_content_response(response, "unknown-model", "google", none_cost_fn)
+        response = {"embeddings": [{"values": [0.1]}]}
+        result = map_batch_embeddings_response(response, "unknown-model", "google", none_cost_fn)
         assert result.cost is None
 
     def test_approximates_tokens_from_billable_characters(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = MagicMock()
-        emb = MagicMock()
-        emb.values = [0.1]
-        response.embeddings = [emb]
-        metadata = MagicMock()
-        metadata.billable_character_count = 400
-        response.metadata = metadata
-
-        result = map_embed_content_response(response, "text-embedding-005", "google", noop_cost_fn)
+        response = {"embeddings": [{"values": [0.1]}], "metadata": {"billableCharacterCount": 400}}
+        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
         assert result.usage == Usage(input_tokens=100, output_tokens=0)
 
     def test_billable_character_count_none_falls_back_to_zero(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = MagicMock()
-        emb = MagicMock()
-        emb.values = [0.1]
-        response.embeddings = [emb]
-        metadata = MagicMock()
-        metadata.billable_character_count = None
-        response.metadata = metadata
-
-        result = map_embed_content_response(response, "text-embedding-005", "google", noop_cost_fn)
+        response = {"embeddings": [{"values": [0.1]}], "metadata": {"billableCharacterCount": None}}
+        result = map_batch_embeddings_response(response, "text-embedding-005", "google", noop_cost_fn)
         assert result.usage == Usage(input_tokens=0, output_tokens=0)
-
-
-# MARK: map_tool_choice
-
-
-class TestMapToolChoice:
-    def test_auto(self) -> None:
-        assert map_tool_choice("auto") == {"function_calling_config": {"mode": "AUTO"}}
-
-    def test_required(self) -> None:
-        assert map_tool_choice("required") == {"function_calling_config": {"mode": "ANY"}}
-
-    def test_none(self) -> None:
-        assert map_tool_choice("none") == {"function_calling_config": {"mode": "NONE"}}
-
-    def test_specific_function(self) -> None:
-        assert map_tool_choice(ToolChoiceFunction(name="get_weather")) == {
-            "function_calling_config": {"mode": "ANY", "allowed_function_names": ["get_weather"]},
-        }

--- a/packages/lmux-google/tests/test_mappers.py
+++ b/packages/lmux-google/tests/test_mappers.py
@@ -42,8 +42,13 @@ from lmux_google._mappers import (
     map_response_format,
     map_tool_choice,
     map_tools,
+    map_vertex_embed_response,
 )
-from lmux_google._wire import WireBatchEmbeddingsResponse, WireGenerateContentResponse
+from lmux_google._wire import (
+    WireBatchEmbeddingsResponse,
+    WireGenerateContentResponse,
+    WireVertexPredictResponse,
+)
 
 # MARK: Fixtures
 
@@ -705,3 +710,48 @@ class TestMapBatchEmbeddingsResponse:
             WireBatchEmbeddingsResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
         )
         assert result.usage == Usage(input_tokens=0, output_tokens=0)
+
+
+# MARK: map_vertex_embed_response
+
+
+class TestMapVertexEmbedResponse:
+    def test_single_prediction(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        response = {"predictions": [{"embeddings": {"values": [0.1, 0.2], "statistics": {"token_count": 3}}}]}
+        result = map_vertex_embed_response(
+            WireVertexPredictResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
+        )
+        assert result == EmbeddingResponse(
+            embeddings=[[0.1, 0.2]],
+            usage=Usage(input_tokens=3, output_tokens=0),
+            cost=Cost(input_cost=0.0, output_cost=0.0, total_cost=0.0),
+            model="text-embedding-005",
+            provider="google",
+        )
+
+    def test_multiple_predictions_sum_tokens(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        response = {
+            "predictions": [
+                {"embeddings": {"values": [0.1], "statistics": {"token_count": 2}}},
+                {"embeddings": {"values": [0.2], "statistics": {"token_count": 4}}},
+            ]
+        }
+        result = map_vertex_embed_response(
+            WireVertexPredictResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
+        )
+        assert result.embeddings == [[0.1], [0.2]]
+        assert result.usage == Usage(input_tokens=6, output_tokens=0)
+
+    def test_missing_statistics_defaults_tokens_to_zero(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        response = {"predictions": [{"embeddings": {"values": [0.1]}}]}
+        result = map_vertex_embed_response(
+            WireVertexPredictResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
+        )
+        assert result.usage == Usage(input_tokens=0, output_tokens=0)
+
+    def test_cost_none_for_unknown(self, none_cost_fn: Any) -> None:  # noqa: ANN401
+        response = {"predictions": [{"embeddings": {"values": [0.1]}}]}
+        result = map_vertex_embed_response(
+            WireVertexPredictResponse.model_validate(response), "unknown-model", "google", none_cost_fn
+        )
+        assert result.cost is None

--- a/packages/lmux-google/tests/test_mappers.py
+++ b/packages/lmux-google/tests/test_mappers.py
@@ -36,6 +36,7 @@ from lmux.types import (
 from lmux_google._mappers import (
     Json,
     map_batch_embeddings_response,
+    map_embed_content_response,
     map_generate_content_chunk,
     map_generate_content_response,
     map_messages,
@@ -46,6 +47,7 @@ from lmux_google._mappers import (
 )
 from lmux_google._wire import (
     WireBatchEmbeddingsResponse,
+    WireEmbedContentResponse,
     WireGenerateContentResponse,
     WireVertexPredictResponse,
 )
@@ -697,15 +699,15 @@ class TestMapBatchEmbeddingsResponse:
         )
         assert result.cost is None
 
-    def test_approximates_tokens_from_billable_characters(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = {"embeddings": [{"values": [0.1]}], "metadata": {"billableCharacterCount": 400}}
+    def test_tokens_from_usage_metadata(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        response = {"embeddings": [{"values": [0.1]}], "usageMetadata": {"promptTokenCount": 42}}
         result = map_batch_embeddings_response(
             WireBatchEmbeddingsResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
         )
-        assert result.usage == Usage(input_tokens=100, output_tokens=0)
+        assert result.usage == Usage(input_tokens=42, output_tokens=0)
 
-    def test_billable_character_count_none_falls_back_to_zero(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
-        response = {"embeddings": [{"values": [0.1]}], "metadata": {"billableCharacterCount": None}}
+    def test_missing_usage_metadata_falls_back_to_zero(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
+        response = {"embeddings": [{"values": [0.1]}]}
         result = map_batch_embeddings_response(
             WireBatchEmbeddingsResponse.model_validate(response), "text-embedding-005", "google", noop_cost_fn
         )
@@ -755,3 +757,20 @@ class TestMapVertexEmbedResponse:
             WireVertexPredictResponse.model_validate(response), "unknown-model", "google", none_cost_fn
         )
         assert result.cost is None
+
+
+# MARK: map_embed_content_response
+
+
+class TestMapEmbedContentResponse:
+    def test_values_and_tokens(self) -> None:
+        response = {"embedding": {"values": [0.1, 0.2]}, "usageMetadata": {"promptTokenCount": 7}}
+        values, tokens = map_embed_content_response(WireEmbedContentResponse.model_validate(response))
+        assert values == [0.1, 0.2]
+        assert tokens == 7
+
+    def test_missing_usage_defaults_to_zero(self) -> None:
+        response = {"embedding": {"values": [0.3]}}
+        values, tokens = map_embed_content_response(WireEmbedContentResponse.model_validate(response))
+        assert values == [0.3]
+        assert tokens == 0

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -87,6 +87,28 @@ def provider(api_auth: FakeAPIKeyAuth) -> GoogleProvider:
     return GoogleProvider(auth=api_auth, vertexai=False)
 
 
+@pytest.fixture
+def sync_create_raises(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_google.provider.create_sync_client", side_effect=RuntimeError("client init failed"))
+
+
+@pytest.fixture
+def async_create_raises(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_google.provider.create_async_client", side_effect=RuntimeError("client init failed"))
+
+
+@pytest.fixture
+def async_create_two_clients(mocker: MockerFixture) -> tuple[MagicMock, MagicMock, MagicMock]:
+    c1, c2 = MagicMock(), MagicMock()
+    create = mocker.patch("lmux_google.provider.create_async_client", side_effect=[c1, c2])
+    return create, c1, c2
+
+
+@pytest.fixture
+def mock_get_running_loop(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_google.provider.asyncio.get_running_loop")
+
+
 def _gen_response(
     text: str = "Hello!", prompt_tokens: int = 10, output_tokens: int = 5, *, finish_reason: str = "STOP"
 ) -> dict[str, Any]:
@@ -302,11 +324,11 @@ class TestChatStream:
         with pytest.raises(ProviderError, match="mid-stream boom"):
             next(stream)
 
-    def test_client_init_failure(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_google.provider.create_sync_client", side_effect=RuntimeError("boom"))
+    def test_client_init_failure(self, api_auth: FakeAPIKeyAuth, sync_create_raises: MagicMock) -> None:
         provider = GoogleProvider(auth=api_auth, vertexai=False)
-        with pytest.raises(ProviderError, match="boom"):
+        with pytest.raises(ProviderError, match="client init failed"):
             list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+        sync_create_raises.assert_called_once()
 
 
 # MARK: AchatStream
@@ -349,12 +371,12 @@ class TestAchatStream:
         with pytest.raises(ProviderError, match="mid-stream boom"):
             await anext(stream)
 
-    async def test_client_init_failure(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_google.provider.create_async_client", side_effect=RuntimeError("boom"))
+    async def test_client_init_failure(self, api_auth: FakeAPIKeyAuth, async_create_raises: MagicMock) -> None:
         provider = GoogleProvider(auth=api_auth, vertexai=False)
-        with pytest.raises(ProviderError, match="boom"):
+        with pytest.raises(ProviderError, match="client init failed"):
             async for _ in provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass  # pragma: no cover
+        async_create_raises.assert_called_once()
 
 
 # MARK: Embed
@@ -491,24 +513,27 @@ class TestClientManagement:
         assert provider._sync_client is not None
         assert provider._sync_client.timeout.read == 30.0
 
-    def test_sync_init_failure_mapped(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_google.provider.create_sync_client", side_effect=RuntimeError("connection refused"))
+    def test_sync_init_failure_mapped(self, api_auth: FakeAPIKeyAuth, sync_create_raises: MagicMock) -> None:
         provider = GoogleProvider(auth=api_auth, vertexai=False)
-        with pytest.raises(ProviderError, match="connection refused"):
+        with pytest.raises(ProviderError, match="client init failed"):
             provider.chat(MODEL, [UserMessage(content="Hi")])
+        sync_create_raises.assert_called_once()
 
-    async def test_async_init_failure_mapped(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_google.provider.create_async_client", side_effect=RuntimeError("connection refused"))
+    async def test_async_init_failure_mapped(self, api_auth: FakeAPIKeyAuth, async_create_raises: MagicMock) -> None:
         provider = GoogleProvider(auth=api_auth, vertexai=False)
-        with pytest.raises(ProviderError, match="connection refused"):
+        with pytest.raises(ProviderError, match="client init failed"):
             await provider.achat(MODEL, [UserMessage(content="Hi")])
+        async_create_raises.assert_called_once()
 
-    async def test_async_client_recreated_on_new_loop(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
-        c1, c2 = MagicMock(), MagicMock()
-        create = mocker.patch("lmux_google.provider.create_async_client", side_effect=[c1, c2])
-        get_loop = mocker.patch("lmux_google.provider.asyncio.get_running_loop")
+    async def test_async_client_recreated_on_new_loop(
+        self,
+        api_auth: FakeAPIKeyAuth,
+        async_create_two_clients: tuple[MagicMock, MagicMock, MagicMock],
+        mock_get_running_loop: MagicMock,
+    ) -> None:
+        create, c1, c2 = async_create_two_clients
         loop1, loop2 = asyncio.new_event_loop(), asyncio.new_event_loop()
-        get_loop.side_effect = [loop1, loop2]
+        mock_get_running_loop.side_effect = [loop1, loop2]
         provider = GoogleProvider(auth=api_auth, vertexai=False)
         r1 = await provider._get_async_client()
         r2 = await provider._get_async_client()

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -36,6 +36,9 @@ from lmux_google.params import (
 from lmux_google.provider import GoogleProvider
 
 _GEMINI = "https://generativelanguage.googleapis.com/v1beta/models"
+_VERTEX_MODELS = (
+    "https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models"
+)
 MODEL = "gemini-2.0-flash"
 EMBED_MODEL = "text-embedding-005"
 _CHAT_URL = f"{_GEMINI}/{MODEL}:generateContent"
@@ -423,62 +426,6 @@ class TestEmbed:
             provider.embed(EMBED_MODEL, "hello")
 
 
-# MARK: gemini-embedding-001 (one input per request)
-
-
-_GEMINI_EMBED_001 = "gemini-embedding-001"
-
-
-class TestGeminiEmbedding001Batching:
-    # The whole gemini-embedding-* family is one-input-per-request; on the Developer API a multi-input
-    # request would otherwise silently return a single aggregated embedding.
-    @pytest.mark.parametrize("model", ["gemini-embedding-001", "gemini-embedding-2-preview"])
-    def test_dev_api_splits_into_one_request_per_input(
-        self, model: str, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter
-    ) -> None:
-        url = f"{_GEMINI}/{model}:batchEmbedContents"
-        responses = [
-            httpx.Response(200, json={"embeddings": [{"values": [0.1]}], "usageMetadata": {"promptTokenCount": 2}}),
-            httpx.Response(200, json={"embeddings": [{"values": [0.2]}], "usageMetadata": {"promptTokenCount": 3}}),
-        ]
-        route = respx_mock.post(url).mock(side_effect=responses)
-        provider = GoogleProvider(auth=api_auth, vertexai=False)
-        result = provider.embed(model, ["a", "b"])
-        assert result.embeddings == [[0.1], [0.2]]
-        assert result.usage.input_tokens == 5
-        assert len(route.calls) == 2
-        # Each request carries exactly one input.
-        assert [len(json.loads(c.request.content)["requests"]) for c in route.calls] == [1, 1]
-
-    def test_vertex_splits_into_one_request_per_input(self, respx_mock: respx.MockRouter) -> None:
-        creds = FakeCredentials()
-        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
-        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{_GEMINI_EMBED_001}:predict"
-        responses = [
-            httpx.Response(200, json={"predictions": [{"embeddings": {"values": [0.1]}}]}),
-            httpx.Response(200, json={"predictions": [{"embeddings": {"values": [0.2]}}]}),
-        ]
-        route = respx_mock.post(url).mock(side_effect=responses)
-        result = provider.embed(_GEMINI_EMBED_001, ["a", "b"])
-        assert result.embeddings == [[0.1], [0.2]]
-        assert len(route.calls) == 2
-        assert json.loads(route.calls[0].request.content) == {"instances": [{"content": "a"}]}
-
-    async def test_aembed_splits_into_one_request_per_input(
-        self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter
-    ) -> None:
-        url = f"{_GEMINI}/{_GEMINI_EMBED_001}:batchEmbedContents"
-        responses = [
-            httpx.Response(200, json={"embeddings": [{"values": [0.1]}]}),
-            httpx.Response(200, json={"embeddings": [{"values": [0.2]}]}),
-        ]
-        route = respx_mock.post(url).mock(side_effect=responses)
-        provider = GoogleProvider(auth=api_auth, vertexai=False)
-        result = await provider.aembed(_GEMINI_EMBED_001, ["a", "b"])
-        assert result.embeddings == [[0.1], [0.2]]
-        assert len(route.calls) == 2
-
-
 # MARK: Aembed
 
 
@@ -618,6 +565,44 @@ class TestVertexEmbed:
         result = await provider.aembed(EMBED_MODEL, "hello")
         assert result.embeddings == [[0.3]]
         assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
+
+    def test_gemini_embedding_001_splits_into_one_request_per_input(self, respx_mock: respx.MockRouter) -> None:
+        # Vertex :predict serves gemini-embedding-001 one input at a time, so a list becomes N requests.
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"{_VERTEX_MODELS}/gemini-embedding-001:predict"
+        responses = [
+            httpx.Response(200, json={"predictions": [{"embeddings": {"values": [0.1]}}]}),
+            httpx.Response(200, json={"predictions": [{"embeddings": {"values": [0.2]}}]}),
+        ]
+        route = respx_mock.post(url).mock(side_effect=responses)
+        result = provider.embed("gemini-embedding-001", ["a", "b"])
+        assert result.embeddings == [[0.1], [0.2]]
+        assert len(route.calls) == 2
+        assert json.loads(route.calls[0].request.content) == {"instances": [{"content": "a"}]}
+
+    async def test_aembed_gemini_embedding_001_splits_into_one_request_per_input(
+        self, respx_mock: respx.MockRouter
+    ) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"{_VERTEX_MODELS}/gemini-embedding-001:predict"
+        responses = [
+            httpx.Response(200, json={"predictions": [{"embeddings": {"values": [0.1]}}]}),
+            httpx.Response(200, json={"predictions": [{"embeddings": {"values": [0.2]}}]}),
+        ]
+        route = respx_mock.post(url).mock(side_effect=responses)
+        result = await provider.aembed("gemini-embedding-001", ["a", "b"])
+        assert result.embeddings == [[0.1], [0.2]]
+        assert len(route.calls) == 2
+
+    def test_gemini_embedding_001_empty_input_makes_no_request(self, respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        result = provider.embed("gemini-embedding-001", [])
+        assert result.embeddings == []
+        assert result.usage.input_tokens == 0
+        assert not respx_mock.calls
 
 
 # MARK: Vertex embedContent (Gemini Embedding 2)

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -227,7 +227,7 @@ class TestChat:
         provider.chat(MODEL, [UserMessage(content="Hi")], response_format=rf)
         body = json.loads(route.calls.last.request.content)
         assert body["generationConfig"]["responseMimeType"] == "application/json"
-        assert body["generationConfig"]["responseSchema"] == {"type": "object"}
+        assert body["generationConfig"]["responseJsonSchema"] == {"type": "object"}
 
     def test_reasoning_effort(
         self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
@@ -479,6 +479,75 @@ class TestVertexTransport:
         provider = GoogleProvider(auth=FakeCredentialsAuth(creds))
         with pytest.raises(ProviderError, match="requires a project"):
             provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    def test_vertex_reresolves_token_per_request(
+        self, gen_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{MODEL}:generateContent"
+        route = respx_mock.post(url).mock(return_value=httpx.Response(200, json=gen_response))
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.calls[0].request.headers["authorization"] == "Bearer vertex-token"
+        # Credentials expire between requests — the second call must resolve a fresh token, not reuse baked headers.
+        creds.valid = False
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.calls[1].request.headers["authorization"] == "Bearer refreshed-token"
+
+    async def test_vertex_async_bearer(self, gen_response: dict[str, Any], respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{MODEL}:generateContent"
+        route = respx_mock.post(url).mock(return_value=httpx.Response(200, json=gen_response))
+        await provider.achat(MODEL, [UserMessage(content="Hi")])
+        assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
+
+
+# MARK: Vertex Embeddings
+
+
+class TestVertexEmbed:
+    def test_predict_endpoint_and_shape(self, respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{EMBED_MODEL}:predict"
+        predictions = {"predictions": [{"embeddings": {"values": [0.1, 0.2], "statistics": {"token_count": 3}}}]}
+        route = respx_mock.post(url).mock(return_value=httpx.Response(200, json=predictions))
+        result = provider.embed(EMBED_MODEL, "hello")
+        assert result.embeddings == [[0.1, 0.2]]
+        assert result.usage.input_tokens == 3
+        assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"instances": [{"content": "hello"}]}
+
+    def test_dimensions_and_task_type(self, respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{EMBED_MODEL}:predict"
+        predictions = {"predictions": [{"embeddings": {"values": [0.1]}}, {"embeddings": {"values": [0.2]}}]}
+        route = respx_mock.post(url).mock(return_value=httpx.Response(200, json=predictions))
+        result = provider.embed(
+            EMBED_MODEL, ["a", "b"], dimensions=256, provider_params=GoogleParams(task_type="RETRIEVAL_QUERY")
+        )
+        assert result.embeddings == [[0.1], [0.2]]
+        body = json.loads(route.calls.last.request.content)
+        assert body == {
+            "instances": [
+                {"content": "a", "task_type": "RETRIEVAL_QUERY"},
+                {"content": "b", "task_type": "RETRIEVAL_QUERY"},
+            ],
+            "parameters": {"outputDimensionality": 256},
+        }
+
+    async def test_aembed_predict(self, respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{EMBED_MODEL}:predict"
+        predictions = {"predictions": [{"embeddings": {"values": [0.3]}}]}
+        route = respx_mock.post(url).mock(return_value=httpx.Response(200, json=predictions))
+        result = await provider.aembed(EMBED_MODEL, "hello")
+        assert result.embeddings == [[0.3]]
+        assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
 
 
 # MARK: Client Management

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -220,6 +220,11 @@ class TestChat:
         with pytest.raises(InvalidRequestError):
             provider.chat(MODEL, [UserMessage(content="Hi")])
 
+    def test_non_json_body_mapped(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_CHAT_URL).mock(return_value=httpx.Response(200, content=b"not json"))
+        with pytest.raises(ProviderError):
+            provider.chat(MODEL, [UserMessage(content="Hi")])
+
     def test_transport_error_mapped(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
         respx_mock.post(_CHAT_URL).mock(side_effect=httpx.ConnectError("refused"))
         with pytest.raises(ProviderError, match="refused"):
@@ -251,6 +256,12 @@ class TestAchat:
         with pytest.raises(ProviderError, match="refused"):
             await provider.achat(MODEL, [UserMessage(content="Hi")])
 
+    async def test_non_json_body_mapped(self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_CHAT_URL).mock(return_value=httpx.Response(200, content=b"not json"))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        with pytest.raises(ProviderError):
+            await provider.achat(MODEL, [UserMessage(content="Hi")])
+
 
 # MARK: ChatStream
 
@@ -278,6 +289,18 @@ class TestChatStream:
         respx_mock.post(_STREAM_URL).mock(return_value=httpx.Response(200, content=b"data: {not json}\n\n"))
         with pytest.raises(ProviderError):
             list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
+    def test_mid_stream_error_raises_after_partial(
+        self, provider: GoogleProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        first = {"candidates": [{"content": {"parts": [{"text": "Hel"}]}}]}
+        error = {"error": {"message": "mid-stream boom"}}
+        sse = (f"data: {json.dumps(first)}\n\ndata: {json.dumps(error)}\n\n").encode()
+        respx_mock.post(_STREAM_URL).mock(return_value=httpx.Response(200, content=sse))
+        stream = provider.chat_stream(MODEL, [UserMessage(content="Hi")])
+        assert next(stream).delta == "Hel"  # partial output arrives first
+        with pytest.raises(ProviderError, match="mid-stream boom"):
+            next(stream)
 
     def test_client_init_failure(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
         mocker.patch("lmux_google.provider.create_sync_client", side_effect=RuntimeError("boom"))
@@ -312,6 +335,19 @@ class TestAchatStream:
         with pytest.raises(ProviderError):
             async for _ in provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass  # pragma: no cover
+
+    async def test_mid_stream_error_raises_after_partial(
+        self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter
+    ) -> None:
+        first = {"candidates": [{"content": {"parts": [{"text": "Hel"}]}}]}
+        error = {"error": {"message": "mid-stream boom"}}
+        sse = (f"data: {json.dumps(first)}\n\ndata: {json.dumps(error)}\n\n").encode()
+        respx_mock.post(_STREAM_URL).mock(return_value=httpx.Response(200, content=sse))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        stream = provider.achat_stream(MODEL, [UserMessage(content="Hi")])
+        assert (await anext(stream)).delta == "Hel"  # partial output arrives first
+        with pytest.raises(ProviderError, match="mid-stream boom"):
+            await anext(stream)
 
     async def test_client_init_failure(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
         mocker.patch("lmux_google.provider.create_async_client", side_effect=RuntimeError("boom"))

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -417,6 +417,67 @@ class TestEmbed:
         with pytest.raises(ProviderError, match="refused"):
             provider.embed(EMBED_MODEL, "hello")
 
+    def test_status_error_mapped(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_EMBED_URL).mock(return_value=httpx.Response(404, json={"error": {"message": "no"}}))
+        with pytest.raises(NotFoundError):
+            provider.embed(EMBED_MODEL, "hello")
+
+
+# MARK: gemini-embedding-001 (one input per request)
+
+
+_GEMINI_EMBED_001 = "gemini-embedding-001"
+
+
+class TestGeminiEmbedding001Batching:
+    # The whole gemini-embedding-* family is one-input-per-request; on the Developer API a multi-input
+    # request would otherwise silently return a single aggregated embedding.
+    @pytest.mark.parametrize("model", ["gemini-embedding-001", "gemini-embedding-2-preview"])
+    def test_dev_api_splits_into_one_request_per_input(
+        self, model: str, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter
+    ) -> None:
+        url = f"{_GEMINI}/{model}:batchEmbedContents"
+        responses = [
+            httpx.Response(200, json={"embeddings": [{"values": [0.1]}], "usageMetadata": {"promptTokenCount": 2}}),
+            httpx.Response(200, json={"embeddings": [{"values": [0.2]}], "usageMetadata": {"promptTokenCount": 3}}),
+        ]
+        route = respx_mock.post(url).mock(side_effect=responses)
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        result = provider.embed(model, ["a", "b"])
+        assert result.embeddings == [[0.1], [0.2]]
+        assert result.usage.input_tokens == 5
+        assert len(route.calls) == 2
+        # Each request carries exactly one input.
+        assert [len(json.loads(c.request.content)["requests"]) for c in route.calls] == [1, 1]
+
+    def test_vertex_splits_into_one_request_per_input(self, respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{_GEMINI_EMBED_001}:predict"
+        responses = [
+            httpx.Response(200, json={"predictions": [{"embeddings": {"values": [0.1]}}]}),
+            httpx.Response(200, json={"predictions": [{"embeddings": {"values": [0.2]}}]}),
+        ]
+        route = respx_mock.post(url).mock(side_effect=responses)
+        result = provider.embed(_GEMINI_EMBED_001, ["a", "b"])
+        assert result.embeddings == [[0.1], [0.2]]
+        assert len(route.calls) == 2
+        assert json.loads(route.calls[0].request.content) == {"instances": [{"content": "a"}]}
+
+    async def test_aembed_splits_into_one_request_per_input(
+        self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter
+    ) -> None:
+        url = f"{_GEMINI}/{_GEMINI_EMBED_001}:batchEmbedContents"
+        responses = [
+            httpx.Response(200, json={"embeddings": [{"values": [0.1]}]}),
+            httpx.Response(200, json={"embeddings": [{"values": [0.2]}]}),
+        ]
+        route = respx_mock.post(url).mock(side_effect=responses)
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        result = await provider.aembed(_GEMINI_EMBED_001, ["a", "b"])
+        assert result.embeddings == [[0.1], [0.2]]
+        assert len(route.calls) == 2
+
 
 # MARK: Aembed
 

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -55,9 +55,10 @@ class FakeAPIKeyAuth:
 
 
 class FakeCredentials:
-    def __init__(self, *, valid: bool = True, token: str = "vertex-token") -> None:  # noqa: S107
+    def __init__(self, *, valid: bool = True, token: str = "vertex-token", quota_project_id: str | None = None) -> None:  # noqa: S107
         self.valid = valid
         self.token = token
+        self.quota_project_id = quota_project_id
         self.refreshed = False
 
     def refresh(self, _request: Any) -> None:  # noqa: ANN401
@@ -502,6 +503,14 @@ class TestVertexTransport:
         await provider.achat(MODEL, [UserMessage(content="Hi")])
         assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
 
+    def test_vertex_quota_project_header(self, gen_response: dict[str, Any], respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials(quota_project_id="quota-proj")
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{MODEL}:generateContent"
+        route = respx_mock.post(url).mock(return_value=httpx.Response(200, json=gen_response))
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.calls.last.request.headers["x-goog-user-project"] == "quota-proj"
+
 
 # MARK: Vertex Embeddings
 
@@ -548,6 +557,93 @@ class TestVertexEmbed:
         result = await provider.aembed(EMBED_MODEL, "hello")
         assert result.embeddings == [[0.3]]
         assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
+
+
+# MARK: Vertex embedContent (Gemini Embedding 2)
+
+
+_EMBED2_MODEL = "gemini-embedding-2-preview"
+
+
+def _embed_content_url(model: str = _EMBED2_MODEL) -> str:
+    base = "https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models"
+    return f"{base}/{model}:embedContent"
+
+
+def _vertex_embed2_provider() -> GoogleProvider:
+    return GoogleProvider(auth=FakeCredentialsAuth(FakeCredentials()), project="my-proj", location="us-central1")
+
+
+class TestVertexEmbedContent:
+    def test_single_input_endpoint_and_shape(self, respx_mock: respx.MockRouter) -> None:
+        body = {"embedding": {"values": [0.1, 0.2]}, "usageMetadata": {"promptTokenCount": 4}}
+        route = respx_mock.post(_embed_content_url()).mock(return_value=httpx.Response(200, json=body))
+        result = _vertex_embed2_provider().embed(_EMBED2_MODEL, "hello")
+        assert result.embeddings == [[0.1, 0.2]]
+        assert result.usage.input_tokens == 4
+        assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
+        # embedContent is single-content and rejects task_type — the body carries neither instances nor task_type.
+        assert json.loads(route.calls.last.request.content) == {"content": {"parts": [{"text": "hello"}]}}
+
+    def test_list_issues_one_request_per_item(self, respx_mock: respx.MockRouter) -> None:
+        responses = [
+            httpx.Response(200, json={"embedding": {"values": [0.1]}, "usageMetadata": {"promptTokenCount": 2}}),
+            httpx.Response(200, json={"embedding": {"values": [0.2]}, "usageMetadata": {"promptTokenCount": 3}}),
+        ]
+        route = respx_mock.post(_embed_content_url()).mock(side_effect=responses)
+        result = _vertex_embed2_provider().embed(_EMBED2_MODEL, ["a", "b"])
+        assert result.embeddings == [[0.1], [0.2]]
+        assert result.usage.input_tokens == 5
+        assert len(route.calls) == 2
+        assert json.loads(route.calls[0].request.content) == {"content": {"parts": [{"text": "a"}]}}
+
+    def test_dimensions_forwarded(self, respx_mock: respx.MockRouter) -> None:
+        body = {"embedding": {"values": [0.1]}}
+        route = respx_mock.post(_embed_content_url()).mock(return_value=httpx.Response(200, json=body))
+        _vertex_embed2_provider().embed(_EMBED2_MODEL, "hi", dimensions=128)
+        assert json.loads(route.calls.last.request.content) == {
+            "content": {"parts": [{"text": "hi"}]},
+            "outputDimensionality": 128,
+        }
+
+    async def test_aembed_content(self, respx_mock: respx.MockRouter) -> None:
+        body = {"embedding": {"values": [0.5]}, "usageMetadata": {"promptTokenCount": 1}}
+        route = respx_mock.post(_embed_content_url()).mock(return_value=httpx.Response(200, json=body))
+        result = await _vertex_embed2_provider().aembed(_EMBED2_MODEL, "hi")
+        assert result.embeddings == [[0.5]]
+        assert result.usage.input_tokens == 1
+        assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
+
+    def test_status_error_mapped(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_embed_content_url()).mock(return_value=httpx.Response(404, json={"error": {"message": "no"}}))
+        with pytest.raises(NotFoundError):
+            _vertex_embed2_provider().embed(_EMBED2_MODEL, "hi")
+
+    def test_transport_error_mapped(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_embed_content_url()).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            _vertex_embed2_provider().embed(_EMBED2_MODEL, "hi")
+
+    async def test_aembed_transport_error_mapped(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_embed_content_url()).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            await _vertex_embed2_provider().aembed(_EMBED2_MODEL, "hi")
+
+    async def test_aembed_status_error_mapped(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_embed_content_url()).mock(return_value=httpx.Response(404, json={"error": {"message": "no"}}))
+        with pytest.raises(NotFoundError):
+            await _vertex_embed2_provider().aembed(_EMBED2_MODEL, "hi")
+
+    async def test_aembed_list_issues_one_request_per_item(self, respx_mock: respx.MockRouter) -> None:
+        responses = [
+            httpx.Response(200, json={"embedding": {"values": [0.1]}, "usageMetadata": {"promptTokenCount": 2}}),
+            httpx.Response(200, json={"embedding": {"values": [0.2]}, "usageMetadata": {"promptTokenCount": 3}}),
+        ]
+        route = respx_mock.post(_embed_content_url()).mock(side_effect=responses)
+        result = await _vertex_embed2_provider().aembed(_EMBED2_MODEL, ["a", "b"])
+        assert result.embeddings == [[0.1], [0.2]]
+        assert result.usage.input_tokens == 5
+        assert len(route.calls) == 2
 
 
 # MARK: Client Management

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -1,24 +1,27 @@
-"""Tests for the Google provider."""
+"""Tests for the Google provider (SDK-lite, respx)."""
 
 import asyncio
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+import json
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
 
+import httpx
 import pytest
+import respx
 from pytest_mock import MockerFixture
 
+if TYPE_CHECKING:
+    from google.auth.credentials import Credentials
+
 from lmux.cost import ModelPricing, PricingTier
-from lmux.exceptions import ProviderError
+from lmux.exceptions import AuthenticationError, InvalidRequestError, NotFoundError, ProviderError
 from lmux.types import (
-    ChatResponse,
-    EmbeddingResponse,
     FunctionDefinition,
     JsonObjectResponseFormat,
     JsonSchemaResponseFormat,
     SystemMessage,
     TextResponseFormat,
     Tool,
-    Usage,
     UserMessage,
 )
 from lmux_google import preload
@@ -32,22 +35,18 @@ from lmux_google.params import (
 )
 from lmux_google.provider import GoogleProvider
 
+_GEMINI = "https://generativelanguage.googleapis.com/v1beta/models"
+MODEL = "gemini-2.0-flash"
+EMBED_MODEL = "text-embedding-005"
+_CHAT_URL = f"{_GEMINI}/{MODEL}:generateContent"
+_STREAM_URL = f"{_GEMINI}/{MODEL}:streamGenerateContent"
+_EMBED_URL = f"{_GEMINI}/{EMBED_MODEL}:batchEmbedContents"
+
+
 # MARK: Shared Fixtures
 
 
-class FakeAuth:
-    """Fake auth provider for testing — returns mock Credentials."""
-
-    def get_credentials(self) -> MagicMock:
-        return MagicMock()
-
-    async def aget_credentials(self) -> MagicMock:
-        return MagicMock()
-
-
 class FakeAPIKeyAuth:
-    """Fake auth provider for testing — returns an API key string."""
-
     def get_credentials(self) -> str:
         return "test-api-key"
 
@@ -55,573 +54,373 @@ class FakeAPIKeyAuth:
         return "test-api-key"
 
 
-@pytest.fixture
-def fake_auth() -> FakeAuth:
-    return FakeAuth()
+class FakeCredentials:
+    def __init__(self, *, valid: bool = True, token: str = "vertex-token") -> None:  # noqa: S107
+        self.valid = valid
+        self.token = token
+        self.refreshed = False
+
+    def refresh(self, _request: Any) -> None:  # noqa: ANN401
+        self.refreshed = True
+        self.valid = True
+        self.token = "refreshed-token"  # noqa: S105
+
+
+class FakeCredentialsAuth:
+    def __init__(self, credentials: FakeCredentials) -> None:
+        self._credentials = credentials
+
+    def get_credentials(self) -> "Credentials":
+        return cast("Credentials", self._credentials)
+
+    async def aget_credentials(self) -> "Credentials":
+        return cast("Credentials", self._credentials)
 
 
 @pytest.fixture
-def fake_api_key_auth() -> FakeAPIKeyAuth:
+def api_auth() -> FakeAPIKeyAuth:
     return FakeAPIKeyAuth()
 
 
-def _make_response_mock(
-    text: str = "Hello!",
-    prompt_tokens: int = 10,
-    output_tokens: int = 5,
-    cached_tokens: int | None = None,
-    finish_reason: str = "STOP",
-) -> MagicMock:
-    """Create a mock GenerateContentResponse."""
-    response = MagicMock()
-    part = MagicMock()
-    part.thought = False
-    part.text = text
-    part.function_call = None
-    part.executable_code = None
-    part.code_execution_result = None
-
-    content = MagicMock()
-    content.parts = [part]
-    candidate = MagicMock()
-    candidate.content = content
-    candidate.finish_reason = MagicMock(value=finish_reason)
-
-    response.candidates = [candidate]
-
-    usage = MagicMock()
-    usage.prompt_token_count = prompt_tokens
-    usage.candidates_token_count = output_tokens
-    usage.cached_content_token_count = cached_tokens
-    usage.thoughts_token_count = None
-    response.usage_metadata = usage
-
-    return response
+@pytest.fixture
+def provider(api_auth: FakeAPIKeyAuth) -> GoogleProvider:
+    return GoogleProvider(auth=api_auth, vertexai=False)
 
 
-def _make_embed_response_mock(embeddings: list[list[float]], billable_character_count: int | None = None) -> MagicMock:
-    """Create a mock EmbedContentResponse."""
-    response = MagicMock()
-    emb_mocks = []
-    for values in embeddings:
-        emb = MagicMock()
-        emb.values = values
-        emb_mocks.append(emb)
-    response.embeddings = emb_mocks
-    metadata = MagicMock()
-    metadata.billable_character_count = billable_character_count
-    response.metadata = metadata
-    return response
+def _gen_response(
+    text: str = "Hello!", prompt_tokens: int = 10, output_tokens: int = 5, *, finish_reason: str = "STOP"
+) -> dict[str, Any]:
+    return {
+        "candidates": [{"content": {"role": "model", "parts": [{"text": text}]}, "finishReason": finish_reason}],
+        "usageMetadata": {"promptTokenCount": prompt_tokens, "candidatesTokenCount": output_tokens},
+    }
 
 
 @pytest.fixture
-def generate_response() -> MagicMock:
-    return _make_response_mock()
+def gen_response() -> dict[str, Any]:
+    return _gen_response()
 
 
-@pytest.fixture
-def embed_response() -> MagicMock:
-    return _make_embed_response_mock([[0.1, 0.2, 0.3]])
+def _sse_stream() -> bytes:
+    chunks = [
+        {"candidates": [{"content": {"parts": [{"text": "Hel"}]}}]},
+        {
+            "candidates": [{"content": {"parts": [{"text": "lo!"}]}, "finishReason": "STOP"}],
+            "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 5},
+        },
+    ]
+    lines = [f"data: {json.dumps(c)}" for c in chunks]
+    return ("\n\n".join(lines) + "\n\n").encode()
 
 
-@pytest.fixture
-def mock_client() -> MagicMock:
-    mock = MagicMock()
-    mock.aio.aclose = AsyncMock()
-    return mock
-
-
-@pytest.fixture
-def mock_create(mock_client: MagicMock, mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("lmux_google.provider.create_client", return_value=mock_client)
-
-
-@pytest.fixture
-def sync_provider(fake_auth: FakeAuth, mock_create: MagicMock) -> GoogleProvider:
-    mock_create.assert_not_called()
-    return GoogleProvider(auth=fake_auth)
-
-
-@pytest.fixture
-def async_provider(fake_auth: FakeAuth, mock_create: MagicMock) -> GoogleProvider:
-    mock_create.assert_not_called()
-    return GoogleProvider(auth=fake_auth)
-
-
-@pytest.fixture
-def server_error() -> Exception:
-    return Exception("test error")
+def _ok(respx_mock: respx.MockRouter, response: dict[str, Any], url: str = _CHAT_URL) -> respx.Route:
+    return respx_mock.post(url).mock(return_value=httpx.Response(200, json=response))
 
 
 # MARK: Chat
 
 
 class TestChat:
-    def test_basic_chat(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        result = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")])
-
-        assert result == ChatResponse(
-            content="Hello!",
-            tool_calls=None,
-            usage=Usage(input_tokens=10, output_tokens=5),
-            cost=result.cost,
-            model="gemini-2.0-flash",
-            provider="google",
-            finish_reason="stop",
-        )
+    def test_basic(self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter) -> None:
+        route = _ok(respx_mock, gen_response)
+        result = provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result.content == "Hello!"
+        assert result.model == MODEL
+        assert result.provider == "google"
+        assert result.usage is not None
+        assert result.usage.input_tokens == 10
         assert result.cost is not None
         assert result.cost.total_cost > 0
-        mock_client.models.generate_content.assert_called_once()
-        mock_client.models.embed_content.assert_not_called()
+        assert route.called
+        assert route.calls.last.request.headers["x-goog-api-key"] == "test-api-key"
 
-    def test_chat_with_params(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_request_body(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
+            [SystemMessage(content="Be helpful."), UserMessage(content="Hi")],
             temperature=0.5,
             max_tokens=100,
             top_p=0.9,
             stop=["END"],
         )
+        body = json.loads(route.calls.last.request.content)
+        assert body == {
+            "contents": [{"role": "user", "parts": [{"text": "Hi"}]}],
+            "systemInstruction": {"parts": [{"text": "Be helpful."}]},
+            "generationConfig": {
+                "temperature": 0.5,
+                "maxOutputTokens": 100,
+                "topP": 0.9,
+                "stopSequences": ["END"],
+            },
+        }
 
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        config = call_kwargs["config"]
-        assert config["temperature"] == 0.5
-        assert config["max_output_tokens"] == 100
-        assert config["top_p"] == 0.9
-        assert config["stop_sequences"] == ["END"]
-
-    def test_chat_with_stop_string(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_stop_string(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
+        route = _ok(respx_mock, gen_response)
+        provider.chat(MODEL, [UserMessage(content="Hi")], stop="STOP")
+        body = json.loads(route.calls.last.request.content)
+        assert body["generationConfig"]["stopSequences"] == ["STOP"]
 
-        _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")], stop="STOP")
-
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        assert call_kwargs["config"]["stop_sequences"] == ["STOP"]
-
-    def test_chat_with_tools(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_tools_and_choice(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        tools = [Tool(function=FunctionDefinition(name="get_weather"))]
-        _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")], tools=tools)
-
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        assert call_kwargs["config"]["tools"] == [{"function_declarations": [{"name": "get_weather"}]}]
-
-    def test_chat_with_tool_choice(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")], tool_choice="required")
-
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        assert call_kwargs["config"]["tool_config"] == {"function_calling_config": {"mode": "ANY"}}
-
-    def test_chat_with_text_response_format(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        result = sync_provider.chat(
-            "gemini-2.0-flash", [UserMessage(content="Hi")], response_format=TextResponseFormat()
-        )
-
-        assert result.content == "Hello!"
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        assert "response_mime_type" not in call_kwargs["config"]
-
-    def test_chat_with_json_response_format(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash", [UserMessage(content="Hi")], response_format=JsonObjectResponseFormat()
-        )
-
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        assert call_kwargs["config"]["response_mime_type"] == "application/json"
-
-    def test_chat_with_json_schema_response_format(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        rf = JsonSchemaResponseFormat(name="test", json_schema={"type": "object"})
-        _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")], response_format=rf)
-
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        assert call_kwargs["config"]["response_mime_type"] == "application/json"
-        assert call_kwargs["config"]["response_schema"] == {"type": "object"}
-
-    def test_chat_with_provider_params(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
-            provider_params=GoogleParams(
-                safety_settings=[SafetySetting(category="HARM_CATEGORY_HARASSMENT", threshold="BLOCK_NONE")],
-                presence_penalty=0.5,
-            ),
+            tools=[Tool(function=FunctionDefinition(name="get_weather"))],
+            tool_choice="required",
         )
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"functionDeclarations": [{"name": "get_weather"}]}]
+        assert body["toolConfig"] == {"functionCallingConfig": {"mode": "ANY"}}
 
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        config = call_kwargs["config"]
-        assert config["safety_settings"] == [
-            {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"},
-        ]
-        assert config["presence_penalty"] == 0.5
-
-    def test_chat_with_reasoning_effort(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_text_response_format_no_mime(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
+        route = _ok(respx_mock, gen_response)
+        provider.chat(MODEL, [UserMessage(content="Hi")], response_format=TextResponseFormat())
+        body = json.loads(route.calls.last.request.content)
+        assert "generationConfig" not in body
 
-        _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")], reasoning_effort="medium")
-
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        assert call_kwargs["config"]["thinking_config"] == {"thinking_budget": 8192, "include_thoughts": True}
-
-    def test_chat_exception_mapping(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, server_error: Exception
+    def test_json_object_response_format(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.side_effect = server_error
+        route = _ok(respx_mock, gen_response)
+        provider.chat(MODEL, [UserMessage(content="Hi")], response_format=JsonObjectResponseFormat())
+        body = json.loads(route.calls.last.request.content)
+        assert body["generationConfig"]["responseMimeType"] == "application/json"
+        assert "responseSchema" not in body["generationConfig"]
 
-        with pytest.raises(ProviderError):
-            _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")])
-
-    def test_chat_with_system_message(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_json_schema_response_format(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
+        route = _ok(respx_mock, gen_response)
+        rf = JsonSchemaResponseFormat(name="test", json_schema={"type": "object"})
+        provider.chat(MODEL, [UserMessage(content="Hi")], response_format=rf)
+        body = json.loads(route.calls.last.request.content)
+        assert body["generationConfig"]["responseMimeType"] == "application/json"
+        assert body["generationConfig"]["responseSchema"] == {"type": "object"}
 
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [SystemMessage(content="Be helpful."), UserMessage(content="Hi")],
-        )
+    def test_reasoning_effort(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock, gen_response)
+        provider.chat(MODEL, [UserMessage(content="Hi")], reasoning_effort="medium")
+        body = json.loads(route.calls.last.request.content)
+        assert body["generationConfig"]["thinkingConfig"] == {"thinkingBudget": 8192, "includeThoughts": True}
 
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        assert call_kwargs["config"]["system_instruction"] == "Be helpful."
-        assert call_kwargs["contents"] == [{"role": "user", "parts": [{"text": "Hi"}]}]
+    def test_status_error_mapped(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_CHAT_URL).mock(return_value=httpx.Response(400, json={"error": {"message": "bad"}}))
+        with pytest.raises(InvalidRequestError):
+            provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    def test_transport_error_mapped(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_CHAT_URL).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            provider.chat(MODEL, [UserMessage(content="Hi")])
 
 
 # MARK: Achat
 
 
 class TestAchat:
-    async def test_basic_achat(
-        self, async_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    async def test_basic(
+        self, api_auth: FakeAPIKeyAuth, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.aio.models.generate_content = AsyncMock(return_value=generate_response)
-
-        result = await async_provider.achat("gemini-2.0-flash", [UserMessage(content="Hi")])
-
+        _ok(respx_mock, gen_response)
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        result = await provider.achat(MODEL, [UserMessage(content="Hi")])
         assert result.content == "Hello!"
         assert result.provider == "google"
-        mock_client.aio.models.generate_content.assert_awaited_once()
-        mock_client.aio.models.embed_content.assert_not_called()
 
-    async def test_achat_exception_mapping(
-        self, async_provider: GoogleProvider, mock_client: MagicMock, server_error: Exception
-    ) -> None:
-        mock_client.aio.models.generate_content = AsyncMock(side_effect=server_error)
+    async def test_status_error_mapped(self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_CHAT_URL).mock(return_value=httpx.Response(401, json={"error": {"message": "no"}}))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        with pytest.raises(AuthenticationError):
+            await provider.achat(MODEL, [UserMessage(content="Hi")])
 
-        with pytest.raises(ProviderError):
-            _ = await async_provider.achat("gemini-2.0-flash", [UserMessage(content="Hi")])
+    async def test_transport_error_mapped(self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_CHAT_URL).mock(side_effect=httpx.ConnectError("refused"))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        with pytest.raises(ProviderError, match="refused"):
+            await provider.achat(MODEL, [UserMessage(content="Hi")])
 
 
 # MARK: ChatStream
 
 
 class TestChatStream:
-    def test_yields_chunks(
-        self,
-        sync_provider: GoogleProvider,
-        mock_client: MagicMock,
-    ) -> None:
-        chunk1 = _make_response_mock(text="Hello")
-        chunk1.usage_metadata = None
-        chunk1.candidates[0].finish_reason = None
-
-        chunk2 = _make_response_mock(text="")
-        chunk2.candidates[0].content = None
-        chunk2.candidates[0].finish_reason = MagicMock(value="STOP")
-        chunk2.usage_metadata = None
-
-        chunk3 = _make_response_mock()
-        chunk3.candidates = None
-
-        mock_client.models.generate_content_stream.return_value = iter([chunk1, chunk2, chunk3])
-
-        chunks = list(sync_provider.chat_stream("gemini-2.0-flash", [UserMessage(content="Hi")]))
-
-        assert len(chunks) == 3
-        assert chunks[0].delta == "Hello"
+    def test_yields_and_costs(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_STREAM_URL).mock(return_value=httpx.Response(200, content=_sse_stream()))
+        chunks = list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+        assert [c.delta for c in chunks[:2]] == ["Hel", "lo!"]
         assert chunks[1].finish_reason == "stop"
-        assert chunks[2].usage is not None
-        assert chunks[2].usage.input_tokens == 10
-        # The terminal (usage-carrying) chunk reports the serving endpoint identity,
-        # matching what the non-streaming path sets on ChatResponse.
-        assert chunks[2].provider == "google"
-        assert chunks[2].model == "gemini-2.0-flash"
-
-    def test_cost_on_usage_chunk(
-        self,
-        sync_provider: GoogleProvider,
-        mock_client: MagicMock,
-    ) -> None:
-        chunk1 = _make_response_mock(text="Hello")
-        chunk1.usage_metadata = None
-        chunk1.candidates[0].finish_reason = None
-
-        chunk2 = _make_response_mock()
-        chunk2.candidates = None
-
-        mock_client.models.generate_content_stream.return_value = iter([chunk1, chunk2])
-
-        chunks = list(sync_provider.chat_stream("gemini-2.0-flash", [UserMessage(content="Hi")]))
-
+        assert chunks[1].usage is not None
         assert chunks[0].cost is None
         assert chunks[1].cost is not None
         assert chunks[1].cost.total_cost > 0
+        assert chunks[1].provider == "google"
+        assert chunks[1].model == MODEL
+        assert route.calls.last.request.url.params["alt"] == "sse"
 
-    def test_stream_exception_on_create(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, server_error: Exception
-    ) -> None:
-        mock_client.models.generate_content_stream.side_effect = server_error
-
+    def test_status_error_on_open(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_STREAM_URL).mock(return_value=httpx.Response(500, json={"error": {"message": "boom"}}))
         with pytest.raises(ProviderError):
-            _ = list(sync_provider.chat_stream("gemini-2.0-flash", [UserMessage(content="Hi")]))
+            list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
-    def test_stream_exception_during_iteration(
-        self,
-        sync_provider: GoogleProvider,
-        mock_client: MagicMock,
-        server_error: Exception,
-    ) -> None:
-        def _failing_iter() -> Any:  # noqa: ANN401
-            yield _make_response_mock(text="Hi")
-            raise server_error
+    def test_malformed_chunk_mapped(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_STREAM_URL).mock(return_value=httpx.Response(200, content=b"data: {not json}\n\n"))
+        with pytest.raises(ProviderError):
+            list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
-        mock_client.models.generate_content_stream.return_value = _failing_iter()
-
-        with pytest.raises(ProviderError, match="test error"):
-            _ = list(sync_provider.chat_stream("gemini-2.0-flash", [UserMessage(content="Hi")]))
+    def test_client_init_failure(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_google.provider.create_sync_client", side_effect=RuntimeError("boom"))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        with pytest.raises(ProviderError, match="boom"):
+            list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
 
 # MARK: AchatStream
 
 
 class TestAchatStream:
-    async def test_yields_chunks(
-        self,
-        async_provider: GoogleProvider,
-        mock_client: MagicMock,
-    ) -> None:
-        chunk1 = _make_response_mock(text="Hello")
-        chunk1.usage_metadata = None
-        chunk1.candidates[0].finish_reason = None
-
-        chunk2 = _make_response_mock()
-        chunk2.candidates = None
-
-        async def _async_iter() -> Any:  # noqa: ANN401
-            yield chunk1
-            yield chunk2
-
-        async def _coro() -> Any:  # noqa: ANN401
-            return _async_iter()
-
-        mock_client.aio.models.generate_content_stream.return_value = _coro()
-
-        chunks = [chunk async for chunk in async_provider.achat_stream("gemini-2.0-flash", [UserMessage(content="Hi")])]
-
-        assert len(chunks) == 2
-        assert chunks[0].delta == "Hello"
+    async def test_yields_and_costs(self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_STREAM_URL).mock(return_value=httpx.Response(200, content=_sse_stream()))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        chunks = [c async for c in provider.achat_stream(MODEL, [UserMessage(content="Hi")])]
+        assert [c.delta for c in chunks[:2]] == ["Hel", "lo!"]
         assert chunks[1].cost is not None
-        # The terminal (usage-carrying) chunk reports the serving endpoint identity,
-        # matching what the non-streaming path sets on ChatResponse.
         assert chunks[1].provider == "google"
-        assert chunks[1].model == "gemini-2.0-flash"
+        assert chunks[1].model == MODEL
 
-    async def test_exception_during_stream(
-        self,
-        async_provider: GoogleProvider,
-        mock_client: MagicMock,
-        server_error: Exception,
-    ) -> None:
-        async def _failing_iter() -> Any:  # noqa: ANN401
-            yield _make_response_mock(text="Hi")
-            raise server_error
+    async def test_status_error_on_open(self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_STREAM_URL).mock(return_value=httpx.Response(500, json={"error": {"message": "boom"}}))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        with pytest.raises(ProviderError):
+            async for _ in provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
+                pass  # pragma: no cover
 
-        async def _coro() -> Any:  # noqa: ANN401
-            return _failing_iter()
+    async def test_malformed_chunk_mapped(self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_STREAM_URL).mock(return_value=httpx.Response(200, content=b"data: {nope}\n\n"))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        with pytest.raises(ProviderError):
+            async for _ in provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
+                pass  # pragma: no cover
 
-        mock_client.aio.models.generate_content_stream.return_value = _coro()
-
-        with pytest.raises(ProviderError, match="test error"):
-            async for _ in async_provider.achat_stream("gemini-2.0-flash", [UserMessage(content="Hi")]):
-                pass
+    async def test_client_init_failure(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_google.provider.create_async_client", side_effect=RuntimeError("boom"))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        with pytest.raises(ProviderError, match="boom"):
+            async for _ in provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
+                pass  # pragma: no cover
 
 
 # MARK: Embed
 
 
 class TestEmbed:
-    def test_basic_embed(
-        self,
-        sync_provider: GoogleProvider,
-        mock_client: MagicMock,
-        embed_response: MagicMock,
-    ) -> None:
-        mock_client.models.embed_content.return_value = embed_response
-
-        result = sync_provider.embed("text-embedding-005", "hello")
-
-        assert result == EmbeddingResponse(
-            embeddings=[[0.1, 0.2, 0.3]],
-            usage=Usage(input_tokens=0, output_tokens=0),
-            cost=result.cost,
-            model="text-embedding-005",
-            provider="google",
+    def test_basic(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_EMBED_URL).mock(
+            return_value=httpx.Response(200, json={"embeddings": [{"values": [0.1, 0.2, 0.3]}]})
         )
-        mock_client.models.embed_content.assert_called_once_with(
-            model="text-embedding-005", contents=["hello"], config=None
+        result = provider.embed(EMBED_MODEL, "hello")
+        assert result.embeddings == [[0.1, 0.2, 0.3]]
+        assert result.provider == "google"
+        body = json.loads(route.calls.last.request.content)
+        assert body == {"requests": [{"model": f"models/{EMBED_MODEL}", "content": {"parts": [{"text": "hello"}]}}]}
+
+    def test_list_input(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_EMBED_URL).mock(
+            return_value=httpx.Response(200, json={"embeddings": [{"values": [0.1]}, {"values": [0.2]}]})
         )
-        mock_client.models.generate_content.assert_not_called()
+        result = provider.embed(EMBED_MODEL, ["hello", "world"])
+        assert result.embeddings == [[0.1], [0.2]]
+        body = json.loads(route.calls.last.request.content)
+        assert [r["content"]["parts"][0]["text"] for r in body["requests"]] == ["hello", "world"]
 
-    def test_embed_list_input(
-        self,
-        sync_provider: GoogleProvider,
-        mock_client: MagicMock,
-    ) -> None:
-        mock_client.models.embed_content.return_value = _make_embed_response_mock([[0.1, 0.2], [0.3, 0.4]])
-
-        result = sync_provider.embed("text-embedding-005", ["hello", "world"])
-
-        assert result.embeddings == [[0.1, 0.2], [0.3, 0.4]]
-        mock_client.models.embed_content.assert_called_once_with(
-            model="text-embedding-005", contents=["hello", "world"], config=None
+    def test_dimensions_and_task_type(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_EMBED_URL).mock(
+            return_value=httpx.Response(200, json={"embeddings": [{"values": [0.1]}]})
         )
+        provider.embed(EMBED_MODEL, "hello", dimensions=256, provider_params=GoogleParams(task_type="RETRIEVAL_QUERY"))
+        req = json.loads(route.calls.last.request.content)["requests"][0]
+        assert req["outputDimensionality"] == 256
+        assert req["taskType"] == "RETRIEVAL_QUERY"
 
-    def test_embed_with_dimensions(
-        self,
-        sync_provider: GoogleProvider,
-        mock_client: MagicMock,
-        embed_response: MagicMock,
-    ) -> None:
-        mock_client.models.embed_content.return_value = embed_response
-
-        _ = sync_provider.embed("text-embedding-005", "hello", dimensions=256)
-
-        mock_client.models.embed_content.assert_called_once_with(
-            model="text-embedding-005", contents=["hello"], config={"output_dimensionality": 256}
-        )
-
-    def test_embed_with_task_type(
-        self,
-        sync_provider: GoogleProvider,
-        mock_client: MagicMock,
-        embed_response: MagicMock,
-    ) -> None:
-        mock_client.models.embed_content.return_value = embed_response
-
-        _ = sync_provider.embed(
-            "text-embedding-005", "hello", provider_params=GoogleParams(task_type="RETRIEVAL_QUERY")
-        )
-
-        mock_client.models.embed_content.assert_called_once_with(
-            model="text-embedding-005", contents=["hello"], config={"task_type": "RETRIEVAL_QUERY"}
-        )
-
-    def test_embed_with_dimensions_and_task_type(
-        self,
-        sync_provider: GoogleProvider,
-        mock_client: MagicMock,
-        embed_response: MagicMock,
-    ) -> None:
-        mock_client.models.embed_content.return_value = embed_response
-
-        _ = sync_provider.embed(
-            "text-embedding-005",
-            "hello",
-            dimensions=256,
-            provider_params=GoogleParams(task_type="RETRIEVAL_DOCUMENT"),
-        )
-
-        mock_client.models.embed_content.assert_called_once_with(
-            model="text-embedding-005",
-            contents=["hello"],
-            config={"output_dimensionality": 256, "task_type": "RETRIEVAL_DOCUMENT"},
-        )
-
-    def test_embed_exception_mapping(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, server_error: Exception
-    ) -> None:
-        mock_client.models.embed_content.side_effect = server_error
-
-        with pytest.raises(ProviderError):
-            _ = sync_provider.embed("text-embedding-005", "hello")
+    def test_exception_mapped(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_EMBED_URL).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            provider.embed(EMBED_MODEL, "hello")
 
 
 # MARK: Aembed
 
 
 class TestAembed:
-    async def test_basic_aembed(
-        self,
-        async_provider: GoogleProvider,
-        mock_client: MagicMock,
-        embed_response: MagicMock,
-    ) -> None:
-        mock_client.aio.models.embed_content = AsyncMock(return_value=embed_response)
-
-        result = await async_provider.aembed("text-embedding-005", "hello")
-
-        assert result.embeddings == [[0.1, 0.2, 0.3]]
-        assert result.provider == "google"
-        mock_client.aio.models.embed_content.assert_awaited_once_with(
-            model="text-embedding-005", contents=["hello"], config=None
+    async def test_basic(self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_EMBED_URL).mock(
+            return_value=httpx.Response(200, json={"embeddings": [{"values": [0.1, 0.2]}]})
         )
-        mock_client.aio.models.generate_content.assert_not_called()
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        result = await provider.aembed(EMBED_MODEL, "hello")
+        assert result.embeddings == [[0.1, 0.2]]
 
-    async def test_aembed_list_input(
-        self,
-        async_provider: GoogleProvider,
-        mock_client: MagicMock,
+    async def test_status_error_mapped(self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_EMBED_URL).mock(return_value=httpx.Response(404, json={"error": {"message": "no"}}))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        with pytest.raises(NotFoundError):
+            await provider.aembed(EMBED_MODEL, "hello")
+
+    async def test_transport_error_mapped(self, api_auth: FakeAPIKeyAuth, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_EMBED_URL).mock(side_effect=httpx.ConnectError("refused"))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        with pytest.raises(ProviderError, match="refused"):
+            await provider.aembed(EMBED_MODEL, "hello")
+
+
+# MARK: Vertex Transport
+
+
+class TestVertexTransport:
+    def test_vertex_url_and_bearer(self, gen_response: dict[str, Any], respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{MODEL}:generateContent"
+        route = respx_mock.post(url).mock(return_value=httpx.Response(200, json=gen_response))
+        result = provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result.content == "Hello!"
+        assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
+
+    def test_vertex_global_location(self, gen_response: dict[str, Any], respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj")
+        url = f"https://aiplatform.googleapis.com/v1/projects/my-proj/locations/global/publishers/google/models/{MODEL}:generateContent"
+        route = respx_mock.post(url).mock(return_value=httpx.Response(200, json=gen_response))
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
+
+    def test_vertex_refreshes_invalid_credentials(
+        self, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.aio.models.embed_content = AsyncMock(return_value=_make_embed_response_mock([[0.1], [0.2]]))
+        creds = FakeCredentials(valid=False)
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"https://us-central1-aiplatform.googleapis.com/v1/projects/my-proj/locations/us-central1/publishers/google/models/{MODEL}:generateContent"
+        route = respx_mock.post(url).mock(return_value=httpx.Response(200, json=gen_response))
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert creds.refreshed is True
+        assert route.calls.last.request.headers["authorization"] == "Bearer refreshed-token"
 
-        result = await async_provider.aembed("text-embedding-005", ["hello", "world"])
-
-        assert result.embeddings == [[0.1], [0.2]]
-        mock_client.aio.models.embed_content.assert_awaited_once_with(
-            model="text-embedding-005", contents=["hello", "world"], config=None
-        )
-
-    async def test_aembed_exception_mapping(
-        self, async_provider: GoogleProvider, mock_client: MagicMock, server_error: Exception
-    ) -> None:
-        mock_client.aio.models.embed_content = AsyncMock(side_effect=server_error)
-
-        with pytest.raises(ProviderError):
-            _ = await async_provider.aembed("text-embedding-005", "hello")
+    def test_vertex_requires_project(self) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds))
+        with pytest.raises(ProviderError, match="requires a project"):
+            provider.chat(MODEL, [UserMessage(content="Hi")])
 
 
 # MARK: Client Management
@@ -629,148 +428,56 @@ class TestAembed:
 
 class TestClientManagement:
     def test_sync_client_reused(
-        self,
-        sync_provider: GoogleProvider,
-        mock_client: MagicMock,
-        generate_response: MagicMock,
-        mock_create: MagicMock,
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")])
-        _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi again")])
-
-        mock_create.assert_called_once()
-
-    def test_project_and_location_passed(
-        self,
-        fake_auth: FakeAuth,
-        mock_create: MagicMock,
-        mock_client: MagicMock,
-        generate_response: MagicMock,
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-        provider = GoogleProvider(auth=fake_auth, project="my-project", location="us-central1")
-        _ = provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")])
-
-        mock_create.assert_called_once()
-        call_kwargs = mock_create.call_args.kwargs
-        assert call_kwargs["project"] == "my-project"
-        assert call_kwargs["location"] == "us-central1"
-        assert call_kwargs["vertexai"] is True
-
-    def test_api_key_auth_passes_api_key(
-        self,
-        fake_api_key_auth: FakeAPIKeyAuth,
-        mock_create: MagicMock,
-        mock_client: MagicMock,
-        generate_response: MagicMock,
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-        provider = GoogleProvider(auth=fake_api_key_auth, vertexai=False)
-        _ = provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")])
-
-        mock_create.assert_called_once()
-        call_kwargs = mock_create.call_args.kwargs
-        assert call_kwargs["api_key"] == "test-api-key"
-        assert call_kwargs["credentials"] is None
-        assert call_kwargs["vertexai"] is False
-
-    async def test_api_key_auth_passes_api_key_async(
-        self,
-        fake_api_key_auth: FakeAPIKeyAuth,
-        mock_create: MagicMock,
-        mock_client: MagicMock,
-        generate_response: MagicMock,
-    ) -> None:
-        mock_client.aio.models.generate_content = AsyncMock(return_value=generate_response)
-        provider = GoogleProvider(auth=fake_api_key_auth, vertexai=False)
-        _ = await provider.achat("gemini-2.0-flash", [UserMessage(content="Hi")])
-
-        mock_create.assert_called_once()
-        call_kwargs = mock_create.call_args.kwargs
-        assert call_kwargs["api_key"] == "test-api-key"
-        assert call_kwargs["credentials"] is None
+        _ok(respx_mock, gen_response)
+        provider.chat(MODEL, [UserMessage(content="a")])
+        client = provider._sync_client
+        provider.chat(MODEL, [UserMessage(content="b")])
+        assert provider._sync_client is client
 
     async def test_async_client_reused(
-        self,
-        fake_auth: FakeAuth,
-        mock_create: MagicMock,
-        mock_client: MagicMock,
-        generate_response: MagicMock,
+        self, api_auth: FakeAPIKeyAuth, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.aio.models.generate_content = AsyncMock(return_value=generate_response)
-        provider = GoogleProvider(auth=fake_auth)
-        _ = await provider.achat("gemini-2.0-flash", [UserMessage(content="Hi")])
-        _ = await provider.achat("gemini-2.0-flash", [UserMessage(content="Hi again")])
+        _ok(respx_mock, gen_response)
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        await provider.achat(MODEL, [UserMessage(content="a")])
+        client = provider._async_client
+        await provider.achat(MODEL, [UserMessage(content="b")])
+        assert provider._async_client is client
 
-        mock_create.assert_called_once()
-
-    def test_default_options(
-        self,
-        fake_auth: FakeAuth,
-        mock_create: MagicMock,
-        mock_client: MagicMock,
-        generate_response: MagicMock,
+    def test_timeout_passed(
+        self, api_auth: FakeAPIKeyAuth, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-        provider = GoogleProvider(auth=fake_auth)
-        _ = provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")])
+        _ok(respx_mock, gen_response)
+        provider = GoogleProvider(auth=api_auth, vertexai=False, timeout=30.0, max_retries=5)
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert provider._sync_client is not None
+        assert provider._sync_client.timeout.read == 30.0
 
-        mock_create.assert_called_once()
-        call_kwargs = mock_create.call_args.kwargs
-        assert call_kwargs["vertexai"] is True
-        assert call_kwargs["project"] is None
-        assert call_kwargs["location"] is None
-        assert call_kwargs["credentials"] is not None
-        assert call_kwargs["api_key"] is None
-
-    def test_client_init_failure_mapped(
-        self,
-        fake_auth: FakeAuth,
-        mock_create: MagicMock,
-    ) -> None:
-        mock_create.side_effect = Exception("connection refused")
-        provider = GoogleProvider(auth=fake_auth)
-
+    def test_sync_init_failure_mapped(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_google.provider.create_sync_client", side_effect=RuntimeError("connection refused"))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
         with pytest.raises(ProviderError, match="connection refused"):
-            _ = provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")])
+            provider.chat(MODEL, [UserMessage(content="Hi")])
 
-    async def test_async_client_init_failure_mapped(
-        self,
-        fake_auth: FakeAuth,
-        mock_create: MagicMock,
-    ) -> None:
-        mock_create.side_effect = Exception("connection refused")
-        provider = GoogleProvider(auth=fake_auth)
-
+    async def test_async_init_failure_mapped(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_google.provider.create_async_client", side_effect=RuntimeError("connection refused"))
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
         with pytest.raises(ProviderError, match="connection refused"):
-            _ = await provider.achat("gemini-2.0-flash", [UserMessage(content="Hi")])
+            await provider.achat(MODEL, [UserMessage(content="Hi")])
 
-    @pytest.fixture
-    def mock_get_running_loop(self, mocker: MockerFixture) -> MagicMock:
-        return mocker.patch("lmux_google.provider.asyncio.get_running_loop")
-
-    async def test_achat_recreates_client_on_new_event_loop(
-        self,
-        fake_auth: FakeAuth,
-        mock_create: MagicMock,
-        mock_client: MagicMock,
-        generate_response: MagicMock,
-        mock_get_running_loop: MagicMock,
-    ) -> None:
-        mock_client.aio.models.generate_content = AsyncMock(return_value=generate_response)
-        provider = GoogleProvider(auth=fake_auth)
-
-        loop1 = asyncio.new_event_loop()
-        loop2 = asyncio.new_event_loop()
-        mock_get_running_loop.side_effect = [loop1, loop2]
-
-        _ = await provider.achat("gemini-2.0-flash", [UserMessage(content="Hi")])
-        _ = await provider.achat("gemini-2.0-flash", [UserMessage(content="Hi again")])
-
-        assert mock_create.call_count == 2
-        assert mock_get_running_loop.call_count == 2
+    async def test_async_client_recreated_on_new_loop(self, api_auth: FakeAPIKeyAuth, mocker: MockerFixture) -> None:
+        c1, c2 = MagicMock(), MagicMock()
+        create = mocker.patch("lmux_google.provider.create_async_client", side_effect=[c1, c2])
+        get_loop = mocker.patch("lmux_google.provider.asyncio.get_running_loop")
+        loop1, loop2 = asyncio.new_event_loop(), asyncio.new_event_loop()
+        get_loop.side_effect = [loop1, loop2]
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        r1 = await provider._get_async_client()
+        r2 = await provider._get_async_client()
+        assert (r1, r2) == (c1, c2)
+        assert create.call_count == 2
         loop1.close()
         loop2.close()
 
@@ -779,371 +486,265 @@ class TestClientManagement:
 
 
 class TestRegisterPricing:
-    def test_custom_pricing_for_unknown_model(self, sync_provider: GoogleProvider, mock_client: MagicMock) -> None:
-        custom_response = _make_response_mock(prompt_tokens=1000, output_tokens=500)
-        mock_client.models.generate_content.return_value = custom_response
-
-        sync_provider.register_pricing(
-            "custom.my-model-v1",
-            ModelPricing(
-                tiers=[PricingTier(input_cost_per_token=5.0 / 1_000_000, output_cost_per_token=15.0 / 1_000_000)]
-            ),
+    def test_custom_for_unknown_model(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        model = "custom.my-model-v1"
+        _ok(respx_mock, _gen_response(prompt_tokens=1000, output_tokens=500), url=f"{_GEMINI}/{model}:generateContent")
+        provider.register_pricing(
+            model, ModelPricing(tiers=[PricingTier(input_cost_per_token=5e-6, output_cost_per_token=15e-6)])
         )
-        result = sync_provider.chat("custom.my-model-v1", [UserMessage(content="Hi")])
-
+        result = provider.chat(model, [UserMessage(content="Hi")])
         assert result.cost is not None
-        assert result.cost.input_cost == pytest.approx(1000 * 5.0 / 1_000_000)
-        assert result.cost.output_cost == pytest.approx(500 * 15.0 / 1_000_000)
+        assert result.cost.input_cost == pytest.approx(1000 * 5e-6)
 
-    def test_custom_pricing_overrides_builtin(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_custom_overrides_builtin(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        custom_pricing = ModelPricing(
-            tiers=[PricingTier(input_cost_per_token=99.0 / 1_000_000, output_cost_per_token=199.0 / 1_000_000)]
+        _ok(respx_mock, gen_response)
+        provider.register_pricing(
+            MODEL, ModelPricing(tiers=[PricingTier(input_cost_per_token=99e-6, output_cost_per_token=199e-6)])
         )
-        sync_provider.register_pricing("gemini-2.0-flash", custom_pricing)
-        result = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")])
-
+        result = provider.chat(MODEL, [UserMessage(content="Hi")])
         assert result.cost is not None
-        assert result.cost.input_cost == pytest.approx(10 * 99.0 / 1_000_000)
-        assert result.cost.output_cost == pytest.approx(5 * 199.0 / 1_000_000)
+        assert result.cost.input_cost == pytest.approx(10 * 99e-6)
 
-    def test_unregistered_unknown_model_returns_none_cost(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock
-    ) -> None:
-        unknown_response = _make_response_mock()
-        mock_client.models.generate_content.return_value = unknown_response
-
-        result = sync_provider.chat("totally-unknown-model", [UserMessage(content="Hi")])
-
+    def test_unknown_model_none_cost(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        model = "totally-unknown-model"
+        _ok(respx_mock, _gen_response(), url=f"{_GEMINI}/{model}:generateContent")
+        result = provider.chat(model, [UserMessage(content="Hi")])
         assert result.cost is None
 
 
-# MARK: Provider Params Kwargs
+# MARK: Provider Params
 
 
-class TestProviderParamsKwargs:
+class TestProviderParams:
     def test_empty_params(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
+        route = _ok(respx_mock, gen_response)
+        provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=GoogleParams())
+        body = json.loads(route.calls.last.request.content)
+        assert "safetySettings" not in body
+        assert "generationConfig" not in body
+        assert "tools" not in body
 
-        _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")], provider_params=GoogleParams())
-
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        config = call_kwargs["config"]
-        assert "safety_settings" not in config
-        assert "presence_penalty" not in config
-        assert "frequency_penalty" not in config
-        assert "seed" not in config
-        assert "labels" not in config
-        assert "thinking_config" not in config
-
-    def test_all_params(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_all_generation_params(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        params = GoogleParams(
-            safety_settings=[SafetySetting(category="HARM_CATEGORY_HARASSMENT", threshold="BLOCK_NONE")],
-            presence_penalty=0.5,
-            frequency_penalty=0.3,
-            seed=42,
-            labels={"env": "test"},
-            thinking_config={"thinking_budget": 1024},
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            provider_params=GoogleParams(
+                safety_settings=[SafetySetting(category="HARM_CATEGORY_HARASSMENT", threshold="BLOCK_NONE")],
+                presence_penalty=0.5,
+                frequency_penalty=0.3,
+                seed=42,
+                labels={"env": "test"},
+                thinking_config={"thinkingBudget": 1024},
+            ),
         )
-        _ = sync_provider.chat("gemini-2.0-flash", [UserMessage(content="Hi")], provider_params=params)
-
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        config = call_kwargs["config"]
-        assert config["safety_settings"] == [{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}]
-        assert config["presence_penalty"] == 0.5
-        assert config["frequency_penalty"] == 0.3
-        assert config["seed"] == 42
-        assert config["labels"] == {"env": "test"}
-        assert config["thinking_config"] == {"thinking_budget": 1024}
+        body = json.loads(route.calls.last.request.content)
+        assert body["safetySettings"] == [{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}]
+        assert body["labels"] == {"env": "test"}
+        assert body["generationConfig"] == {
+            "presencePenalty": 0.5,
+            "frequencyPenalty": 0.3,
+            "seed": 42,
+            "thinkingConfig": {"thinkingBudget": 1024},
+        }
 
     def test_google_search_bool(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
+        route = _ok(respx_mock, gen_response)
+        provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=GoogleParams(google_search=True))
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"googleSearch": {}}]
 
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(google_search=True),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [{"google_search": {}}]
-
-    def test_google_search_config_with_search_types(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_google_search_false_is_noop(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
+        route = _ok(respx_mock, gen_response)
+        provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=GoogleParams(google_search=False))
+        body = json.loads(route.calls.last.request.content)
+        assert "tools" not in body
 
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
+    def test_google_search_config_full(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             provider_params=GoogleParams(
                 google_search=GoogleSearchConfig(
-                    search_types=GoogleSearchTypes(web_search=True),
-                    exclude_domains=["example.com"],
-                ),
+                    search_types=GoogleSearchTypes(web_search=True), exclude_domains=["example.com"]
+                )
             ),
         )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [
-            {"google_search": {"search_types": {"web_search": {}}, "exclude_domains": ["example.com"]}},
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [
+            {"googleSearch": {"searchTypes": {"webSearch": {}}, "excludeDomains": ["example.com"]}}
         ]
 
-    def test_google_search_config_empty(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(google_search=GoogleSearchConfig()),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [{"google_search": {}}]
-
     def test_google_search_config_image_search(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             provider_params=GoogleParams(
-                google_search=GoogleSearchConfig(search_types=GoogleSearchTypes(image_search=True)),
+                google_search=GoogleSearchConfig(search_types=GoogleSearchTypes(image_search=True))
             ),
         )
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"googleSearch": {"searchTypes": {"imageSearch": {}}}}]
 
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [{"google_search": {"search_types": {"image_search": {}}}}]
+    def test_google_search_config_empty(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL, [UserMessage(content="Hi")], provider_params=GoogleParams(google_search=GoogleSearchConfig())
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"googleSearch": {}}]
+
+    def test_google_search_config_empty_search_types(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            provider_params=GoogleParams(google_search=GoogleSearchConfig(search_types=GoogleSearchTypes())),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"googleSearch": {}}]
 
     def test_code_execution(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
+        route = _ok(respx_mock, gen_response)
+        provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=GoogleParams(code_execution=True))
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"codeExecution": {}}]
 
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(code_execution=True),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [{"code_execution": {}}]
-
-    def test_google_search_retrieval(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_google_search_retrieval_full(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             provider_params=GoogleParams(
                 google_search_retrieval=GoogleSearchRetrievalConfig(
-                    dynamic_retrieval_config=DynamicRetrievalConfig(mode="MODE_DYNAMIC", dynamic_threshold=0.5),
-                ),
+                    dynamic_retrieval_config=DynamicRetrievalConfig(mode="MODE_DYNAMIC", dynamic_threshold=0.5)
+                )
             ),
         )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        expected_drc = {"mode": "MODE_DYNAMIC", "dynamic_threshold": 0.5}
-        assert config["tools"] == [
-            {"google_search_retrieval": {"dynamic_retrieval_config": expected_drc}},
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [
+            {"googleSearchRetrieval": {"dynamicRetrievalConfig": {"mode": "MODE_DYNAMIC", "dynamicThreshold": 0.5}}}
         ]
 
-    def test_google_search_retrieval_empty(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+    def test_google_search_retrieval_mode_only(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            provider_params=GoogleParams(
+                google_search_retrieval=GoogleSearchRetrievalConfig(
+                    dynamic_retrieval_config=DynamicRetrievalConfig(mode="MODE_DYNAMIC")
+                )
+            ),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"googleSearchRetrieval": {"dynamicRetrievalConfig": {"mode": "MODE_DYNAMIC"}}}]
 
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
+    def test_google_search_retrieval_threshold_only(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            provider_params=GoogleParams(
+                google_search_retrieval=GoogleSearchRetrievalConfig(
+                    dynamic_retrieval_config=DynamicRetrievalConfig(dynamic_threshold=0.7)
+                )
+            ),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"googleSearchRetrieval": {"dynamicRetrievalConfig": {"dynamicThreshold": 0.7}}}]
+
+    def test_google_search_retrieval_empty_drc(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            provider_params=GoogleParams(
+                google_search_retrieval=GoogleSearchRetrievalConfig(dynamic_retrieval_config=DynamicRetrievalConfig())
+            ),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"googleSearchRetrieval": {}}]
+
+    def test_google_search_retrieval_no_drc(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             provider_params=GoogleParams(google_search_retrieval=GoogleSearchRetrievalConfig()),
         )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [{"google_search_retrieval": {}}]
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [{"googleSearchRetrieval": {}}]
 
     def test_special_tools_merge_with_function_tools(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
+        route = _ok(respx_mock, gen_response)
+        provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             tools=[Tool(function=FunctionDefinition(name="get_weather"))],
             provider_params=GoogleParams(google_search=True, code_execution=True),
         )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [
-            {"function_declarations": [{"name": "get_weather"}]},
-            {"google_search": {}},
-            {"code_execution": {}},
+        body = json.loads(route.calls.last.request.content)
+        assert body["tools"] == [
+            {"functionDeclarations": [{"name": "get_weather"}]},
+            {"googleSearch": {}},
+            {"codeExecution": {}},
         ]
 
-    def test_multiple_special_tools(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
 
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(google_search=True, code_execution=True),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [{"google_search": {}}, {"code_execution": {}}]
-
-    def test_google_search_retrieval_mode_only(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(
-                google_search_retrieval=GoogleSearchRetrievalConfig(
-                    dynamic_retrieval_config=DynamicRetrievalConfig(mode="MODE_DYNAMIC"),
-                ),
-            ),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [
-            {"google_search_retrieval": {"dynamic_retrieval_config": {"mode": "MODE_DYNAMIC"}}},
-        ]
-
-    def test_google_search_retrieval_threshold_only(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(
-                google_search_retrieval=GoogleSearchRetrievalConfig(
-                    dynamic_retrieval_config=DynamicRetrievalConfig(dynamic_threshold=0.7),
-                ),
-            ),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [
-            {"google_search_retrieval": {"dynamic_retrieval_config": {"dynamic_threshold": 0.7}}},
-        ]
-
-    def test_google_search_retrieval_empty_drc(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(
-                google_search_retrieval=GoogleSearchRetrievalConfig(
-                    dynamic_retrieval_config=DynamicRetrievalConfig(),
-                ),
-            ),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [{"google_search_retrieval": {}}]
-
-    def test_google_search_config_empty_search_types(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(
-                google_search=GoogleSearchConfig(search_types=GoogleSearchTypes()),
-            ),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert config["tools"] == [{"google_search": {}}]
-
-    def test_google_search_false_is_noop(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(google_search=False),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert "tools" not in config
-
-    def test_no_special_tools_no_tools_key(
-        self, sync_provider: GoogleProvider, mock_client: MagicMock, generate_response: MagicMock
-    ) -> None:
-        mock_client.models.generate_content.return_value = generate_response
-
-        _ = sync_provider.chat(
-            "gemini-2.0-flash",
-            [UserMessage(content="Hi")],
-            provider_params=GoogleParams(presence_penalty=0.5),
-        )
-
-        config = mock_client.models.generate_content.call_args.kwargs["config"]
-        assert "tools" not in config
-
-
-# MARK: Aclose
+# MARK: Aclose & Preload
 
 
 class TestAclose:
-    async def test_aclose_closes_client(
-        self,
-        fake_auth: FakeAuth,
-        mock_create: MagicMock,
-        mock_client: MagicMock,
-        generate_response: MagicMock,
+    async def test_closes_client(
+        self, api_auth: FakeAPIKeyAuth, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_client.aio.models.generate_content = AsyncMock(return_value=generate_response)
-        provider = GoogleProvider(auth=fake_auth)
-
-        _ = await provider.achat("gemini-2.0-flash", [UserMessage(content="Hi")])
+        _ok(respx_mock, gen_response)
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
+        await provider.achat(MODEL, [UserMessage(content="Hi")])
+        assert provider._async_client is not None
         await provider.aclose()
+        assert provider._async_client is None
 
-        mock_create.assert_called_once()
-        mock_client.aio.aclose.assert_awaited_once()
-        assert provider._client is None
-
-    async def test_aclose_noop_when_no_client(self, fake_auth: FakeAuth) -> None:
-        provider = GoogleProvider(auth=fake_auth)
+    async def test_noop_when_no_client(self, api_auth: FakeAPIKeyAuth) -> None:
+        provider = GoogleProvider(auth=api_auth, vertexai=False)
         await provider.aclose()
-
-
-# MARK: Preload
 
 
 class TestPreload:
-    def test_preload_imports_genai(self) -> None:
-        preload()  # should not raise
+    def test_preload(self) -> None:
+        preload()

--- a/uv.lock
+++ b/uv.lock
@@ -512,15 +512,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -604,32 +595,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
-]
-
-[package.optional-dependencies]
-requests = [
-    { name = "requests" },
-]
-
-[[package]]
-name = "google-genai"
-version = "1.75.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "google-auth", extra = ["requests"] },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "sniffio" },
-    { name = "tenacity" },
-    { name = "typing-extensions" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/59/3ed61240ef20b3ae6ed54e82c6f8b6d1f194947bc6679679dd6cdb037594/google_genai-1.75.0.tar.gz", hash = "sha256:56bac3991b311c93f980c0a2abcd287b672146905df1fbd71c92ed633d5a07cf", size = 539039, upload-time = "2026-05-04T22:48:54.857Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/b6/552d40e96da22921eb1fead7c14b00b5b5473a20e45959488660fab35ee2/google_genai-1.75.0-py3-none-any.whl", hash = "sha256:8dc4c096e7d6288c3087f6893f582fe52468932464781edb8193bd92b9fefb2c", size = 793726, upload-time = "2026-05-04T22:48:53.033Z" },
 ]
 
 [[package]]
@@ -789,13 +754,15 @@ name = "lmux-google"
 version = "0.8.1"
 source = { editable = "packages/lmux-google" }
 dependencies = [
-    { name = "google-genai" },
+    { name = "google-auth" },
+    { name = "httpx" },
     { name = "lmux" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "google-genai", specifier = "~=1.0" },
+    { name = "google-auth", specifier = "~=2.0" },
+    { name = "httpx", specifier = "~=0.28" },
     { name = "lmux", editable = "packages/lmux" },
 ]
 
@@ -1346,24 +1313,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sniffio"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "tenacity"
-version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
-]
-
-[[package]]
 name = "ty"
 version = "0.0.57"
 source = { registry = "https://pypi.org/simple" }
@@ -1460,66 +1409,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
-]
-
-[[package]]
-name = "websockets"
-version = "16.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/02/b9a097e1e16fee4e2fd1ec8c39f6a9c5d6257bae8fa12640caf869f54436/websockets-16.1.tar.gz", hash = "sha256:299468cbe42e2b9981134c7c51d99387d8a7bf562b00183b3eec53f882846dad", size = 182530, upload-time = "2026-07-10T06:32:57.734Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/63/df158b155420b566f025e75613424ad9649a24bcb0e9f259321ab3d58bea/websockets-16.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b0232ed141cec3df2af5a3959a071c51f40036336b0d37e17faf9ef52fc73e47", size = 179791, upload-time = "2026-07-10T06:31:33.108Z" },
-    { url = "https://files.pythonhosted.org/packages/74/cf/00fe9414dfeafa6fe54eae9f5716c8c8e9ac59d192be3b893c096d395846/websockets-16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a71b73d143991714144e159f767b698f03c4a70b8a65ae1733b650cff488045b", size = 177472, upload-time = "2026-07-10T06:31:34.522Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/76/b10633424d40681b4e892ffd08ca5226322b2426e62d4ab71eae484c3a32/websockets-16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:187323204c3b2fc465e8fc2609e60437c521790cb9c1acb49c4c452a33e57f37", size = 177737, upload-time = "2026-07-10T06:31:35.964Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/61/d3bb03b2229bb1afd72008742d586cf1ea240dce64dd48c71c8c7fd3294c/websockets-16.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dba74233c8c3ce368850818c98354dad2570f57231b3fd3bd00d7aa57628881", size = 187403, upload-time = "2026-07-10T06:31:37.496Z" },
-    { url = "https://files.pythonhosted.org/packages/26/16/cc2e80478f688fc3c39c67dc1fac6a0783858058914ebc2489917462cb42/websockets-16.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63339bc8c63c86a463177775cb7c677691f5bcfac7b3b2f01b286d42acd41600", size = 188639, upload-time = "2026-07-10T06:31:38.86Z" },
-    { url = "https://files.pythonhosted.org/packages/15/d6/ad87b2507e57de1cbf897a56c963f2925962ed5e85fbe06aaa83ced27acd/websockets-16.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23e545ea8ae4263e37cdfd4e22a217f519e48e432728bc461185bbf585f38a83", size = 190078, upload-time = "2026-07-10T06:31:40.218Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1a/5b37b3fd335d5811f29fc829f2646a3e6d1463a4bf09c3100708684c766e/websockets-16.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2237081454846fb40403a80ba86d82e2038b9c45865ab96af0abe7d002a91045", size = 189267, upload-time = "2026-07-10T06:31:41.523Z" },
-    { url = "https://files.pythonhosted.org/packages/42/98/06afc33e9450d4230f94c664db78875d90f5f6a5fb77f0bc6ec15ae74e1c/websockets-16.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f5218de1ed047385ca53744caba9435d65f75d008364970a3fae95a05812cf9", size = 188022, upload-time = "2026-07-10T06:31:42.838Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bf/42fef5d5887c18cf2d148b02debf56cecb9cfbffc68027cde9b12c8f432c/websockets-16.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75c98e3920039d0edff03b74478ada504b7ce3a1bc406db2cabfca84320f7baf", size = 185435, upload-time = "2026-07-10T06:31:44.219Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/9b/8021c133add5fe40ed40312553a6cd1408c069d7efe3444ad483d4973ed3/websockets-16.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1facd189d8190af30487a55b4c3688484dd50801628a3b5b2ccd26db08e67057", size = 188080, upload-time = "2026-07-10T06:31:45.986Z" },
-    { url = "https://files.pythonhosted.org/packages/69/54/1e37384f395eaa127383aab15c1c45e200890a7d7b99db5c312233d193e0/websockets-16.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cc0c6a6eef613c7da32d4fb068f82ef834b58134f6a16b54e6c1e5bf9529ab3d", size = 186678, upload-time = "2026-07-10T06:31:47.449Z" },
-    { url = "https://files.pythonhosted.org/packages/68/79/1caeacab5bc2081e4519288d248bc8bd2de30652e6eaa94be6be09a1fe5b/websockets-16.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ad9411eded8988b879be6038206698bf7106c85a78f642c004485bcb95be17eb", size = 188554, upload-time = "2026-07-10T06:31:48.886Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/83/b3dca5fad71487b726e31cb0acf56f226792c1cc34e6ab18cbf146bd2d74/websockets-16.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cd68f0914f3b64694895bc5e9b14e8b447e41d7bf5ffaf989bb8dcb5e2dfdce7", size = 186109, upload-time = "2026-07-10T06:31:50.508Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/0b/8f246c3712f07f207b52ea5fb47f3b2b66fafec7303162644c74aed51c6a/websockets-16.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fef2debfe7f7ebdda12176f26166f95b7af17af05ba06150fcf889032e0213e9", size = 187061, upload-time = "2026-07-10T06:31:51.861Z" },
-    { url = "https://files.pythonhosted.org/packages/47/eb/27d6c92a01696b6495386af4fc941d7d0a13f2eab2bf9c336111d7321491/websockets-16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3cd6c9b798218798f4bb7b2e71c38f0e744bb94ca537b13376f88019d46384d", size = 187347, upload-time = "2026-07-10T06:31:53.246Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d5/eeee439921f55d5eaeabcea18d0f7ce32cdc39cb8fc1e185431a094c5c7b/websockets-16.1-cp313-cp313-win32.whl", hash = "sha256:84c170c6869633536921e4474b1cce7254c0c9b0053ef5725f966cee47e718e4", size = 180149, upload-time = "2026-07-10T06:31:55.058Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/03/971e98d4a4864cf263f9e94c5b2b7c9a9b7682d77bfbba4e732c55ee85a9/websockets-16.1-cp313-cp313-win_amd64.whl", hash = "sha256:bef52d327d70fa75dad93ee61ea2cb1d1489aca9f35c188833563f5a3b4df0a5", size = 180458, upload-time = "2026-07-10T06:31:56.767Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/e6/da1dc11507f8118145a81c751fe0c77e5e1c11b8554496addb39389e2dc2/websockets-16.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f881fca0a45dd6789939bd6637cd98169b92f1c3fdc78262f2cb9ec2cb1f324e", size = 179833, upload-time = "2026-07-10T06:31:58.19Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ac/c0d46f62e31e232487b2c123bc3cfd9a4e45684ca7dc0c37f0987f29baae/websockets-16.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c379d5b207d3a7f0ba4c2e4602a895b0bcc63fb5f5371a4ae7fbddb03b672b", size = 177524, upload-time = "2026-07-10T06:31:59.563Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/33/abd966074b34a51e4f134e0aaed80f5a4a0a35163ea5ac58a1bc5a076d23/websockets-16.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98ab58a4faa72b46da0127ccc1931dcbfc0985b0778892300a092185910c4cbe", size = 177743, upload-time = "2026-07-10T06:32:00.959Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/30/646e47b8a8dff04e227bdab512e6dde60663a647eeac7bbd6edddd92bbc5/websockets-16.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e9c4e369fc181b2d41a99e01477215cecdc8546a39f7d41a59cc0a7065a0b09", size = 187474, upload-time = "2026-07-10T06:32:02.54Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/72/890ab9d77494af93ea65268230bfbc0a90ba789401ed7a44356a44785644/websockets-16.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0704df094b2d5fa7f6f410925a594c2a5c9a09167731a76292e5410934208209", size = 188717, upload-time = "2026-07-10T06:32:04.156Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/aa/baedbbaa6bf9ed6029617ed5e8976535bd805f483ca9b3484e7ad9ee08bf/websockets-16.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b22b1f4950f6ab7126623329c3b47b3b90a14c05db517f2db2a026ad6c928352", size = 190090, upload-time = "2026-07-10T06:32:05.822Z" },
-    { url = "https://files.pythonhosted.org/packages/52/4f/d813ec94e18002571ef4959d87a630eff6e01b72a51bcb0832b75ae8c51a/websockets-16.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1ae4a686a662964a6671069f84f7f908cc3475e782227726b0c622c715962105", size = 189320, upload-time = "2026-07-10T06:32:07.223Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/3c/8ec52a6662f3df64090fba28cd521d405d54759268d8e820477037e8c80d/websockets-16.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:856bdd638f8277f86465057bfdd4da097c73058fb0f9d2bd5baea29e2bf2d367", size = 188068, upload-time = "2026-07-10T06:32:08.586Z" },
-    { url = "https://files.pythonhosted.org/packages/96/7f/f0ae6042b14f86fa5f996c6563ea4cf107adc036ccbedc9d4f418d0095f9/websockets-16.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9003a1fde1c21a322a3ca3fa0c4bda8c639da81dbc925162766086643b05ba87", size = 185493, upload-time = "2026-07-10T06:32:09.968Z" },
-    { url = "https://files.pythonhosted.org/packages/89/ad/5ffc53af9939c49fd653d147fa5b8f78ced1f6bce6c49a7446860945b0ce/websockets-16.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e947b1f5fdab045174306e3916785bf3ed537648acc1549827c08c33b10953", size = 188141, upload-time = "2026-07-10T06:32:11.434Z" },
-    { url = "https://files.pythonhosted.org/packages/67/62/729206c0ee577a4db8eae6dd06e0eef725a1287c6df11b2ef831d003df31/websockets-16.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5dd0e666b5931c0509cf65714686a1c5126771e663a79ac5d40da4f58b1f9502", size = 186653, upload-time = "2026-07-10T06:32:12.845Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/86/e8806a99ec4589914f255e6b658853fe537bf359c05e6ba5762ad9c27917/websockets-16.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a0285df7925657ad65a65fb8dc330808bce082827538fd50ef45fa12d1fc5bca", size = 188614, upload-time = "2026-07-10T06:32:14.236Z" },
-    { url = "https://files.pythonhosted.org/packages/89/38/ac554e2fc6ff0b8deeff9798b92e7abd8f99e2bd9731532e7033de208220/websockets-16.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:82d1c2cab3c133e9d059b3a5420bed9376bd30e21c185c63dda4ddadf6ddda47", size = 186165, upload-time = "2026-07-10T06:32:15.626Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/c5/4ef4d8e53342f94f3c49e1ae089b32c1e8b3878e15e0022c7708c647f351/websockets-16.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c39907f1eaf11f6277def65aa02d68f30576b693d0c1ca332aafa3caa723ac6d", size = 187119, upload-time = "2026-07-10T06:32:17.114Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/33/4788b1dd417bd97eeb2698af3b9df6775ac656f96e9987da0419a067602f/websockets-16.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45c5ea55446171949eb99fd34b771ceddd511ca21958d40d0197ced33159e5ee", size = 187411, upload-time = "2026-07-10T06:32:18.629Z" },
-    { url = "https://files.pythonhosted.org/packages/30/38/00d37aad6dc3244ce349e2864815362e50b3cfc00cac28d216db20efe40f/websockets-16.1-cp314-cp314-win32.whl", hash = "sha256:b8ef8b1c8d6bd029a475ac432e730fba2dfd456715d26c473e2a82291024b99c", size = 179822, upload-time = "2026-07-10T06:32:20.233Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/37/2a8cb0eaddee5eaebda47a90a3ba0898d1ce3d866b02a4857fea17d82e5b/websockets-16.1-cp314-cp314-win_amd64.whl", hash = "sha256:7358ff21632b5d062707f73e859c824f1c3807e73d8ca25e71caca7c4cdcf145", size = 180167, upload-time = "2026-07-10T06:32:21.749Z" },
-    { url = "https://files.pythonhosted.org/packages/07/5a/262ad5fcaef4198997b165060f09a63f861e76939b1786ab546ccc3f8120/websockets-16.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d0f38f4c3e9b359e257c339c2cc1967ccaeedb102e57c1c986bdce4bf4f32268", size = 180166, upload-time = "2026-07-10T06:32:23.278Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/c7/36377db690f4292826e4501a6dec2801dc55fd1cf0405923b04937e478df/websockets-16.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:3c3d2cbd1602593bad49bd86fa3fbb25407d87a3b4bf8857c0ac5ac4914e1901", size = 177697, upload-time = "2026-07-10T06:32:25.164Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/c7/07171abce1e39799a76f473608580fe98bd43a1230f5146159622c02bccf/websockets-16.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:36069b74671e7e667f48a7484249f84c45a825a134c8b1bdc01875d0daa10d79", size = 177902, upload-time = "2026-07-10T06:32:26.564Z" },
-    { url = "https://files.pythonhosted.org/packages/14/17/c831f48e250bc4749f57c00dcce73337c41cd32f6d59a64567b84e782601/websockets-16.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:587f83c2ce8a5d628e166384d77fa7f0ac69b9007d515ab442123e6615aa8da3", size = 187766, upload-time = "2026-07-10T06:32:27.981Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/2e/4dfe63e245b0ecfaf470cf082d25c6ce35808159135fd88c82653a6b11ab/websockets-16.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6db7972d52bc1b66cefe2246902e256cbaebc9ba8a45eac09343d7eb6671b2", size = 188939, upload-time = "2026-07-10T06:32:29.365Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/e5/5faf65aebd9562f6b4bc473d24ce38cc56f84eb5f5bee66ed9b86733f93c/websockets-16.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e7d6014888a0632e1ed7a4095248bb3095232999447f2d83bfb1900987dd9ed9", size = 191081, upload-time = "2026-07-10T06:32:30.868Z" },
-    { url = "https://files.pythonhosted.org/packages/49/cd/2634f2f2c0556c1aae6501ed6840019cc569dd6fdbcac6494378daea4dc0/websockets-16.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cb074d150e4ad2a77aa8a332c2be85f3f64f2681519d2570c1225c12c9821ff", size = 189513, upload-time = "2026-07-10T06:32:32.399Z" },
-    { url = "https://files.pythonhosted.org/packages/59/bb/2c700b51196104f09715b326b1f092ed25326bdf79a03e00a4842e503743/websockets-16.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d19c9067e1fe9490f974bffbc0e443b80a7674c5efb4980c429cc00771f07c5a", size = 188240, upload-time = "2026-07-10T06:32:33.897Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/20/86283636e499a1a357fa9441f690ba34f255e731f2fea174132b3b762b57/websockets-16.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d440ff0c6c7469ad59c0a412c383c235935b43635e89425e3f6a0c36de90c31b", size = 185955, upload-time = "2026-07-10T06:32:35.279Z" },
-    { url = "https://files.pythonhosted.org/packages/91/23/d7fb734b0095d43bc7f1c9f68afd50adb4176e7e513403e8c70ad7daa4fa/websockets-16.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8613129a2533f08de24505e69a3e403cedaadae49abdb043c4d170ca71b7e4bd", size = 188491, upload-time = "2026-07-10T06:32:36.673Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/5e/168a192689db468405ecf3b8e4a2c18811936b0724d017ad7e6d252734f0/websockets-16.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a5bf9c23f197b4ec88290fd5463f33db67362a1bb10f85fc2e8e7627f0ddab97", size = 186983, upload-time = "2026-07-10T06:32:38.207Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/9b/66795fa91ebe49019ebe4fa910282172252e37046b80e08fc52e0c365150/websockets-16.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:520b0fd0395f075febb283c76755af724ab9fd19dffa4f3bfd18cb4e622790a3", size = 188890, upload-time = "2026-07-10T06:32:39.545Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/32/126bbc844be5afb3613fd43211dac10a9645f4cf39741d04acaa2ec7030c/websockets-16.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:7143aa09a67e1c013be44e81a88dfe90fc6244198ab86c7edd064152cf619805", size = 186583, upload-time = "2026-07-10T06:32:41.038Z" },
-    { url = "https://files.pythonhosted.org/packages/22/b9/0b5db9cbcf6e4970db4496893244a8d92e07f71a8ef27cf34b08aa02fef1/websockets-16.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:7acb811fad08e611755800d1560e395c67e11a6bd563598ea6abb319afb86938", size = 187353, upload-time = "2026-07-10T06:32:42.501Z" },
-    { url = "https://files.pythonhosted.org/packages/99/2e/254b2131a10d831b76e2c18dfe7add9729c6292c674a8085bf8de01ad151/websockets-16.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c5cf88e3faa2f7931bc6baeee7599c97656a3f6ac7f831f4fccba233e141783a", size = 187784, upload-time = "2026-07-10T06:32:43.929Z" },
-    { url = "https://files.pythonhosted.org/packages/21/dc/e7288aa8e3ac5a88a0924619984d663c1abf2a87d0ea98290c66fdaee0ec/websockets-16.1-cp314-cp314t-win32.whl", hash = "sha256:589f8842521c8307684ce0b40ce4ad70c5e0aa46484c6f1225a94ef4b8970341", size = 179947, upload-time = "2026-07-10T06:32:45.495Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/de/37edf1260ff0fbbd2f82433489c4cfbe799ac2ff21355331609879329fe6/websockets-16.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c0e0857c30bbbc2bb5c30687508f0b7ec19aa026cd9f2ff8424d0fee42dcc07", size = 180291, upload-time = "2026-07-10T06:32:47.119Z" },
-    { url = "https://files.pythonhosted.org/packages/66/58/bd83247f39ddc26ffc2c24eb05087a3b749e00cb4509fc6d19daa23c8495/websockets-16.1-py3-none-any.whl", hash = "sha256:c5149dfe490ec7e5ee5dbf624c642fb725f93a5575c7f00ab594ca9eddb8dd81", size = 174031, upload-time = "2026-07-10T06:32:56.079Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Converts the Google (Gemini) provider off the `google-genai` SDK to a direct httpx transport, following the earlier conversions (#91, #92, #94, #97).

- **SDK-lite**: httpx instead of the `google-genai` SDK — lazy client creation, no SDK dependency. Credentials are still resolved via `google-auth` (ADC / service account / API key).
- **Wire models**: `generateContent` responses (and streaming chunks) and `batchEmbedContents` parse into validated Pydantic models. Gemini's camelCase wire shape is handled with a shared alias generator; a content part is a field-bag the mapper dispatches on.
- Mid-stream error events surface as errors; HTTP 403 maps to `PermissionDeniedError`.
