### PR TITLE
feat(aws-bedrock): SDK-lite httpx transport with Pydantic wire models

### DIFF
--- a/packages/lmux-aws-bedrock/README.md
+++ b/packages/lmux-aws-bedrock/README.md
@@ -1,6 +1,6 @@
 # lmux-aws-bedrock
 
-AWS Bedrock provider for [lmux](https://github.com/cluebbehusen/lmux). Uses [boto3](https://pypi.org/project/boto3/), [aiobotocore](https://pypi.org/project/aiobotocore/), and the Converse API.
+AWS Bedrock provider for [lmux](https://github.com/cluebbehusen/lmux). Talks to the Bedrock Converse and InvokeModel REST endpoints directly over [httpx](https://pypi.org/project/httpx/), using [boto3](https://pypi.org/project/boto3/) only to resolve AWS credentials for request signing.
 
 Supports chat completions, streaming, and embeddings.
 
@@ -8,11 +8,14 @@ Part of the [lmux](https://github.com/cluebbehusen/lmux) ecosystem: standardized
 
 ## Optional Extras
 
-- `lmux-aws-bedrock[async]`: async support via `aiobotocore`
+- `lmux-aws-bedrock[async]`: `aiobotocore` for async AWS credential resolution in the auth providers. Not required for `achat`/`aembed`/`achat_stream` themselves.
 
 ## Auth
 
-Uses boto3's default credential chain (env vars, AWS config, instance metadata). No extra setup needed if your AWS credentials are already configured.
+Two authentication modes are supported, resolved on the first request:
+
+1. **Bedrock API key (simplest):** set `AWS_BEARER_TOKEN_BEDROCK` and each request is sent with an `Authorization: Bearer <token>` header — no signing required.
+2. **SigV4 (fallback):** otherwise AWS credentials are resolved through boto3's default credential chain (env vars, AWS config, instance metadata) and each request is SigV4-signed. No extra setup needed if your AWS credentials are already configured.
 
 ```python
 from lmux_aws_bedrock import BedrockProvider
@@ -60,7 +63,7 @@ print(response.embeddings)
 
 ### Async
 
-Requires the `[async]` extra. All methods have async variants: `achat`, `achat_stream`, `aembed`.
+All methods have async variants: `achat`, `achat_stream`, `aembed`. These run over `httpx`'s async client; credentials are resolved synchronously (via boto3) even on the async path.
 
 Bedrock also supports lmux `response_format`, mapped to Converse `outputConfig.textFormat`.
 

--- a/packages/lmux-aws-bedrock/README.md
+++ b/packages/lmux-aws-bedrock/README.md
@@ -124,6 +124,9 @@ Cache points are emitted for whatever model the request targets; models without 
 BedrockProvider(
     auth=...,          # AuthProvider, default: BedrockEnvAuthProvider()
     region=...,        # AWS region
-    endpoint_url=...,  # Custom endpoint URL
+    endpoint_url=...,  # Custom endpoint URL (overrides region/FIPS host selection)
+    use_fips=...,      # bool, default False: target the FIPS 140-3 endpoint (bedrock-runtime-fips.<region>.amazonaws.com)
+    timeout=...,       # request timeout in seconds
+    max_retries=...,   # retry count for transient failures
 )
 ```

--- a/packages/lmux-aws-bedrock/pyproject.toml
+++ b/packages/lmux-aws-bedrock/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
 ]
 dependencies = [
   "lmux~=0.9",
+  "httpx~=0.28",
   "boto3>=1.42.31,<2",
 ]
 

--- a/packages/lmux-aws-bedrock/pyproject.toml
+++ b/packages/lmux-aws-bedrock/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "lmux~=0.9",
+  "lmux~=0.10",
   "httpx~=0.28",
   "boto3>=1.42.31,<2",
 ]

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/__init__.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/__init__.py
@@ -19,12 +19,14 @@ __all__ = [
 
 
 def preload() -> None:
-    """Eagerly import boto3 (and aiobotocore if installed).
+    """Eagerly import httpx and boto3 (and aiobotocore if installed).
 
-    Call this during application startup to pay the import cost upfront
-    rather than on the first request.
+    httpx is the request transport; boto3 resolves AWS credentials for SigV4 signing.
+    Call this during application startup to pay the import cost upfront rather than on
+    the first request.
     """
     import boto3  # noqa: F401, PLC0415
+    import httpx  # noqa: F401, PLC0415
 
     with contextlib.suppress(ImportError):
         import aiobotocore  # noqa: F401, PLC0415

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
@@ -15,7 +15,7 @@ _PRELUDE_DATA_LEN = 8  # total_length(4) + headers_length(4), the bytes the prel
 _MESSAGE_CRC_LEN = 4
 _HEADER_STRING_TYPE = 7
 _TOTAL_LENGTH_LEN = 4
-_MAX_FRAME_LEN = 32 * 1024 * 1024  # anti-DoS bound; above botocore's max message and any real (KB-scale) frame
+_MAX_FRAME_LEN = 32 * 1024 * 1024  # anti-DoS cap on per-frame buffering; real Converse frames are KB-scale
 
 
 def _parse_headers(raw: bytes) -> dict[str, str]:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
@@ -12,6 +12,7 @@ from collections.abc import Iterator
 _PRELUDE_LEN = 12  # total_length(4) + headers_length(4) + prelude_crc(4)
 _MESSAGE_CRC_LEN = 4
 _HEADER_STRING_TYPE = 7
+_TOTAL_LENGTH_LEN = 4
 
 
 def _parse_headers(raw: bytes) -> dict[str, str]:
@@ -34,13 +35,40 @@ def _parse_headers(raw: bytes) -> dict[str, str]:
     return headers
 
 
+def _decode_frame(frame: bytes) -> tuple[dict[str, str], bytes]:
+    """Decode one complete event-stream message frame into ``(headers, payload)``."""
+    total_length, headers_length = struct.unpack(">II", frame[:8])
+    payload_start = _PRELUDE_LEN + headers_length
+    payload_end = total_length - _MESSAGE_CRC_LEN
+    return _parse_headers(frame[_PRELUDE_LEN:payload_start]), frame[payload_start:payload_end]
+
+
 def decode_messages(data: bytes) -> Iterator[tuple[dict[str, str], bytes]]:
     """Yield ``(headers, payload)`` for each complete event-stream message in ``data``."""
     offset = 0
     while offset < len(data):
-        total_length, headers_length = struct.unpack(">II", data[offset : offset + 8])
-        headers_start = offset + _PRELUDE_LEN
-        payload_start = headers_start + headers_length
-        payload_end = offset + total_length - _MESSAGE_CRC_LEN
-        yield _parse_headers(data[headers_start:payload_start]), data[payload_start:payload_end]
+        total_length = struct.unpack(">I", data[offset : offset + _TOTAL_LENGTH_LEN])[0]
+        yield _decode_frame(data[offset : offset + total_length])
         offset += total_length
+
+
+class EventStreamDecoder:
+    """Incremental event-stream decoder.
+
+    Feed it response byte chunks as they arrive; each ``feed`` yields every complete
+    ``(headers, payload)`` message now buffered, holding any trailing partial frame until
+    the rest of its bytes arrive.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = bytearray()
+
+    def feed(self, chunk: bytes) -> Iterator[tuple[dict[str, str], bytes]]:
+        self._buffer.extend(chunk)
+        while len(self._buffer) >= _TOTAL_LENGTH_LEN:
+            total_length = struct.unpack(">I", self._buffer[:_TOTAL_LENGTH_LEN])[0]
+            if len(self._buffer) < total_length:
+                break
+            frame = bytes(self._buffer[:total_length])
+            del self._buffer[:total_length]
+            yield _decode_frame(frame)

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
@@ -7,9 +7,11 @@ JSON payload, which is all the Converse stream needs. Unit-tested for parity wit
 """
 
 import struct
+import zlib
 from collections.abc import Iterator
 
 _PRELUDE_LEN = 12  # total_length(4) + headers_length(4) + prelude_crc(4)
+_PRELUDE_DATA_LEN = 8  # total_length(4) + headers_length(4), the bytes the prelude CRC covers
 _MESSAGE_CRC_LEN = 4
 _HEADER_STRING_TYPE = 7
 _TOTAL_LENGTH_LEN = 4
@@ -36,8 +38,18 @@ def _parse_headers(raw: bytes) -> dict[str, str]:
 
 
 def _decode_frame(frame: bytes) -> tuple[dict[str, str], bytes]:
-    """Decode one complete event-stream message frame into ``(headers, payload)``."""
-    total_length, headers_length = struct.unpack(">II", frame[:8])
+    """Decode one complete event-stream message frame into ``(headers, payload)``.
+
+    Both CRC32 checksums are verified first (matching botocore); a corrupted frame that would
+    otherwise still decode is rejected rather than silently yielding altered headers or payload.
+    """
+    total_length, headers_length = struct.unpack(">II", frame[:_PRELUDE_DATA_LEN])
+    if struct.unpack(">I", frame[_PRELUDE_DATA_LEN:_PRELUDE_LEN])[0] != zlib.crc32(frame[:_PRELUDE_DATA_LEN]):
+        msg = "event-stream prelude checksum mismatch"
+        raise ValueError(msg)
+    if struct.unpack(">I", frame[-_MESSAGE_CRC_LEN:])[0] != zlib.crc32(frame[:-_MESSAGE_CRC_LEN]):
+        msg = "event-stream message checksum mismatch"
+        raise ValueError(msg)
     payload_start = _PRELUDE_LEN + headers_length
     payload_end = total_length - _MESSAGE_CRC_LEN
     return _parse_headers(frame[_PRELUDE_LEN:payload_start]), frame[payload_start:payload_end]

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
@@ -15,6 +15,7 @@ _PRELUDE_DATA_LEN = 8  # total_length(4) + headers_length(4), the bytes the prel
 _MESSAGE_CRC_LEN = 4
 _HEADER_STRING_TYPE = 7
 _TOTAL_LENGTH_LEN = 4
+_MAX_FRAME_LEN = 32 * 1024 * 1024  # anti-DoS bound; above botocore's max message and any real (KB-scale) frame
 
 
 def _parse_headers(raw: bytes) -> dict[str, str]:
@@ -77,8 +78,19 @@ class EventStreamDecoder:
 
     def feed(self, chunk: bytes) -> Iterator[tuple[dict[str, str], bytes]]:
         self._buffer.extend(chunk)
-        while len(self._buffer) >= _TOTAL_LENGTH_LEN:
+        while len(self._buffer) >= _PRELUDE_LEN:
             total_length = struct.unpack(">I", self._buffer[:_TOTAL_LENGTH_LEN])[0]
+            # Validate the prelude (its own CRC covers the first 8 bytes) and bound the advertised
+            # frame size BEFORE buffering total_length bytes, so a corrupt/huge length cannot drive
+            # the buffer toward gigabytes before the frame's own checksum would catch it.
+            if struct.unpack(">I", self._buffer[_PRELUDE_DATA_LEN:_PRELUDE_LEN])[0] != zlib.crc32(
+                self._buffer[:_PRELUDE_DATA_LEN]
+            ):
+                msg = "event-stream prelude checksum mismatch"
+                raise ValueError(msg)
+            if total_length > _MAX_FRAME_LEN:
+                msg = f"event-stream frame length {total_length} exceeds the {_MAX_FRAME_LEN}-byte limit"
+                raise ValueError(msg)
             if len(self._buffer) < total_length:
                 break
             frame = bytes(self._buffer[:total_length])

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_eventstream.py
@@ -1,0 +1,46 @@
+"""Minimal AWS event-stream (``vnd.amazon.eventstream``) decoder.
+
+Bedrock's Converse streaming responses use AWS's binary event-stream framing.
+This decodes the frames enough to recover each event's ``:event-type`` header and
+JSON payload, which is all the Converse stream needs. Unit-tested for parity with
+``botocore.eventstream`` (a dev-only dependency).
+"""
+
+import struct
+from collections.abc import Iterator
+
+_PRELUDE_LEN = 12  # total_length(4) + headers_length(4) + prelude_crc(4)
+_MESSAGE_CRC_LEN = 4
+_HEADER_STRING_TYPE = 7
+
+
+def _parse_headers(raw: bytes) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    i = 0
+    while i < len(raw):
+        name_len = raw[i]
+        i += 1
+        name = raw[i : i + name_len].decode()
+        i += name_len
+        value_type = raw[i]
+        i += 1
+        if value_type != _HEADER_STRING_TYPE:  # pragma: no cover - Bedrock events only use string headers
+            msg = f"unsupported event-stream header type {value_type}"
+            raise ValueError(msg)
+        value_len = struct.unpack(">H", raw[i : i + 2])[0]
+        i += 2
+        headers[name] = raw[i : i + value_len].decode()
+        i += value_len
+    return headers
+
+
+def decode_messages(data: bytes) -> Iterator[tuple[dict[str, str], bytes]]:
+    """Yield ``(headers, payload)`` for each complete event-stream message in ``data``."""
+    offset = 0
+    while offset < len(data):
+        total_length, headers_length = struct.unpack(">II", data[offset : offset + 8])
+        headers_start = offset + _PRELUDE_LEN
+        payload_start = headers_start + headers_length
+        payload_end = offset + total_length - _MESSAGE_CRC_LEN
+        yield _parse_headers(data[headers_start:payload_start]), data[payload_start:payload_end]
+        offset += total_length

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
@@ -6,7 +6,7 @@ Credentials are still resolved through boto3, so botocore's credential errors ar
 here too.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lmux.exceptions import (
     AuthenticationError,
@@ -45,6 +45,19 @@ def raise_for_status(response: "httpx.Response") -> None:
     """Raise the mapped lmux error for an error response (body must be readable)."""
     if response.status_code >= _BAD_REQUEST:
         raise error_from_response(response)
+
+
+def parse_json(response: "httpx.Response") -> dict[str, Any]:
+    """Return the JSON object body of a success response, mapping a malformed or non-object body to a ProviderError."""
+    try:
+        data = response.json()
+    except ValueError as e:
+        msg = "malformed response body"
+        raise ProviderError(msg, provider=PROVIDER, status_code=response.status_code) from e
+    if not isinstance(data, dict):
+        msg = "expected a JSON object response body"
+        raise ProviderError(msg, provider=PROVIDER, status_code=response.status_code)
+    return data
 
 
 def error_from_response(response: "httpx.Response") -> LmuxError:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
@@ -1,6 +1,12 @@
-"""Map botocore/boto3 exceptions to lmux exception hierarchy."""
+"""Map HTTP responses and transport/credential errors to the lmux exception hierarchy.
 
-from typing import Any
+The Bedrock provider talks to the REST endpoints over httpx, so runtime errors arrive
+as HTTP status codes (with an ``x-amzn-errortype`` header) or httpx transport failures.
+Credentials are still resolved through boto3, so botocore's credential errors are mapped
+here too.
+"""
+
+from typing import TYPE_CHECKING
 
 from lmux.exceptions import (
     AuthenticationError,
@@ -12,9 +18,20 @@ from lmux.exceptions import (
     TimeoutError,  # noqa: A004
 )
 
+if TYPE_CHECKING:
+    import httpx
+
 PROVIDER = "aws-bedrock"
 
-_AUTH_ERROR_CODES = frozenset(
+_BAD_REQUEST = 400
+_AUTH = 401
+_FORBIDDEN = 403
+_NOT_FOUND = 404
+_RATE_LIMIT = 429
+
+# AWS ``x-amzn-errortype`` values that map to authentication failures regardless of the
+# HTTP status code (some arrive as 403, some as 400).
+_AUTH_ERROR_TYPES = frozenset(
     {
         "UnrecognizedClientException",
         "InvalidSignatureException",
@@ -24,59 +41,74 @@ _AUTH_ERROR_CODES = frozenset(
 )
 
 
-def map_bedrock_error(error: Exception) -> LmuxError:
-    """Convert a botocore/boto3 exception to the corresponding lmux exception."""
-    import botocore.exceptions  # noqa: PLC0415
+def raise_for_status(response: "httpx.Response") -> None:
+    """Raise the mapped lmux error for an error response (body must be readable)."""
+    if response.status_code >= _BAD_REQUEST:
+        raise error_from_response(response)
 
-    if isinstance(error, botocore.exceptions.ClientError):
-        return _map_client_error(error)
 
-    if isinstance(error, botocore.exceptions.ReadTimeoutError | botocore.exceptions.ConnectTimeoutError):
+def error_from_response(response: "httpx.Response") -> LmuxError:
+    """Map an HTTP error response to an lmux exception, using the AWS error type header."""
+    code = response.status_code
+    error_type = _error_type(response)
+    message = _message(response)
+
+    if error_type in _AUTH_ERROR_TYPES or code in (_AUTH, _FORBIDDEN):
+        return AuthenticationError(message, provider=PROVIDER, status_code=code)
+    if error_type == "ThrottlingException" or code == _RATE_LIMIT:
+        return RateLimitError(message, provider=PROVIDER, status_code=code, retry_after=_retry_after(response))
+    if error_type == "ValidationException" or code == _BAD_REQUEST:
+        return InvalidRequestError(message, provider=PROVIDER, status_code=code)
+    if error_type == "ResourceNotFoundException" or code == _NOT_FOUND:
+        return NotFoundError(message, provider=PROVIDER, status_code=code)
+    return ProviderError(message, provider=PROVIDER, status_code=code)
+
+
+def map_transport_error(error: Exception) -> LmuxError:
+    """Map an httpx transport error or a credential-resolution failure to an lmux error."""
+    import httpx  # noqa: PLC0415
+
+    if isinstance(error, httpx.TimeoutException):
         return TimeoutError(str(error), provider=PROVIDER)
+    return _map_credential_error(error)
+
+
+def _map_credential_error(error: Exception) -> LmuxError:
+    """Map botocore credential errors (raised while resolving SigV4 creds) to lmux errors."""
+    import botocore.exceptions  # noqa: PLC0415
 
     if isinstance(error, botocore.exceptions.NoCredentialsError | botocore.exceptions.PartialCredentialsError):
         return AuthenticationError(str(error), provider=PROVIDER)
-
-    if isinstance(error, botocore.exceptions.EndpointConnectionError):
-        return ProviderError(str(error), provider=PROVIDER)
-
-    if isinstance(error, botocore.exceptions.BotoCoreError):
-        return ProviderError(str(error), provider=PROVIDER)
-
     return ProviderError(str(error), provider=PROVIDER)
 
 
-def _map_client_error(error: Exception) -> LmuxError:
-    """Map a botocore ClientError based on its error code."""
-    response: dict[str, Any] = getattr(error, "response", {})
-    error_info: dict[str, str] = response.get("Error", {})
-    code = error_info.get("Code", "")
-    message = error_info.get("Message", str(error))
-    http_status: int | None = response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+def _error_type(response: "httpx.Response") -> str:
+    """Extract the AWS error code from ``x-amzn-errortype``.
 
-    if code in _AUTH_ERROR_CODES:
-        return AuthenticationError(message, provider=PROVIDER, status_code=http_status)
-
-    if code == "ThrottlingException":
-        retry_after = _extract_retry_after(response)
-        return RateLimitError(message, provider=PROVIDER, status_code=http_status or 429, retry_after=retry_after)
-
-    if code == "ValidationException":
-        return InvalidRequestError(message, provider=PROVIDER, status_code=http_status or 400)
-
-    if code == "ResourceNotFoundException":
-        return NotFoundError(message, provider=PROVIDER, status_code=http_status or 404)
-
-    return ProviderError(message, provider=PROVIDER, status_code=http_status)
+    The header can be a bare code, ``Code:http://...``, or ``prefix#Code``.
+    """
+    raw = response.headers.get("x-amzn-errortype", "")
+    raw = raw.split(":", 1)[0]
+    return raw.rsplit("#", 1)[-1]
 
 
-def _extract_retry_after(response: dict[str, Any]) -> float | None:
-    """Extract Retry-After from response headers if present."""
-    headers: dict[str, str] = response.get("ResponseMetadata", {}).get("HTTPHeaders", {})
-    retry_header = headers.get("retry-after")
-    if retry_header is None:
+def _message(response: "httpx.Response") -> str:
+    try:
+        data = response.json()
+    except ValueError:
+        return response.text
+    if isinstance(data, dict):
+        message = data.get("message") or data.get("Message")
+        if message:
+            return str(message)
+    return response.text
+
+
+def _retry_after(response: "httpx.Response") -> float | None:
+    header = response.headers.get("retry-after")
+    if header is None:
         return None
     try:
-        return float(retry_header)
-    except (ValueError, TypeError):
+        return float(header)
+    except ValueError:
         return None

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
@@ -66,14 +66,15 @@ def error_from_response(response: "httpx.Response") -> LmuxError:
     return _classify(_error_type(response), response.status_code, _message(response), _retry_after(response))
 
 
-def error_from_stream_exception(exception_type: str, message: str) -> LmuxError:
-    """Map a mid-stream event-stream ``:exception-type`` to the lmux exception hierarchy.
+def error_from_stream_exception(error_type: str, message: str) -> LmuxError:
+    """Map a mid-stream event-stream failure code to the lmux exception hierarchy.
 
-    Stream exception frames carry the AWS error name in camelCase (``throttlingException``) with no HTTP
-    status, so the name is PascalCased and run through the same classifier as the ``x-amzn-errortype``
+    Applies to both ``exception`` frames (the ``:exception-type`` header, camelCase like
+    ``throttlingException``) and unmodeled ``error`` frames (the ``:error-code`` header); the code has
+    no HTTP status, so it is PascalCased and run through the same classifier as the ``x-amzn-errortype``
     response header — keeping RateLimitError/InvalidRequestError/etc. catchable for mid-stream failures.
     """
-    normalized = exception_type[:1].upper() + exception_type[1:]
+    normalized = error_type[:1].upper() + error_type[1:]
     return _classify(normalized, None, message, None)
 
 

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
@@ -63,16 +63,28 @@ def parse_body[T: BaseModel](response: "httpx.Response", model: type[T]) -> T:
 
 def error_from_response(response: "httpx.Response") -> LmuxError:
     """Map an HTTP error response to an lmux exception, using the AWS error type header."""
-    code = response.status_code
-    error_type = _error_type(response)
-    message = _message(response)
+    return _classify(_error_type(response), response.status_code, _message(response), _retry_after(response))
 
+
+def error_from_stream_exception(exception_type: str, message: str) -> LmuxError:
+    """Map a mid-stream event-stream ``:exception-type`` to the lmux exception hierarchy.
+
+    Stream exception frames carry the AWS error name in camelCase (``throttlingException``) with no HTTP
+    status, so the name is PascalCased and run through the same classifier as the ``x-amzn-errortype``
+    response header — keeping RateLimitError/InvalidRequestError/etc. catchable for mid-stream failures.
+    """
+    normalized = exception_type[:1].upper() + exception_type[1:]
+    return _classify(normalized, None, message, None)
+
+
+def _classify(error_type: str, code: int | None, message: str, retry_after: float | None) -> LmuxError:
+    """Map an AWS error type (and/or HTTP status) to an lmux exception."""
     if error_type in _AUTH_ERROR_TYPES or code == _AUTH:
         return AuthenticationError(message, provider=PROVIDER, status_code=code)
     if error_type in _PERMISSION_ERROR_TYPES or code == _FORBIDDEN:
         return PermissionDeniedError(message, provider=PROVIDER, status_code=code)
     if error_type == "ThrottlingException" or code == _RATE_LIMIT:
-        return RateLimitError(message, provider=PROVIDER, status_code=code, retry_after=_retry_after(response))
+        return RateLimitError(message, provider=PROVIDER, status_code=code, retry_after=retry_after)
     if error_type == "ValidationException" or code == _BAD_REQUEST:
         return InvalidRequestError(message, provider=PROVIDER, status_code=code)
     if error_type == "ResourceNotFoundException" or code == _NOT_FOUND:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
@@ -6,7 +6,9 @@ Credentials are still resolved through boto3, so botocore's credential errors ar
 here too.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ValidationError
 
 from lmux.exceptions import (
     AuthenticationError,
@@ -50,17 +52,13 @@ def raise_for_status(response: "httpx.Response") -> None:
         raise error_from_response(response)
 
 
-def parse_json(response: "httpx.Response") -> dict[str, Any]:
-    """Return the JSON object body of a success response, mapping a malformed or non-object body to a ProviderError."""
+def parse_body[T: BaseModel](response: "httpx.Response", model: type[T]) -> T:
+    """Validate a success body into the given wire model, mapping a malformed or mis-shaped body to a ProviderError."""
     try:
-        data = response.json()
-    except ValueError as e:
+        return model.model_validate_json(response.content)
+    except ValidationError as e:
         msg = "malformed response body"
         raise ProviderError(msg, provider=PROVIDER, status_code=response.status_code) from e
-    if not isinstance(data, dict):
-        msg = "expected a JSON object response body"
-        raise ProviderError(msg, provider=PROVIDER, status_code=response.status_code)
-    return data
 
 
 def error_from_response(response: "httpx.Response") -> LmuxError:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_exceptions.py
@@ -13,6 +13,7 @@ from lmux.exceptions import (
     InvalidRequestError,
     LmuxError,
     NotFoundError,
+    PermissionDeniedError,
     ProviderError,
     RateLimitError,
     TimeoutError,  # noqa: A004
@@ -29,16 +30,18 @@ _FORBIDDEN = 403
 _NOT_FOUND = 404
 _RATE_LIMIT = 429
 
-# AWS ``x-amzn-errortype`` values that map to authentication failures regardless of the
-# HTTP status code (some arrive as 403, some as 400).
+# AWS ``x-amzn-errortype`` values that map to authentication failures (bad/expired
+# credentials) regardless of the HTTP status code (some arrive as 403, some as 400).
 _AUTH_ERROR_TYPES = frozenset(
     {
         "UnrecognizedClientException",
         "InvalidSignatureException",
         "ExpiredTokenException",
-        "AccessDeniedException",
     }
 )
+# AccessDenied means valid credentials lacking access — a permission failure, not an
+# authentication one.
+_PERMISSION_ERROR_TYPES = frozenset({"AccessDeniedException"})
 
 
 def raise_for_status(response: "httpx.Response") -> None:
@@ -66,8 +69,10 @@ def error_from_response(response: "httpx.Response") -> LmuxError:
     error_type = _error_type(response)
     message = _message(response)
 
-    if error_type in _AUTH_ERROR_TYPES or code in (_AUTH, _FORBIDDEN):
+    if error_type in _AUTH_ERROR_TYPES or code == _AUTH:
         return AuthenticationError(message, provider=PROVIDER, status_code=code)
+    if error_type in _PERMISSION_ERROR_TYPES or code == _FORBIDDEN:
+        return PermissionDeniedError(message, provider=PROVIDER, status_code=code)
     if error_type == "ThrottlingException" or code == _RATE_LIMIT:
         return RateLimitError(message, provider=PROVIDER, status_code=code, retry_after=_retry_after(response))
     if error_type == "ValidationException" or code == _BAD_REQUEST:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_lazy.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_lazy.py
@@ -1,38 +1,47 @@
-"""Lazy AWS SDK loading internals.
+"""HTTP client factories for the AWS Bedrock provider (SDK-lite, httpx transport).
 
-Client creation is isolated here so tests can easily mock it
-without patching sys.modules or using TYPE_CHECKING tricks.
+Bedrock is reached over its REST endpoints (Converse / InvokeModel) with ``httpx``
+directly rather than through boto3's client. boto3 is still used to resolve classic
+AWS credentials for SigV4 signing (see ``provider``), but never sits in the request
+path. Client creation is isolated here so tests can mock it without patching
+``sys.modules``.
 """
 
-from contextlib import AbstractAsyncContextManager
 from typing import TYPE_CHECKING
 
+from lmux._http import create_async_client as _create_async
+from lmux._http import create_sync_client as _create_sync
+
 if TYPE_CHECKING:
-    import boto3
-    from aiobotocore.session import AioSession
-    from mypy_boto3_bedrock_runtime import BedrockRuntimeClient
-    from types_aiobotocore_bedrock_runtime import BedrockRuntimeClient as AsyncBedrockRuntimeClient
+    import httpx
+
+DEFAULT_REGION = "us-east-1"
+
+
+def bedrock_base_url(region: str) -> str:
+    """Return the bedrock-runtime endpoint for a region."""
+    return f"https://bedrock-runtime.{region}.amazonaws.com"
 
 
 def create_sync_client(
-    session: "boto3.Session",
     *,
-    region_name: str | None = None,
-    endpoint_url: str | None = None,
-) -> "BedrockRuntimeClient":
-    """Create a sync bedrock-runtime client from a boto3.Session."""
-    return session.client("bedrock-runtime", region_name=region_name, endpoint_url=endpoint_url)
+    base_url: str,
+    timeout: float | None = None,
+    max_retries: int | None = None,
+) -> "httpx.Client":
+    """Create an httpx client for the Bedrock runtime endpoint.
+
+    Auth headers are attached per request (SigV4 signs the exact body/host, or a
+    bearer token is set), so the client carries no default ``Authorization``.
+    """
+    return _create_sync(base_url=base_url, headers={}, timeout=timeout, max_retries=max_retries)
 
 
 def create_async_client(
-    session: "AioSession",
     *,
-    region_name: str | None = None,
-    endpoint_url: str | None = None,
-) -> AbstractAsyncContextManager["AsyncBedrockRuntimeClient"]:
-    """Create an async bedrock-runtime client context manager from an aiobotocore session."""
-    return session.create_client(
-        "bedrock-runtime",
-        region_name=region_name,
-        endpoint_url=endpoint_url,
-    )
+    base_url: str,
+    timeout: float | None = None,
+    max_retries: int | None = None,
+) -> "httpx.AsyncClient":
+    """Create an async httpx client for the Bedrock runtime endpoint."""
+    return _create_async(base_url=base_url, headers={}, timeout=timeout, max_retries=max_retries)

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_lazy.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_lazy.py
@@ -18,9 +18,14 @@ if TYPE_CHECKING:
 DEFAULT_REGION = "us-east-1"
 
 
-def bedrock_base_url(region: str) -> str:
-    """Return the bedrock-runtime endpoint for a region."""
-    return f"https://bedrock-runtime.{region}.amazonaws.com"
+def bedrock_base_url(region: str, *, use_fips: bool = False) -> str:
+    """Return the bedrock-runtime endpoint for a region, optionally the FIPS 140-3 variant.
+
+    FIPS endpoints (``bedrock-runtime-fips.<region>.amazonaws.com``) are offered in the commercial
+    and GovCloud regions where Bedrock runs; they force FIPS-validated in-transit cryptography.
+    """
+    service = "bedrock-runtime-fips" if use_fips else "bedrock-runtime"
+    return f"https://{service}.{region}.amazonaws.com"
 
 
 def create_sync_client(

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
@@ -11,15 +11,9 @@ if TYPE_CHECKING:
     from mypy_boto3_bedrock_runtime.literals import CacheTTLType, ImageFormatType
     from mypy_boto3_bedrock_runtime.type_defs import (
         CachePointBlockTypeDef,
-        ContentBlockDeltaEventTypeDef,
-        ContentBlockStartEventTypeDef,
         ContentBlockTypeDef,
-        ConverseResponseTypeDef,
-        ConverseStreamMetadataEventTypeDef,
-        ConverseStreamOutputTypeDef,
         MessageTypeDef,
         SystemContentBlockTypeDef,
-        TokenUsageTypeDef,
         ToolConfigurationTypeDef,
         ToolSpecificationTypeDef,
         ToolTypeDef,
@@ -53,6 +47,15 @@ from lmux.types import (
     ToolMessage,
     Usage,
     UserMessage,
+)
+from lmux_aws_bedrock._wire import (
+    WireContentBlockDeltaEvent,
+    WireContentBlockStartEvent,
+    WireConverseResponse,
+    WireEmbeddingResponse,
+    WireMetadataEvent,
+    WireStreamEvent,
+    WireTokenUsage,
 )
 
 type CostCalculator = Callable[[str, Usage], Cost | None]
@@ -284,44 +287,36 @@ def map_response_format(rf: ResponseFormat) -> dict[str, object] | None:
 
 
 def map_converse_response(
-    response: "ConverseResponseTypeDef",
+    response: WireConverseResponse,
     model: str,
     provider_name: str,
     cost_fn: CostCalculator,
 ) -> ChatResponse:
-    """Convert Converse API response dict to lmux ChatResponse."""
-    output = response.get("output", {})
-    message = output.get("message", {})
-    content_blocks = message.get("content", [])
-
+    """Convert a validated Converse API response to an lmux ChatResponse."""
     text_parts: list[str] = []
     tool_calls: list[ToolCall] = []
     reasoning_parts: list[str] = []
 
-    for block in content_blocks:
-        if "reasoningContent" in block:
-            reasoning_text = block["reasoningContent"].get("reasoningText", {})
-            if text := reasoning_text.get("text"):
-                reasoning_parts.append(text)
-        elif "text" in block:
-            text_parts.append(block["text"])
-        elif "toolUse" in block:
-            tu = block["toolUse"]
+    for block in response.output.message.content:
+        if block.reasoning_content is not None:
+            reasoning_text = block.reasoning_content.reasoning_text
+            if reasoning_text.text:
+                reasoning_parts.append(reasoning_text.text)
+        elif block.text is not None:
+            text_parts.append(block.text)
+        elif block.tool_use is not None:
+            tu = block.tool_use
             tool_calls.append(
                 ToolCall(
-                    id=tu["toolUseId"],
-                    function=FunctionCallResult(
-                        name=tu["name"],
-                        arguments=json.dumps(tu["input"]),
-                    ),
+                    id=tu.tool_use_id,
+                    function=FunctionCallResult(name=tu.name, arguments=json.dumps(tu.input)),
                 )
             )
 
     content = "\n".join(text_parts) if text_parts else None
     reasoning = "\n".join(reasoning_parts) if reasoning_parts else None
-    stop_reason = response.get("stopReason")
-    finish_reason = _map_stop_reason(stop_reason)
-    usage = _map_converse_usage(response)
+    finish_reason = _map_stop_reason(response.stop_reason)
+    usage = _map_token_usage(response.usage) if response.usage else None
     cost = cost_fn(model, usage) if usage else None
 
     return ChatResponse(
@@ -342,98 +337,86 @@ def _map_stop_reason(stop_reason: str | None) -> str | None:
     return _STOP_REASON_MAP.get(stop_reason, stop_reason)
 
 
-def _map_converse_usage(response: "ConverseResponseTypeDef") -> Usage | None:
-    usage_data = response.get("usage")
-    if usage_data is None:
-        return None
-    return _map_token_usage(usage_data)
-
-
-def _map_token_usage(usage_data: "TokenUsageTypeDef") -> Usage:
-    cache_read: int = usage_data.get("cacheReadInputTokens") or 0
-    cache_write: int = usage_data.get("cacheWriteInputTokens") or 0
+def _map_token_usage(usage_data: WireTokenUsage) -> Usage:
+    cache_read = usage_data.cache_read_input_tokens or 0
+    cache_write = usage_data.cache_write_input_tokens or 0
     return Usage(
         # Converse reports inputTokens exclusive of cached tokens; lmux's
         # Usage convention is the inclusive total (see lmux.types.Usage).
-        input_tokens=usage_data.get("inputTokens", 0) + cache_read + cache_write,
-        output_tokens=usage_data.get("outputTokens", 0),
+        input_tokens=usage_data.input_tokens + cache_read + cache_write,
+        output_tokens=usage_data.output_tokens,
         cache_read_tokens=cache_read or None,
         cache_creation_tokens=cache_write or None,
         cache_creation_tokens_by_ttl=_map_cache_details(usage_data),
     )
 
 
-def _map_cache_details(usage_data: "TokenUsageTypeDef") -> dict[str, int] | None:
+def _map_cache_details(usage_data: WireTokenUsage) -> dict[str, int] | None:
     """Aggregate the per-TTL cache-write breakdown (``cacheDetails``) if reported."""
     breakdown: dict[str, int] = {}
-    for detail in usage_data.get("cacheDetails") or []:
-        tokens = detail["inputTokens"]
-        if tokens:
-            ttl = detail["ttl"]
-            breakdown[ttl] = breakdown.get(ttl, 0) + tokens
+    for detail in usage_data.cache_details or []:
+        if detail.input_tokens:
+            breakdown[detail.ttl] = breakdown.get(detail.ttl, 0) + detail.input_tokens
     return breakdown or None
 
 
 # MARK: Stream Event Mappers
 
 
-def map_stream_event(event: "ConverseStreamOutputTypeDef") -> ChatChunk | None:
+def map_stream_event(event: WireStreamEvent) -> ChatChunk | None:
     """Map a single ConverseStream event to a ChatChunk, or None to skip."""
-    if "contentBlockDelta" in event:
-        return _map_content_block_delta(event["contentBlockDelta"])
-    if "contentBlockStart" in event:
-        return _map_content_block_start(event["contentBlockStart"])
-    if "messageStop" in event:
-        return ChatChunk(finish_reason=_map_stop_reason(event["messageStop"].get("stopReason")))
-    if "metadata" in event:
-        return _map_metadata_event(event["metadata"])
+    if event.content_block_delta is not None:
+        return _map_content_block_delta(event.content_block_delta)
+    if event.content_block_start is not None:
+        return _map_content_block_start(event.content_block_start)
+    if event.message_stop is not None:
+        return ChatChunk(finish_reason=_map_stop_reason(event.message_stop.stop_reason))
+    if event.metadata is not None:
+        return _map_metadata_event(event.metadata)
     # messageStart, contentBlockStop — not interesting
     return None
 
 
-def _map_content_block_delta(data: "ContentBlockDeltaEventTypeDef") -> ChatChunk | None:
-    delta = data.get("delta", {})
-    if "reasoningContent" in delta:
-        text = delta["reasoningContent"].get("text")
-        if text:
-            return ChatChunk(reasoning_delta=text)
+def _map_content_block_delta(data: WireContentBlockDeltaEvent) -> ChatChunk | None:
+    delta = data.delta
+    if delta.reasoning_content is not None:
+        if delta.reasoning_content.text:
+            return ChatChunk(reasoning_delta=delta.reasoning_content.text)
         return None
-    if "text" in delta:
-        return ChatChunk(delta=delta["text"])
-    if "toolUse" in delta:
+    if delta.text is not None:
+        return ChatChunk(delta=delta.text)
+    if delta.tool_use is not None:
         return ChatChunk(
             tool_call_deltas=[
                 ToolCallDelta(
-                    index=data.get("contentBlockIndex", 0),
-                    function=FunctionCallDelta(arguments=delta["toolUse"].get("input", "")),
+                    index=data.content_block_index,
+                    function=FunctionCallDelta(arguments=delta.tool_use.input),
                 )
             ]
         )
     return None
 
 
-def _map_content_block_start(data: "ContentBlockStartEventTypeDef") -> ChatChunk | None:
-    start = data.get("start", {})
-    if "toolUse" in start:
-        tu = start["toolUse"]
+def _map_content_block_start(data: WireContentBlockStartEvent) -> ChatChunk | None:
+    if data.start.tool_use is not None:
+        tu = data.start.tool_use
         return ChatChunk(
             tool_call_deltas=[
                 ToolCallDelta(
-                    index=data.get("contentBlockIndex", 0),
-                    id=tu.get("toolUseId"),
+                    index=data.content_block_index,
+                    id=tu.tool_use_id,
                     type="function",
-                    function=FunctionCallDelta(name=tu.get("name")),
+                    function=FunctionCallDelta(name=tu.name),
                 )
             ]
         )
     return None
 
 
-def _map_metadata_event(metadata: "ConverseStreamMetadataEventTypeDef") -> ChatChunk | None:
-    usage_data = metadata.get("usage")
-    if usage_data is None:
+def _map_metadata_event(metadata: WireMetadataEvent) -> ChatChunk | None:
+    if metadata.usage is None:
         return None
-    return ChatChunk(usage=_map_token_usage(usage_data))
+    return ChatChunk(usage=_map_token_usage(metadata.usage))
 
 
 # MARK: Embedding Mappers
@@ -448,20 +431,17 @@ def build_embedding_request_body(text: str, *, dimensions: int | None = None) ->
 
 
 def map_embedding_response(
-    response_body: dict[str, Any],
+    response_body: WireEmbeddingResponse,
     model: str,
     provider_name: str,
     cost_fn: CostCalculator,
 ) -> EmbeddingResponse:
-    """Convert a single InvokeModel embedding response to lmux EmbeddingResponse."""
-    embedding: list[float] = response_body.get("embedding", [])
-    input_token_count: int = response_body.get("inputTextTokenCount", 0)
-
-    usage = Usage(input_tokens=input_token_count, output_tokens=0)
+    """Convert a validated single InvokeModel embedding response to an lmux EmbeddingResponse."""
+    usage = Usage(input_tokens=response_body.input_text_token_count, output_tokens=0)
     cost = cost_fn(model, usage)
 
     return EmbeddingResponse(
-        embeddings=[embedding],
+        embeddings=[response_body.embedding],
         usage=usage,
         cost=cost,
         model=model,

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
@@ -1,6 +1,5 @@
 """Internal mappers between lmux types and Bedrock Converse API types."""
 
-import base64
 import copy
 import json
 import re
@@ -170,8 +169,10 @@ def _map_image_content(img: ImageContent) -> "ContentBlockTypeDef":
     match = _DATA_URI_PATTERN.match(img.url)
     if match:
         fmt = cast("ImageFormatType", match.group(1))
-        data = base64.b64decode(match.group(2))
-        return {"image": {"format": fmt, "source": {"bytes": data}}}
+        # The Converse REST API serializes the image blob as a base64 string in JSON; the base64
+        # payload from the data URI is already that string (boto3 accepted raw bytes and encoded
+        # them itself, but json.dumps cannot serialize bytes).
+        return {"image": {"format": fmt, "source": {"bytes": match.group(2)}}}
     msg = "Bedrock Converse API requires base64 data URIs for images, not URLs"
     raise UnsupportedFeatureError(msg, provider=PROVIDER_NAME)
 

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_sigv4.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_sigv4.py
@@ -1,0 +1,96 @@
+"""Minimal AWS Signature Version 4 signer (stdlib-only).
+
+Bedrock's SDK-lite transport signs requests with SigV4 without pulling botocore
+into the request path. This implements header-based SigV4 (AWS4-HMAC-SHA256).
+It is unit-tested for byte-parity against ``botocore.auth.SigV4Auth`` (a dev-only
+dependency), so the hand-rolled signer is safe to ship.
+"""
+
+import hashlib
+import hmac
+from collections.abc import Mapping
+from datetime import datetime
+from urllib.parse import quote, urlsplit
+
+_ALGORITHM = "AWS4-HMAC-SHA256"
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _hmac(key: bytes, msg: str) -> bytes:
+    return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+
+def _signing_key(secret: str, date: str, region: str, service: str) -> bytes:
+    k_date = _hmac(("AWS4" + secret).encode(), date)
+    k_region = _hmac(k_date, region)
+    k_service = _hmac(k_region, service)
+    return _hmac(k_service, "aws4_request")
+
+
+def _canonical_uri(path: str) -> str:
+    return quote(path, safe="/~") if path else "/"
+
+
+def _canonical_query(query: str) -> str:
+    if not query:
+        return ""
+    # Match botocore: sort the raw (already-encoded) key/value pairs and rejoin.
+    pairs = [(item.partition("=")[0], item.partition("=")[2]) for item in query.split("&")]
+    return "&".join(f"{k}={v}" for k, v in sorted(pairs))
+
+
+def sign(  # noqa: PLR0913
+    *,
+    method: str,
+    url: str,
+    headers: Mapping[str, str],
+    body: bytes,
+    access_key: str,
+    secret_key: str,
+    region: str,
+    service: str,
+    now: datetime,
+    session_token: str | None = None,
+) -> dict[str, str]:
+    """Return ``headers`` with the SigV4 ``Authorization`` (and X-Amz-*) headers added."""
+    parts = urlsplit(url)
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date = now.strftime("%Y%m%d")
+    payload_hash = _sha256_hex(body)
+
+    signed: dict[str, str] = {k.lower(): v.strip() for k, v in headers.items()}
+    signed["host"] = parts.netloc
+    signed["x-amz-date"] = amz_date
+    if session_token:
+        signed["x-amz-security-token"] = session_token
+
+    names = sorted(signed)
+    canonical_headers = "".join(f"{n}:{signed[n]}\n" for n in names)
+    signed_headers = ";".join(names)
+    canonical_request = "\n".join(
+        [
+            method,
+            _canonical_uri(parts.path),
+            _canonical_query(parts.query),
+            canonical_headers,
+            signed_headers,
+            payload_hash,
+        ]
+    )
+    scope = f"{date}/{region}/{service}/aws4_request"
+    string_to_sign = "\n".join([_ALGORITHM, amz_date, scope, _sha256_hex(canonical_request.encode())])
+    signature = hmac.new(
+        _signing_key(secret_key, date, region, service), string_to_sign.encode(), hashlib.sha256
+    ).hexdigest()
+
+    result = dict(headers)
+    result["Authorization"] = (
+        f"{_ALGORITHM} Credential={access_key}/{scope}, SignedHeaders={signed_headers}, Signature={signature}"
+    )
+    result["X-Amz-Date"] = amz_date
+    if session_token:
+        result["X-Amz-Security-Token"] = session_token
+    return result

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_wire.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_wire.py
@@ -1,0 +1,130 @@
+"""Pydantic wire models for the Bedrock Converse (+ ConverseStream) and Titan embedding responses.
+
+Only the fields lmux consumes are declared; unknown fields are ignored (Pydantic's default),
+so new server fields do not break parsing. Bedrock uses camelCase on the wire, so a shared
+alias generator maps snake_case field names to camelCase (``tool_use_id`` -> ``toolUseId``).
+Content blocks and stream events are field-bags (no ``type`` tag), so each carries the shapes
+lmux reads as optional fields and the mapper dispatches on which are present. Nested containers
+default to empty (mirroring the old ``dict.get(..., {})`` access) so the mappers stay guard-free.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
+
+
+class _BedrockModel(BaseModel):
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+
+# MARK: Token usage (shared by the response and the stream metadata event)
+
+
+class WireCacheDetail(_BedrockModel):
+    ttl: str
+    input_tokens: int
+
+
+class WireTokenUsage(_BedrockModel):
+    input_tokens: int
+    output_tokens: int
+    cache_read_input_tokens: int | None = None
+    cache_write_input_tokens: int | None = None
+    cache_details: list[WireCacheDetail] | None = None
+
+
+# MARK: Converse response
+
+
+class WireToolUse(_BedrockModel):
+    tool_use_id: str
+    name: str
+    input: dict[str, Any]
+
+
+class WireReasoningText(_BedrockModel):
+    text: str | None = None
+
+
+class WireReasoningContent(_BedrockModel):
+    reasoning_text: WireReasoningText = Field(default_factory=WireReasoningText)
+
+
+class WireContentBlock(_BedrockModel):
+    text: str | None = None
+    tool_use: WireToolUse | None = None
+    reasoning_content: WireReasoningContent | None = None
+
+
+class WireMessage(_BedrockModel):
+    content: list[WireContentBlock] = Field(default_factory=list)
+
+
+class WireOutput(_BedrockModel):
+    message: WireMessage = Field(default_factory=WireMessage)
+
+
+class WireConverseResponse(_BedrockModel):
+    output: WireOutput = Field(default_factory=WireOutput)
+    stop_reason: str | None = None
+    usage: WireTokenUsage | None = None
+
+
+# MARK: ConverseStream events
+
+
+class WireToolUseDelta(_BedrockModel):
+    input: str = ""
+
+
+class WireReasoningDelta(_BedrockModel):
+    text: str | None = None
+
+
+class WireStreamDelta(_BedrockModel):
+    text: str | None = None
+    tool_use: WireToolUseDelta | None = None
+    reasoning_content: WireReasoningDelta | None = None
+
+
+class WireContentBlockDeltaEvent(_BedrockModel):
+    delta: WireStreamDelta = Field(default_factory=WireStreamDelta)
+    content_block_index: int = 0
+
+
+class WireToolUseStart(_BedrockModel):
+    tool_use_id: str | None = None
+    name: str | None = None
+
+
+class WireContentBlockStart(_BedrockModel):
+    tool_use: WireToolUseStart | None = None
+
+
+class WireContentBlockStartEvent(_BedrockModel):
+    start: WireContentBlockStart = Field(default_factory=WireContentBlockStart)
+    content_block_index: int = 0
+
+
+class WireMessageStopEvent(_BedrockModel):
+    stop_reason: str | None = None
+
+
+class WireMetadataEvent(_BedrockModel):
+    usage: WireTokenUsage | None = None
+
+
+class WireStreamEvent(_BedrockModel):
+    content_block_delta: WireContentBlockDeltaEvent | None = None
+    content_block_start: WireContentBlockStartEvent | None = None
+    message_stop: WireMessageStopEvent | None = None
+    metadata: WireMetadataEvent | None = None
+
+
+# MARK: Embeddings (Titan InvokeModel)
+
+
+class WireEmbeddingResponse(_BedrockModel):
+    embedding: list[float] = Field(default_factory=list)
+    input_text_token_count: int = 0

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -19,14 +19,13 @@ import os
 from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast, override
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, override
 from urllib.parse import quote
 
 if TYPE_CHECKING:
     import boto3
     import httpx
     from aiobotocore.session import AioSession
-    from mypy_boto3_bedrock_runtime.type_defs import ConverseResponseTypeDef, ConverseStreamOutputTypeDef
 
 from lmux.cost import ModelPricing, calculate_cost
 from lmux.exceptions import LmuxError, ProviderError
@@ -43,7 +42,7 @@ from lmux.types import (
     Usage,
 )
 from lmux_aws_bedrock._eventstream import decode_messages
-from lmux_aws_bedrock._exceptions import PROVIDER, map_transport_error, parse_json, raise_for_status
+from lmux_aws_bedrock._exceptions import PROVIDER, map_transport_error, parse_body, raise_for_status
 from lmux_aws_bedrock._lazy import DEFAULT_REGION, bedrock_base_url, create_async_client, create_sync_client
 from lmux_aws_bedrock._mappers import (
     build_embedding_request_body,
@@ -56,6 +55,11 @@ from lmux_aws_bedrock._mappers import (
     model_uses_adaptive_thinking,
 )
 from lmux_aws_bedrock._sigv4 import sign
+from lmux_aws_bedrock._wire import (
+    WireConverseResponse,
+    WireEmbeddingResponse,
+    WireStreamEvent,
+)
 from lmux_aws_bedrock.auth import BedrockEnvAuthProvider
 from lmux_aws_bedrock.cost import calculate_bedrock_cost
 from lmux_aws_bedrock.params import BedrockParams
@@ -253,7 +257,7 @@ class BedrockProvider(
             raise map_transport_error(e) from e
         raise_for_status(response)
         return map_converse_response(
-            cast("ConverseResponseTypeDef", parse_json(response)),
+            parse_body(response, WireConverseResponse),
             model,
             PROVIDER_NAME,
             lambda m, u: self._calculate_cost(m, u, as_of),
@@ -288,7 +292,7 @@ class BedrockProvider(
             raise map_transport_error(e) from e
         raise_for_status(response)
         return map_converse_response(
-            cast("ConverseResponseTypeDef", parse_json(response)),
+            parse_body(response, WireConverseResponse),
             model,
             PROVIDER_NAME,
             lambda m, u: self._calculate_cost(m, u, as_of),
@@ -359,7 +363,7 @@ class BedrockProvider(
         """Decode an event-stream body into ChatChunks, stamping cost on the usage chunk."""
         try:
             for event in _decode_stream(content):
-                chunk = map_stream_event(cast("ConverseStreamOutputTypeDef", event))
+                chunk = map_stream_event(WireStreamEvent.model_validate(event))
                 if chunk is not None:
                     yield self._finalize_chunk(chunk, model, as_of)
         except LmuxError:
@@ -399,9 +403,9 @@ class BedrockProvider(
                 body = build_embedding_request_body(text, dimensions=dimensions).encode()
                 response = client.send(self._build_request(client, path, body))
                 raise_for_status(response)
-                result: dict[str, Any] = parse_json(response)
-                all_embeddings.append(result.get("embedding", []))
-                total_input_tokens += result.get("inputTextTokenCount", 0)
+                result = parse_body(response, WireEmbeddingResponse)
+                all_embeddings.append(result.embedding)
+                total_input_tokens += result.input_text_token_count
         except LmuxError:
             raise
         except Exception as e:
@@ -428,9 +432,9 @@ class BedrockProvider(
                 body = build_embedding_request_body(text, dimensions=dimensions).encode()
                 response = await client.send(self._build_request(client, path, body))
                 raise_for_status(response)
-                result: dict[str, Any] = parse_json(response)
-                all_embeddings.append(result.get("embedding", []))
-                total_input_tokens += result.get("inputTextTokenCount", 0)
+                result = parse_body(response, WireEmbeddingResponse)
+                all_embeddings.append(result.embedding)
+                total_input_tokens += result.input_text_token_count
         except LmuxError:
             raise
         except Exception as e:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -173,18 +173,20 @@ class BedrockProvider(
 ):
     """AWS Bedrock API provider over httpx (Converse API + InvokeModel embeddings)."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         auth: "AuthProvider[boto3.Session, AioSession] | None" = None,
         region: str | None = None,
         endpoint_url: str | None = None,
+        use_fips: bool = False,
         timeout: float | None = None,
         max_retries: int | None = None,
     ) -> None:
         self._auth: AuthProvider[boto3.Session, AioSession] = auth or BedrockEnvAuthProvider()
         self._region: str | None = region
         self._endpoint_url: str | None = endpoint_url
+        self._use_fips: bool = use_fips
         self._timeout: float | None = timeout
         self._max_retries: int | None = max_retries
         self._auth_ctx: _AuthContext | None = None
@@ -220,7 +222,7 @@ class BedrockProvider(
         return self._auth_ctx
 
     def _base_url(self, auth: _AuthContext) -> str:
-        return self._endpoint_url or bedrock_base_url(auth.region)
+        return self._endpoint_url or bedrock_base_url(auth.region, use_fips=self._use_fips)
 
     def _get_sync_client(self) -> "httpx.Client":
         if self._sync_client is None:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -127,20 +127,36 @@ def _resolve_auth_context(auth: "AuthProvider[boto3.Session, AioSession]", regio
     """Resolve the auth mode once: bearer token if present, else a SigV4 credentials source.
 
     The region is resolved from the configured session (``AWS_DEFAULT_REGION``, a profile, or an
-    explicit ``region_name``) in both modes — a bearer token still needs the caller's region to reach
-    the right regional endpoint, so it must not silently fall back to us-east-1.
+    explicit ``region_name``) so a bearer token reaches the right regional endpoint instead of
+    silently defaulting to us-east-1. Bearer mode resolves the region best-effort and never *requires*
+    a constructable session — a stale ``AWS_PROFILE`` must not break bearer auth, which does not use
+    boto3 at all.
     """
-    session = auth.get_credentials()
-    region = region_override or session.region_name or DEFAULT_REGION
-
     bearer = os.environ.get(_BEARER_TOKEN_ENV)
     if bearer:
-        return _AuthContext(region=region, bearer_token=bearer)
+        return _AuthContext(region=region_override or _session_region(auth), bearer_token=bearer)
 
+    session = auth.get_credentials()
+    region = region_override or session.region_name or DEFAULT_REGION
     credentials = session.get_credentials()
     if credentials is None:
         _raise_no_credentials()
     return _AuthContext(region=region, credentials=credentials)
+
+
+def _session_region(auth: "AuthProvider[boto3.Session, AioSession]") -> str:
+    """Best-effort region from the configured session for bearer mode.
+
+    ``region_name`` already reflects ``AWS_REGION``/``AWS_DEFAULT_REGION``/profile config; if the
+    session cannot be constructed (e.g. a missing ``AWS_PROFILE``), fall back to the default region
+    rather than failing a request that only needs a bearer token.
+    """
+    import botocore.exceptions  # noqa: PLC0415
+
+    try:
+        return auth.get_credentials().region_name or DEFAULT_REGION
+    except botocore.exceptions.BotoCoreError:
+        return DEFAULT_REGION
 
 
 def _raise_no_credentials() -> NoReturn:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from botocore.credentials import Credentials
 
 from lmux.cost import ModelPricing, calculate_cost
-from lmux.exceptions import LmuxError, ProviderError
+from lmux.exceptions import LmuxError
 from lmux.protocols import AuthProvider, CompletionProvider, EmbeddingProvider, PricingProvider
 from lmux.types import (
     ChatChunk,
@@ -43,7 +43,13 @@ from lmux.types import (
     Usage,
 )
 from lmux_aws_bedrock._eventstream import EventStreamDecoder
-from lmux_aws_bedrock._exceptions import PROVIDER, map_transport_error, parse_body, raise_for_status
+from lmux_aws_bedrock._exceptions import (
+    PROVIDER,
+    error_from_stream_exception,
+    map_transport_error,
+    parse_body,
+    raise_for_status,
+)
 from lmux_aws_bedrock._lazy import DEFAULT_REGION, bedrock_base_url, create_async_client, create_sync_client
 from lmux_aws_bedrock._mappers import (
     build_embedding_request_body,
@@ -118,16 +124,22 @@ class _AuthContext:
 
 
 def _resolve_auth_context(auth: "AuthProvider[boto3.Session, AioSession]", region_override: str | None) -> _AuthContext:
-    """Resolve the auth mode once: bearer token if present, else a SigV4 credentials source."""
+    """Resolve the auth mode once: bearer token if present, else a SigV4 credentials source.
+
+    The region is resolved from the configured session (``AWS_DEFAULT_REGION``, a profile, or an
+    explicit ``region_name``) in both modes — a bearer token still needs the caller's region to reach
+    the right regional endpoint, so it must not silently fall back to us-east-1.
+    """
+    session = auth.get_credentials()
+    region = region_override or session.region_name or DEFAULT_REGION
+
     bearer = os.environ.get(_BEARER_TOKEN_ENV)
     if bearer:
-        return _AuthContext(region=region_override or DEFAULT_REGION, bearer_token=bearer)
+        return _AuthContext(region=region, bearer_token=bearer)
 
-    session = auth.get_credentials()
     credentials = session.get_credentials()
     if credentials is None:
         _raise_no_credentials()
-    region = region_override or session.region_name or DEFAULT_REGION
     return _AuthContext(region=region, credentials=credentials)
 
 
@@ -151,10 +163,14 @@ class BedrockProvider(
         auth: "AuthProvider[boto3.Session, AioSession] | None" = None,
         region: str | None = None,
         endpoint_url: str | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
     ) -> None:
         self._auth: AuthProvider[boto3.Session, AioSession] = auth or BedrockEnvAuthProvider()
         self._region: str | None = region
         self._endpoint_url: str | None = endpoint_url
+        self._timeout: float | None = timeout
+        self._max_retries: int | None = max_retries
         self._auth_ctx: _AuthContext | None = None
         self._sync_client: httpx.Client | None = None
         self._async_client: httpx.AsyncClient | None = None
@@ -193,14 +209,18 @@ class BedrockProvider(
     def _get_sync_client(self) -> "httpx.Client":
         if self._sync_client is None:
             auth = self._resolve_auth()
-            self._sync_client = create_sync_client(base_url=self._base_url(auth))
+            self._sync_client = create_sync_client(
+                base_url=self._base_url(auth), timeout=self._timeout, max_retries=self._max_retries
+            )
         return self._sync_client
 
     async def _get_async_client(self) -> "httpx.AsyncClient":
         loop = asyncio.get_running_loop()
         if self._async_client is None or self._async_loop is not loop:
             auth = self._resolve_auth()
-            self._async_client = create_async_client(base_url=self._base_url(auth))
+            self._async_client = create_async_client(
+                base_url=self._base_url(auth), timeout=self._timeout, max_retries=self._max_retries
+            )
             self._async_loop = loop
         return self._async_client
 
@@ -586,6 +606,7 @@ def _decode_event(headers: dict[str, str], payload: bytes) -> dict[str, Any]:
     """
     data: dict[str, Any] = json.loads(payload) if payload else {}
     if headers.get(":message-type") == _EXCEPTION_MESSAGE_TYPE:
-        message = data.get("message") or data.get("Message") or headers.get(":exception-type", "")
-        raise ProviderError(str(message), provider=PROVIDER_NAME)
+        exception_type = headers.get(":exception-type", "")
+        message = data.get("message") or data.get("Message") or exception_type
+        raise error_from_stream_exception(exception_type, str(message))
     return {headers[":event-type"]: data}

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     import boto3
     import httpx
     from aiobotocore.session import AioSession
-    from mypy_boto3_bedrock_runtime.type_defs import ConverseStreamOutputTypeDef
+    from mypy_boto3_bedrock_runtime.type_defs import ConverseResponseTypeDef, ConverseStreamOutputTypeDef
 
 from lmux.cost import ModelPricing, calculate_cost
 from lmux.exceptions import LmuxError, ProviderError
@@ -43,7 +43,7 @@ from lmux.types import (
     Usage,
 )
 from lmux_aws_bedrock._eventstream import decode_messages
-from lmux_aws_bedrock._exceptions import PROVIDER, map_transport_error, raise_for_status
+from lmux_aws_bedrock._exceptions import PROVIDER, map_transport_error, parse_json, raise_for_status
 from lmux_aws_bedrock._lazy import DEFAULT_REGION, bedrock_base_url, create_async_client, create_sync_client
 from lmux_aws_bedrock._mappers import (
     build_embedding_request_body,
@@ -253,7 +253,10 @@ class BedrockProvider(
             raise map_transport_error(e) from e
         raise_for_status(response)
         return map_converse_response(
-            response.json(), model, PROVIDER_NAME, lambda m, u: self._calculate_cost(m, u, as_of)
+            cast("ConverseResponseTypeDef", parse_json(response)),
+            model,
+            PROVIDER_NAME,
+            lambda m, u: self._calculate_cost(m, u, as_of),
         )
 
     @override
@@ -285,7 +288,10 @@ class BedrockProvider(
             raise map_transport_error(e) from e
         raise_for_status(response)
         return map_converse_response(
-            response.json(), model, PROVIDER_NAME, lambda m, u: self._calculate_cost(m, u, as_of)
+            cast("ConverseResponseTypeDef", parse_json(response)),
+            model,
+            PROVIDER_NAME,
+            lambda m, u: self._calculate_cost(m, u, as_of),
         )
 
     @override
@@ -393,7 +399,7 @@ class BedrockProvider(
                 body = build_embedding_request_body(text, dimensions=dimensions).encode()
                 response = client.send(self._build_request(client, path, body))
                 raise_for_status(response)
-                result: dict[str, Any] = response.json()
+                result: dict[str, Any] = parse_json(response)
                 all_embeddings.append(result.get("embedding", []))
                 total_input_tokens += result.get("inputTextTokenCount", 0)
         except LmuxError:
@@ -422,7 +428,7 @@ class BedrockProvider(
                 body = build_embedding_request_body(text, dimensions=dimensions).encode()
                 response = await client.send(self._build_request(client, path, body))
                 raise_for_status(response)
-                result: dict[str, Any] = response.json()
+                result: dict[str, Any] = parse_json(response)
                 all_embeddings.append(result.get("embedding", []))
                 total_input_tokens += result.get("inputTextTokenCount", 0)
         except LmuxError:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     import boto3
     import httpx
     from aiobotocore.session import AioSession
+    from botocore.credentials import Credentials
 
 from lmux.cost import ModelPricing, calculate_cost
 from lmux.exceptions import LmuxError, ProviderError
@@ -41,7 +42,7 @@ from lmux.types import (
     ToolChoice,
     Usage,
 )
-from lmux_aws_bedrock._eventstream import decode_messages
+from lmux_aws_bedrock._eventstream import EventStreamDecoder
 from lmux_aws_bedrock._exceptions import PROVIDER, map_transport_error, parse_body, raise_for_status
 from lmux_aws_bedrock._lazy import DEFAULT_REGION, bedrock_base_url, create_async_client, create_sync_client
 from lmux_aws_bedrock._mappers import (
@@ -83,36 +84,41 @@ def _today() -> date:
 
 @dataclass(frozen=True)
 class _AuthContext:
-    """Resolved per-provider auth: a region plus either a bearer token or SigV4 creds."""
+    """Resolved per-provider auth: a region plus either a bearer token or a SigV4 credentials source."""
 
     region: str
     bearer_token: str | None = None
-    access_key: str | None = None
-    secret_key: str | None = None
-    session_token: str | None = None
+    credentials: "Credentials | None" = None
 
     def apply(self, request: "httpx.Request") -> None:
         """Attach the auth header(s) to a fully built request."""
         if self.bearer_token is not None:
             request.headers["Authorization"] = f"Bearer {self.bearer_token}"
             return
+        credentials = self.credentials
+        if credentials is None:  # pragma: no cover - always set when bearer_token is None
+            _raise_no_credentials()
+        # Freeze credentials per request: a refreshable source (SSO, assume-role, IMDS) rotates the
+        # keys over the provider's lifetime, so signing with a snapshot taken at client creation
+        # would start failing once the original token expires.
+        frozen = credentials.get_frozen_credentials()
         signed = sign(
             method=request.method,
             url=str(request.url),
             headers={"content-type": _JSON_CONTENT_TYPE},
             body=request.content,
-            access_key=self.access_key or "",
-            secret_key=self.secret_key or "",
+            access_key=frozen.access_key or "",
+            secret_key=frozen.secret_key or "",
             region=self.region,
             service=_SERVICE,
             now=datetime.now(UTC),
-            session_token=self.session_token,
+            session_token=frozen.token,
         )
         request.headers.update(signed)
 
 
 def _resolve_auth_context(auth: "AuthProvider[boto3.Session, AioSession]", region_override: str | None) -> _AuthContext:
-    """Resolve the auth mode once: bearer token if present, else SigV4 credentials."""
+    """Resolve the auth mode once: bearer token if present, else a SigV4 credentials source."""
     bearer = os.environ.get(_BEARER_TOKEN_ENV)
     if bearer:
         return _AuthContext(region=region_override or DEFAULT_REGION, bearer_token=bearer)
@@ -121,14 +127,8 @@ def _resolve_auth_context(auth: "AuthProvider[boto3.Session, AioSession]", regio
     credentials = session.get_credentials()
     if credentials is None:
         _raise_no_credentials()
-    frozen = credentials.get_frozen_credentials()
     region = region_override or session.region_name or DEFAULT_REGION
-    return _AuthContext(
-        region=region,
-        access_key=frozen.access_key,
-        secret_key=frozen.secret_key,
-        session_token=frozen.token,
-    )
+    return _AuthContext(region=region, credentials=credentials)
 
 
 def _raise_no_credentials() -> NoReturn:
@@ -322,11 +322,23 @@ class BedrockProvider(
         try:
             client = self._get_sync_client()
             path = self._endpoint_path(model, _CONVERSE_STREAM)
-            response = client.send(self._build_request(client, path, self._converse_body(kwargs)))
+            response = client.send(self._build_request(client, path, self._converse_body(kwargs)), stream=True)
         except Exception as e:
             raise map_transport_error(e) from e
-        raise_for_status(response)
-        yield from self._iter_stream(response.content, model, as_of)
+        try:
+            self._raise_for_stream_status(response)
+            decoder = EventStreamDecoder()
+            for raw in response.iter_bytes():
+                for headers, payload in decoder.feed(raw):
+                    chunk = self._map_stream_event(_decode_event(headers, payload), model, as_of)
+                    if chunk is not None:
+                        yield chunk
+        except LmuxError:
+            raise
+        except Exception as e:
+            raise map_transport_error(e) from e
+        finally:
+            response.close()
 
     @override
     async def achat_stream(
@@ -352,24 +364,43 @@ class BedrockProvider(
         try:
             client = await self._get_async_client()
             path = self._endpoint_path(model, _CONVERSE_STREAM)
-            response = await client.send(self._build_request(client, path, self._converse_body(kwargs)))
+            response = await client.send(self._build_request(client, path, self._converse_body(kwargs)), stream=True)
         except Exception as e:
             raise map_transport_error(e) from e
-        raise_for_status(response)
-        for chunk in self._iter_stream(response.content, model, as_of):
-            yield chunk
-
-    def _iter_stream(self, content: bytes, model: str, as_of: date) -> Iterator[ChatChunk]:
-        """Decode an event-stream body into ChatChunks, stamping cost on the usage chunk."""
         try:
-            for event in _decode_stream(content):
-                chunk = map_stream_event(WireStreamEvent.model_validate(event))
-                if chunk is not None:
-                    yield self._finalize_chunk(chunk, model, as_of)
+            await self._araise_for_stream_status(response)
+            decoder = EventStreamDecoder()
+            async for raw in response.aiter_bytes():
+                for headers, payload in decoder.feed(raw):
+                    chunk = self._map_stream_event(_decode_event(headers, payload), model, as_of)
+                    if chunk is not None:
+                        yield chunk
         except LmuxError:
             raise
         except Exception as e:
             raise map_transport_error(e) from e
+        finally:
+            await response.aclose()
+
+    @staticmethod
+    def _raise_for_stream_status(response: "httpx.Response") -> None:
+        """Read the body and raise the mapped error before iterating a streamed response."""
+        if response.is_error:
+            response.read()
+            raise_for_status(response)
+
+    @staticmethod
+    async def _araise_for_stream_status(response: "httpx.Response") -> None:
+        if response.is_error:
+            await response.aread()
+            raise_for_status(response)
+
+    def _map_stream_event(self, event: dict[str, Any], model: str, as_of: date) -> ChatChunk | None:
+        """Map one decoded event to a ChatChunk, stamping cost on the usage chunk (None if not user-facing)."""
+        chunk = map_stream_event(WireStreamEvent.model_validate(event))
+        if chunk is None:
+            return None
+        return self._finalize_chunk(chunk, model, as_of)
 
     def _finalize_chunk(self, chunk: ChatChunk, model: str, as_of: date) -> ChatChunk:
         if chunk.usage is None:
@@ -545,16 +576,16 @@ class BedrockProvider(
         return kwargs
 
 
-def _decode_stream(content: bytes) -> Iterator[dict[str, Any]]:
-    """Decode an AWS event-stream body into ``{event_type: payload}`` dicts.
+def _decode_event(headers: dict[str, str], payload: bytes) -> dict[str, Any]:
+    """Decode one event-stream message into a ``{event_type: payload}`` dict.
 
-    Frames whose ``:message-type`` is ``exception`` (a mid-stream service error) are
-    raised rather than yielded, preserving the boto3 client's fail-on-error behavior.
+    Exception frames (a mid-stream service error) carry ``:message-type: exception`` and an
+    ``:exception-type`` header but no ``:event-type``, so the message type is checked before the
+    event type is read; those frames are raised rather than returned, preserving the boto3
+    client's fail-on-error behavior.
     """
-    for headers, payload in decode_messages(content):
-        event_type = headers[":event-type"]
-        data: dict[str, Any] = json.loads(payload) if payload else {}
-        if headers.get(":message-type") == _EXCEPTION_MESSAGE_TYPE:
-            message = data.get("message") or data.get("Message") or event_type
-            raise ProviderError(str(message), provider=PROVIDER_NAME)
-        yield {event_type: data}
+    data: dict[str, Any] = json.loads(payload) if payload else {}
+    if headers.get(":message-type") == _EXCEPTION_MESSAGE_TYPE:
+        message = data.get("message") or data.get("Message") or headers.get(":exception-type", "")
+        raise ProviderError(str(message), provider=PROVIDER_NAME)
+    return {headers[":event-type"]: data}

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -81,6 +81,7 @@ _CONVERSE_STREAM = "converse-stream"
 _INVOKE = "invoke"
 
 _EXCEPTION_MESSAGE_TYPE = "exception"
+_ERROR_MESSAGE_TYPE = "error"
 
 
 def _today() -> date:
@@ -617,14 +618,18 @@ class BedrockProvider(
 def _decode_event(headers: dict[str, str], payload: bytes) -> dict[str, Any]:
     """Decode one event-stream message into a ``{event_type: payload}`` dict.
 
-    Exception frames (a mid-stream service error) carry ``:message-type: exception`` and an
-    ``:exception-type`` header but no ``:event-type``, so the message type is checked before the
-    event type is read; those frames are raised rather than returned, preserving the boto3
-    client's fail-on-error behavior.
+    A mid-stream failure has no ``:event-type``, so ``:message-type`` is checked first and those
+    frames are raised (preserving boto3's fail-on-error behavior): a modeled ``exception`` frame
+    carries ``:exception-type`` plus a JSON message, and an unmodeled ``error`` frame carries
+    ``:error-code``/``:error-message`` headers. Both are classified through the same hierarchy.
     """
     data: dict[str, Any] = json.loads(payload) if payload else {}
-    if headers.get(":message-type") == _EXCEPTION_MESSAGE_TYPE:
+    message_type = headers.get(":message-type")
+    if message_type == _EXCEPTION_MESSAGE_TYPE:
         exception_type = headers.get(":exception-type", "")
         message = data.get("message") or data.get("Message") or exception_type
         raise error_from_stream_exception(exception_type, str(message))
+    if message_type == _ERROR_MESSAGE_TYPE:
+        error_code = headers.get(":error-code", "")
+        raise error_from_stream_exception(error_code, headers.get(":error-message") or error_code)
     return {headers[":event-type"]: data}

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -1,18 +1,35 @@
-"""AWS Bedrock provider implementation."""
+"""AWS Bedrock provider implementation (SDK-lite, httpx transport).
 
+Requests go straight to the Bedrock runtime REST endpoints over httpx. Authentication
+is one of two modes, resolved once on first use:
+
+* **Bearer token** — if ``AWS_BEARER_TOKEN_BEDROCK`` is set, each request carries an
+  ``Authorization: Bearer <token>`` header and nothing is signed.
+* **SigV4** — otherwise classic AWS credentials are resolved through boto3 (kept purely
+  for the credential chain) and each request is signed with :mod:`._sigv4`.
+
+Credentials are resolved synchronously even on the async path — reimplementing the AWS
+credential chain asynchronously is out of scope, and boto3 stays a dependency only for
+this step.
+"""
+
+import asyncio
 import json
+import os
 from collections.abc import AsyncIterator, Iterator, Sequence
-from contextlib import AbstractAsyncContextManager
-from datetime import date
-from typing import TYPE_CHECKING, Any, Literal, override
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast, override
+from urllib.parse import quote
 
 if TYPE_CHECKING:
     import boto3
+    import httpx
     from aiobotocore.session import AioSession
-    from mypy_boto3_bedrock_runtime import BedrockRuntimeClient
-    from types_aiobotocore_bedrock_runtime import BedrockRuntimeClient as AsyncBedrockRuntimeClient
+    from mypy_boto3_bedrock_runtime.type_defs import ConverseStreamOutputTypeDef
 
 from lmux.cost import ModelPricing, calculate_cost
+from lmux.exceptions import LmuxError, ProviderError
 from lmux.protocols import AuthProvider, CompletionProvider, EmbeddingProvider, PricingProvider
 from lmux.types import (
     ChatChunk,
@@ -25,8 +42,9 @@ from lmux.types import (
     ToolChoice,
     Usage,
 )
-from lmux_aws_bedrock._exceptions import map_bedrock_error
-from lmux_aws_bedrock._lazy import create_async_client, create_sync_client
+from lmux_aws_bedrock._eventstream import decode_messages
+from lmux_aws_bedrock._exceptions import PROVIDER, map_transport_error, raise_for_status
+from lmux_aws_bedrock._lazy import DEFAULT_REGION, bedrock_base_url, create_async_client, create_sync_client
 from lmux_aws_bedrock._mappers import (
     build_embedding_request_body,
     map_converse_response,
@@ -37,11 +55,21 @@ from lmux_aws_bedrock._mappers import (
     map_tools,
     model_uses_adaptive_thinking,
 )
+from lmux_aws_bedrock._sigv4 import sign
 from lmux_aws_bedrock.auth import BedrockEnvAuthProvider
 from lmux_aws_bedrock.cost import calculate_bedrock_cost
 from lmux_aws_bedrock.params import BedrockParams
 
-PROVIDER_NAME = "aws-bedrock"
+PROVIDER_NAME = PROVIDER
+_SERVICE = "bedrock"
+_BEARER_TOKEN_ENV = "AWS_BEARER_TOKEN_BEDROCK"  # noqa: S105
+_JSON_CONTENT_TYPE = "application/json"
+
+_CONVERSE = "converse"
+_CONVERSE_STREAM = "converse-stream"
+_INVOKE = "invoke"
+
+_EXCEPTION_MESSAGE_TYPE = "exception"
 
 
 def _today() -> date:
@@ -49,25 +77,84 @@ def _today() -> date:
     return date.today()
 
 
+@dataclass(frozen=True)
+class _AuthContext:
+    """Resolved per-provider auth: a region plus either a bearer token or SigV4 creds."""
+
+    region: str
+    bearer_token: str | None = None
+    access_key: str | None = None
+    secret_key: str | None = None
+    session_token: str | None = None
+
+    def apply(self, request: "httpx.Request") -> None:
+        """Attach the auth header(s) to a fully built request."""
+        if self.bearer_token is not None:
+            request.headers["Authorization"] = f"Bearer {self.bearer_token}"
+            return
+        signed = sign(
+            method=request.method,
+            url=str(request.url),
+            headers={"content-type": _JSON_CONTENT_TYPE},
+            body=request.content,
+            access_key=self.access_key or "",
+            secret_key=self.secret_key or "",
+            region=self.region,
+            service=_SERVICE,
+            now=datetime.now(UTC),
+            session_token=self.session_token,
+        )
+        request.headers.update(signed)
+
+
+def _resolve_auth_context(auth: "AuthProvider[boto3.Session, AioSession]", region_override: str | None) -> _AuthContext:
+    """Resolve the auth mode once: bearer token if present, else SigV4 credentials."""
+    bearer = os.environ.get(_BEARER_TOKEN_ENV)
+    if bearer:
+        return _AuthContext(region=region_override or DEFAULT_REGION, bearer_token=bearer)
+
+    session = auth.get_credentials()
+    credentials = session.get_credentials()
+    if credentials is None:
+        _raise_no_credentials()
+    frozen = credentials.get_frozen_credentials()
+    region = region_override or session.region_name or DEFAULT_REGION
+    return _AuthContext(
+        region=region,
+        access_key=frozen.access_key,
+        secret_key=frozen.secret_key,
+        session_token=frozen.token,
+    )
+
+
+def _raise_no_credentials() -> NoReturn:
+    """Raise botocore's ``NoCredentialsError`` so it maps to ``AuthenticationError``."""
+    import botocore.exceptions  # noqa: PLC0415
+
+    raise botocore.exceptions.NoCredentialsError
+
+
 class BedrockProvider(
     CompletionProvider[BedrockParams],
     EmbeddingProvider[BedrockParams],
     PricingProvider,
 ):
-    """AWS Bedrock API provider using the Converse API."""
+    """AWS Bedrock API provider over httpx (Converse API + InvokeModel embeddings)."""
 
     def __init__(
         self,
         *,
-        auth: AuthProvider["boto3.Session", "AioSession"] | None = None,
+        auth: "AuthProvider[boto3.Session, AioSession] | None" = None,
         region: str | None = None,
         endpoint_url: str | None = None,
     ) -> None:
         self._auth: AuthProvider[boto3.Session, AioSession] = auth or BedrockEnvAuthProvider()
         self._region: str | None = region
         self._endpoint_url: str | None = endpoint_url
-        self._sync_client: BedrockRuntimeClient | None = None
-        self._async_session: AioSession | None = None
+        self._auth_ctx: _AuthContext | None = None
+        self._sync_client: httpx.Client | None = None
+        self._async_client: httpx.AsyncClient | None = None
+        self._async_loop: asyncio.AbstractEventLoop | None = None
         self._custom_pricing: dict[str, ModelPricing] = {}
 
     # MARK: Pricing
@@ -89,23 +176,51 @@ class BedrockProvider(
             return calculate_cost(usage, pricing, as_of)
         return calculate_bedrock_cost(model, usage, region=self._region, as_of=as_of)
 
-    # MARK: Client Management
+    # MARK: Client & Auth Management
 
-    def _get_sync_client(self) -> "BedrockRuntimeClient":
+    def _resolve_auth(self) -> _AuthContext:
+        if self._auth_ctx is None:
+            self._auth_ctx = _resolve_auth_context(self._auth, self._region)
+        return self._auth_ctx
+
+    def _base_url(self, auth: _AuthContext) -> str:
+        return self._endpoint_url or bedrock_base_url(auth.region)
+
+    def _get_sync_client(self) -> "httpx.Client":
         if self._sync_client is None:
-            session = self._auth.get_credentials()
-            self._sync_client = create_sync_client(session, region_name=self._region, endpoint_url=self._endpoint_url)
+            auth = self._resolve_auth()
+            self._sync_client = create_sync_client(base_url=self._base_url(auth))
         return self._sync_client
 
-    async def _get_async_client_ctx(self) -> AbstractAsyncContextManager["AsyncBedrockRuntimeClient"]:
-        """Return an aiobotocore async client context manager."""
-        if self._async_session is None:
-            self._async_session = await self._auth.aget_credentials()
-        return create_async_client(
-            self._async_session,
-            region_name=self._region,
-            endpoint_url=self._endpoint_url,
-        )
+    async def _get_async_client(self) -> "httpx.AsyncClient":
+        loop = asyncio.get_running_loop()
+        if self._async_client is None or self._async_loop is not loop:
+            auth = self._resolve_auth()
+            self._async_client = create_async_client(base_url=self._base_url(auth))
+            self._async_loop = loop
+        return self._async_client
+
+    async def aclose(self) -> None:
+        """Close the underlying async HTTP client."""
+        if self._async_client is not None:
+            await self._async_client.aclose()
+            self._async_client = None
+            self._async_loop = None
+
+    def _build_request(self, client: "httpx.Client | httpx.AsyncClient", path: str, body: bytes) -> "httpx.Request":
+        """Build a signed/authorized POST request for a Bedrock endpoint."""
+        request = client.build_request("POST", path, content=body, headers={"content-type": _JSON_CONTENT_TYPE})
+        self._resolve_auth().apply(request)
+        return request
+
+    @staticmethod
+    def _endpoint_path(model: str, action: str) -> str:
+        return f"/model/{quote(model, safe='')}/{action}"
+
+    @staticmethod
+    def _converse_body(kwargs: dict[str, Any]) -> bytes:
+        """Serialize converse kwargs to a JSON body, dropping ``modelId`` (it is in the path)."""
+        return json.dumps({k: v for k, v in kwargs.items() if k != "modelId"}).encode()
 
     # MARK: Chat
 
@@ -126,25 +241,20 @@ class BedrockProvider(
         provider_params: BedrockParams | None = None,
     ) -> ChatResponse:
         kwargs = self._build_converse_kwargs(
-            model,
-            messages,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+            model, messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params,
+        )  # fmt: skip
+        as_of = self._resolve_pricing_as_of(provider_params)
         try:
             client = self._get_sync_client()
-            response = client.converse(**kwargs)
+            request = self._build_request(client, self._endpoint_path(model, _CONVERSE), self._converse_body(kwargs))
+            response = client.send(request)
         except Exception as e:
-            raise map_bedrock_error(e) from e
-        as_of = self._resolve_pricing_as_of(provider_params)
-        return map_converse_response(response, model, PROVIDER_NAME, lambda m, u: self._calculate_cost(m, u, as_of))
+            raise map_transport_error(e) from e
+        raise_for_status(response)
+        return map_converse_response(
+            response.json(), model, PROVIDER_NAME, lambda m, u: self._calculate_cost(m, u, as_of)
+        )
 
     @override
     async def achat(
@@ -163,25 +273,20 @@ class BedrockProvider(
         provider_params: BedrockParams | None = None,
     ) -> ChatResponse:
         kwargs = self._build_converse_kwargs(
-            model,
-            messages,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
-        try:
-            async with await self._get_async_client_ctx() as client:
-                response = await client.converse(**kwargs)
-        except Exception as e:
-            raise map_bedrock_error(e) from e
+            model, messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params,
+        )  # fmt: skip
         as_of = self._resolve_pricing_as_of(provider_params)
-        return map_converse_response(response, model, PROVIDER_NAME, lambda m, u: self._calculate_cost(m, u, as_of))
+        try:
+            client = await self._get_async_client()
+            request = self._build_request(client, self._endpoint_path(model, _CONVERSE), self._converse_body(kwargs))
+            response = await client.send(request)
+        except Exception as e:
+            raise map_transport_error(e) from e
+        raise_for_status(response)
+        return map_converse_response(
+            response.json(), model, PROVIDER_NAME, lambda m, u: self._calculate_cost(m, u, as_of)
+        )
 
     @override
     def chat_stream(
@@ -200,41 +305,18 @@ class BedrockProvider(
         provider_params: BedrockParams | None = None,
     ) -> Iterator[ChatChunk]:
         kwargs = self._build_converse_kwargs(
-            model,
-            messages,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+            model, messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params,
+        )  # fmt: skip
         as_of = self._resolve_pricing_as_of(provider_params)
         try:
             client = self._get_sync_client()
-            response = client.converse_stream(**kwargs)
+            path = self._endpoint_path(model, _CONVERSE_STREAM)
+            response = client.send(self._build_request(client, path, self._converse_body(kwargs)))
         except Exception as e:
-            raise map_bedrock_error(e) from e
-
-        try:
-            event_stream = response.get("stream", [])
-            for event in event_stream:
-                chunk = map_stream_event(event)
-                if chunk is not None:
-                    if chunk.usage is not None:
-                        chunk = chunk.model_copy(
-                            update={
-                                "cost": self._calculate_cost(model, chunk.usage, as_of),
-                                "model": model,
-                                "provider": PROVIDER_NAME,
-                            }
-                        )
-                    yield chunk
-        except Exception as e:
-            raise map_bedrock_error(e) from e
+            raise map_transport_error(e) from e
+        raise_for_status(response)
+        yield from self._iter_stream(response.content, model, as_of)
 
     @override
     async def achat_stream(
@@ -253,37 +335,42 @@ class BedrockProvider(
         provider_params: BedrockParams | None = None,
     ) -> AsyncIterator[ChatChunk]:
         kwargs = self._build_converse_kwargs(
-            model,
-            messages,
-            temperature,
-            max_tokens,
-            top_p,
-            stop,
-            tools,
-            tool_choice,
-            response_format,
-            reasoning_effort,
-            provider_params,
-        )
+            model, messages, temperature, max_tokens, top_p, stop,
+            tools, tool_choice, response_format, reasoning_effort, provider_params,
+        )  # fmt: skip
         as_of = self._resolve_pricing_as_of(provider_params)
         try:
-            async with await self._get_async_client_ctx() as client:
-                response = await client.converse_stream(**kwargs)
-                event_stream = response.get("stream", [])
-                async for event in event_stream:
-                    chunk = map_stream_event(event)
-                    if chunk is not None:
-                        if chunk.usage is not None:
-                            chunk = chunk.model_copy(
-                                update={
-                                    "cost": self._calculate_cost(model, chunk.usage, as_of),
-                                    "model": model,
-                                    "provider": PROVIDER_NAME,
-                                }
-                            )
-                        yield chunk
+            client = await self._get_async_client()
+            path = self._endpoint_path(model, _CONVERSE_STREAM)
+            response = await client.send(self._build_request(client, path, self._converse_body(kwargs)))
         except Exception as e:
-            raise map_bedrock_error(e) from e
+            raise map_transport_error(e) from e
+        raise_for_status(response)
+        for chunk in self._iter_stream(response.content, model, as_of):
+            yield chunk
+
+    def _iter_stream(self, content: bytes, model: str, as_of: date) -> Iterator[ChatChunk]:
+        """Decode an event-stream body into ChatChunks, stamping cost on the usage chunk."""
+        try:
+            for event in _decode_stream(content):
+                chunk = map_stream_event(cast("ConverseStreamOutputTypeDef", event))
+                if chunk is not None:
+                    yield self._finalize_chunk(chunk, model, as_of)
+        except LmuxError:
+            raise
+        except Exception as e:
+            raise map_transport_error(e) from e
+
+    def _finalize_chunk(self, chunk: ChatChunk, model: str, as_of: date) -> ChatChunk:
+        if chunk.usage is None:
+            return chunk
+        return chunk.model_copy(
+            update={
+                "cost": self._calculate_cost(model, chunk.usage, as_of),
+                "model": model,
+                "provider": PROVIDER_NAME,
+            }
+        )
 
     # MARK: Embeddings
 
@@ -297,40 +384,24 @@ class BedrockProvider(
         provider_params: BedrockParams | None = None,
     ) -> EmbeddingResponse:
         texts = [input] if isinstance(input, str) else input
-
         all_embeddings: list[list[float]] = []
         total_input_tokens = 0
-
+        path = self._endpoint_path(model, _INVOKE)
         try:
             client = self._get_sync_client()
+            for text in texts:
+                body = build_embedding_request_body(text, dimensions=dimensions).encode()
+                response = client.send(self._build_request(client, path, body))
+                raise_for_status(response)
+                result: dict[str, Any] = response.json()
+                all_embeddings.append(result.get("embedding", []))
+                total_input_tokens += result.get("inputTextTokenCount", 0)
+        except LmuxError:
+            raise
         except Exception as e:
-            raise map_bedrock_error(e) from e
+            raise map_transport_error(e) from e
 
-        for text in texts:
-            body = build_embedding_request_body(text, dimensions=dimensions)
-            try:
-                response = client.invoke_model(
-                    modelId=model,
-                    contentType="application/json",
-                    body=body,
-                )
-            except Exception as e:
-                raise map_bedrock_error(e) from e
-
-            result: dict[str, Any] = json.loads(response["body"].read())
-            all_embeddings.append(result.get("embedding", []))
-            total_input_tokens += result.get("inputTextTokenCount", 0)
-
-        usage = Usage(input_tokens=total_input_tokens, output_tokens=0)
-        cost = self._calculate_cost(model, usage, self._resolve_pricing_as_of(provider_params))
-
-        return EmbeddingResponse(
-            embeddings=all_embeddings,
-            usage=usage,
-            cost=cost,
-            model=model,
-            provider=PROVIDER_NAME,
-        )
+        return self._embedding_response(model, all_embeddings, total_input_tokens, provider_params)
 
     @override
     async def aembed(
@@ -342,32 +413,36 @@ class BedrockProvider(
         provider_params: BedrockParams | None = None,
     ) -> EmbeddingResponse:
         texts = [input] if isinstance(input, str) else input
-
         all_embeddings: list[list[float]] = []
         total_input_tokens = 0
-
-        async with await self._get_async_client_ctx() as client:
+        path = self._endpoint_path(model, _INVOKE)
+        try:
+            client = await self._get_async_client()
             for text in texts:
-                body = build_embedding_request_body(text, dimensions=dimensions)
-                try:
-                    response = await client.invoke_model(
-                        modelId=model,
-                        contentType="application/json",
-                        body=body,
-                    )
-                except Exception as e:
-                    raise map_bedrock_error(e) from e
-
-                raw = await response["body"].read()
-                result: dict[str, Any] = json.loads(raw)
+                body = build_embedding_request_body(text, dimensions=dimensions).encode()
+                response = await client.send(self._build_request(client, path, body))
+                raise_for_status(response)
+                result: dict[str, Any] = response.json()
                 all_embeddings.append(result.get("embedding", []))
                 total_input_tokens += result.get("inputTextTokenCount", 0)
+        except LmuxError:
+            raise
+        except Exception as e:
+            raise map_transport_error(e) from e
 
-        usage = Usage(input_tokens=total_input_tokens, output_tokens=0)
+        return self._embedding_response(model, all_embeddings, total_input_tokens, provider_params)
+
+    def _embedding_response(
+        self,
+        model: str,
+        embeddings: list[list[float]],
+        input_tokens: int,
+        provider_params: BedrockParams | None,
+    ) -> EmbeddingResponse:
+        usage = Usage(input_tokens=input_tokens, output_tokens=0)
         cost = self._calculate_cost(model, usage, self._resolve_pricing_as_of(provider_params))
-
         return EmbeddingResponse(
-            embeddings=all_embeddings,
+            embeddings=embeddings,
             usage=usage,
             cost=cost,
             model=model,
@@ -458,3 +533,18 @@ class BedrockProvider(
         if params.additional_model_response_field_paths is not None:
             kwargs["additionalModelResponseFieldPaths"] = params.additional_model_response_field_paths
         return kwargs
+
+
+def _decode_stream(content: bytes) -> Iterator[dict[str, Any]]:
+    """Decode an AWS event-stream body into ``{event_type: payload}`` dicts.
+
+    Frames whose ``:message-type`` is ``exception`` (a mid-stream service error) are
+    raised rather than yielded, preserving the boto3 client's fail-on-error behavior.
+    """
+    for headers, payload in decode_messages(content):
+        event_type = headers[":event-type"]
+        data: dict[str, Any] = json.loads(payload) if payload else {}
+        if headers.get(":message-type") == _EXCEPTION_MESSAGE_TYPE:
+            message = data.get("message") or data.get("Message") or event_type
+            raise ProviderError(str(message), provider=PROVIDER_NAME)
+        yield {event_type: data}

--- a/packages/lmux-aws-bedrock/tests/test_eventstream.py
+++ b/packages/lmux-aws-bedrock/tests/test_eventstream.py
@@ -4,6 +4,7 @@ import json
 import struct
 import zlib
 
+import pytest
 from botocore.eventstream import EventStreamBuffer
 
 from lmux_aws_bedrock._eventstream import EventStreamDecoder, decode_messages
@@ -54,3 +55,17 @@ class TestEventStreamDecoder:
         assert list(decoder.feed(_FRAMES[:6])) == []
         messages = list(decoder.feed(_FRAMES[6:]))
         assert [h[":event-type"] for h, _ in messages] == ["messageStart", "contentBlockDelta"]
+
+
+class TestCrcValidation:
+    def test_bad_prelude_crc_raises(self) -> None:
+        frame = bytearray(_encode({":event-type": "contentBlockDelta"}, b'{"x":1}'))
+        frame[8] ^= 0xFF  # corrupt the prelude CRC (bytes 8:12)
+        with pytest.raises(ValueError, match="prelude checksum"):
+            list(decode_messages(bytes(frame)))
+
+    def test_bad_message_crc_raises(self) -> None:
+        frame = bytearray(_encode({":event-type": "contentBlockDelta"}, b'{"x":1}'))
+        frame[-5] ^= 0xFF  # corrupt the last payload byte -> message CRC no longer matches
+        with pytest.raises(ValueError, match="message checksum"):
+            list(decode_messages(bytes(frame)))

--- a/packages/lmux-aws-bedrock/tests/test_eventstream.py
+++ b/packages/lmux-aws-bedrock/tests/test_eventstream.py
@@ -51,10 +51,24 @@ class TestEventStreamDecoder:
 
     def test_holds_partial_frame_until_complete(self) -> None:
         decoder = EventStreamDecoder()
-        # A few bytes in (>= 4, but short of a full frame) nothing decodes yet.
-        assert list(decoder.feed(_FRAMES[:6])) == []
-        messages = list(decoder.feed(_FRAMES[6:]))
+        # A full prelude but short of the frame it advertises -> nothing decodes yet.
+        assert list(decoder.feed(_FRAMES[:20])) == []
+        messages = list(decoder.feed(_FRAMES[20:]))
         assert [h[":event-type"] for h, _ in messages] == ["messageStart", "contentBlockDelta"]
+
+    def test_bad_prelude_crc_raises_before_buffering(self) -> None:
+        frame = bytearray(_encode({":event-type": "contentBlockDelta"}, b'{"x":1}'))
+        frame[8] ^= 0xFF  # corrupt the prelude CRC
+        with pytest.raises(ValueError, match="prelude checksum"):
+            list(EventStreamDecoder().feed(bytes(frame)))
+
+    def test_oversized_frame_rejected_before_buffering(self) -> None:
+        # A prelude with a valid CRC but an absurd total_length must be rejected on sight, not
+        # buffered toward 4 GiB. headers_length=0, total_length=0xFFFFFFFF.
+        prelude_data = struct.pack(">II", 0xFFFFFFFF, 0)
+        prelude = prelude_data + struct.pack(">I", zlib.crc32(prelude_data) & 0xFFFFFFFF)
+        with pytest.raises(ValueError, match="exceeds"):
+            list(EventStreamDecoder().feed(prelude))
 
 
 class TestCrcValidation:

--- a/packages/lmux-aws-bedrock/tests/test_eventstream.py
+++ b/packages/lmux-aws-bedrock/tests/test_eventstream.py
@@ -6,7 +6,7 @@ import zlib
 
 from botocore.eventstream import EventStreamBuffer
 
-from lmux_aws_bedrock._eventstream import decode_messages
+from lmux_aws_bedrock._eventstream import EventStreamDecoder, decode_messages
 
 
 def _encode(headers: dict[str, str], payload: bytes) -> bytes:
@@ -40,3 +40,17 @@ class TestDecodeMessages:
 
     def test_empty(self) -> None:
         assert list(decode_messages(b"")) == []
+
+
+class TestEventStreamDecoder:
+    def test_yields_complete_frames(self) -> None:
+        decoder = EventStreamDecoder()
+        messages = list(decoder.feed(_FRAMES))
+        assert [h[":event-type"] for h, _ in messages] == ["messageStart", "contentBlockDelta"]
+
+    def test_holds_partial_frame_until_complete(self) -> None:
+        decoder = EventStreamDecoder()
+        # A few bytes in (>= 4, but short of a full frame) nothing decodes yet.
+        assert list(decoder.feed(_FRAMES[:6])) == []
+        messages = list(decoder.feed(_FRAMES[6:]))
+        assert [h[":event-type"] for h, _ in messages] == ["messageStart", "contentBlockDelta"]

--- a/packages/lmux-aws-bedrock/tests/test_eventstream.py
+++ b/packages/lmux-aws-bedrock/tests/test_eventstream.py
@@ -1,0 +1,42 @@
+"""Parity tests for the event-stream decoder against botocore."""
+
+import json
+import struct
+import zlib
+
+from botocore.eventstream import EventStreamBuffer
+
+from lmux_aws_bedrock._eventstream import decode_messages
+
+
+def _encode(headers: dict[str, str], payload: bytes) -> bytes:
+    hb = b""
+    for name, value in headers.items():
+        nb, vb = name.encode(), value.encode()
+        hb += bytes([len(nb)]) + nb + bytes([7]) + struct.pack(">H", len(vb)) + vb
+    total = 16 + len(hb) + len(payload)
+    prelude = struct.pack(">II", total, len(hb))
+    body = prelude + struct.pack(">I", zlib.crc32(prelude) & 0xFFFFFFFF) + hb + payload
+    return body + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
+
+
+_FRAMES = _encode(
+    {":event-type": "messageStart", ":content-type": "application/json"}, b'{"role":"assistant"}'
+) + _encode({":event-type": "contentBlockDelta"}, b'{"delta":{"text":"Hi"},"contentBlockIndex":0}')
+
+
+class TestDecodeMessages:
+    def test_parity_with_botocore(self) -> None:
+        mine = [(h[":event-type"], json.loads(p)) for h, p in decode_messages(_FRAMES)]
+        buf = EventStreamBuffer()
+        buf.add_data(_FRAMES)
+        theirs = [(m.headers[":event-type"], json.loads(m.payload)) for m in buf]  # ty: ignore[not-subscriptable]
+        assert mine == theirs
+
+    def test_recovers_events(self) -> None:
+        events = list(decode_messages(_FRAMES))
+        assert events[0][0][":event-type"] == "messageStart"
+        assert json.loads(events[1][1]) == {"delta": {"text": "Hi"}, "contentBlockIndex": 0}
+
+    def test_empty(self) -> None:
+        assert list(decode_messages(b"")) == []

--- a/packages/lmux-aws-bedrock/tests/test_exceptions.py
+++ b/packages/lmux-aws-bedrock/tests/test_exceptions.py
@@ -14,7 +14,8 @@ from lmux.exceptions import (
     RateLimitError,
     TimeoutError,  # noqa: A004
 )
-from lmux_aws_bedrock._exceptions import error_from_response, map_transport_error, parse_json, raise_for_status
+from lmux_aws_bedrock._exceptions import error_from_response, map_transport_error, parse_body, raise_for_status
+from lmux_aws_bedrock._wire import WireConverseResponse
 
 
 def _response(
@@ -183,14 +184,16 @@ class TestMapTransportError:
             assert isinstance(map_transport_error(error), LmuxError)
 
 
-class TestParseJson:
+class TestParseBody:
     def test_valid_body(self) -> None:
-        assert parse_json(_response(200, json={"ok": 1})) == {"ok": 1}
+        body = {"output": {"message": {"content": [{"text": "hi"}]}}, "stopReason": "end_turn"}
+        result = parse_body(_response(200, json=body), WireConverseResponse)
+        assert result == WireConverseResponse.model_validate(body)
 
     def test_malformed_body_maps_to_provider_error(self) -> None:
         with pytest.raises(ProviderError):
-            parse_json(_response(200, content=b"not json"))
+            parse_body(_response(200, content=b"not json"), WireConverseResponse)
 
     def test_non_object_body_maps_to_provider_error(self) -> None:
         with pytest.raises(ProviderError):
-            parse_json(_response(200, json=["not", "an", "object"]))
+            parse_body(_response(200, json=["not", "an", "object"]), WireConverseResponse)

--- a/packages/lmux-aws-bedrock/tests/test_exceptions.py
+++ b/packages/lmux-aws-bedrock/tests/test_exceptions.py
@@ -1,15 +1,8 @@
-"""Tests for AWS Bedrock exception mapping."""
+"""Tests for AWS Bedrock exception mapping (HTTP responses + credential errors)."""
 
+import httpx
 import pytest
-from botocore.exceptions import (
-    BotoCoreError,
-    ClientError,
-    ConnectTimeoutError,
-    EndpointConnectionError,
-    NoCredentialsError,
-    PartialCredentialsError,
-    ReadTimeoutError,
-)
+from botocore.exceptions import NoCredentialsError, PartialCredentialsError
 
 from lmux.exceptions import (
     AuthenticationError,
@@ -20,362 +13,165 @@ from lmux.exceptions import (
     RateLimitError,
     TimeoutError,  # noqa: A004
 )
-from lmux_aws_bedrock._exceptions import map_bedrock_error
-
-# MARK: Fixtures
+from lmux_aws_bedrock._exceptions import error_from_response, map_transport_error, raise_for_status
 
 
-@pytest.fixture
-def throttling_error() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
-            "ResponseMetadata": {"HTTPStatusCode": 429},
-        },
-        operation_name="Converse",
-    )
+def _response(
+    status: int,
+    *,
+    error_type: str | None = None,
+    retry_after: str | None = None,
+    json: object = None,
+    content: bytes | None = None,
+) -> httpx.Response:
+    headers: dict[str, str] = {}
+    if error_type is not None:
+        headers["x-amzn-errortype"] = error_type
+    if retry_after is not None:
+        headers["retry-after"] = retry_after
+    if content is not None:
+        return httpx.Response(status, headers=headers, content=content)
+    return httpx.Response(status, headers=headers, json=json)
 
 
-@pytest.fixture
-def throttling_error_with_retry_after() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
-            "ResponseMetadata": {"HTTPStatusCode": 429, "HTTPHeaders": {"retry-after": "30.5"}},
-        },
-        operation_name="Converse",
-    )
+# MARK: raise_for_status
 
 
-@pytest.fixture
-def throttling_error_invalid_retry_after() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
-            "ResponseMetadata": {"HTTPStatusCode": 429, "HTTPHeaders": {"retry-after": "not-a-number"}},
-        },
-        operation_name="Converse",
-    )
+class TestRaiseForStatus:
+    def test_ok_does_not_raise(self) -> None:
+        raise_for_status(httpx.Response(200, json={"ok": True}))
+
+    def test_error_raises(self) -> None:
+        with pytest.raises(InvalidRequestError):
+            raise_for_status(_response(400, json={"message": "bad"}))
 
 
-@pytest.fixture
-def throttling_error_no_retry_header() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
-            "ResponseMetadata": {"HTTPStatusCode": 429, "HTTPHeaders": {}},
-        },
-        operation_name="Converse",
-    )
+# MARK: error_from_response
 
 
-@pytest.fixture
-def validation_error() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "ValidationException", "Message": "Invalid parameter"},
-            "ResponseMetadata": {"HTTPStatusCode": 400},
-        },
-        operation_name="Converse",
-    )
-
-
-@pytest.fixture
-def access_denied_error() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "AccessDeniedException", "Message": "Access denied"},
-            "ResponseMetadata": {"HTTPStatusCode": 403},
-        },
-        operation_name="Converse",
-    )
-
-
-@pytest.fixture
-def unrecognized_client_error() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "UnrecognizedClientException", "Message": "Unrecognized client"},
-            "ResponseMetadata": {"HTTPStatusCode": 403},
-        },
-        operation_name="Converse",
-    )
-
-
-@pytest.fixture
-def invalid_signature_error() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "InvalidSignatureException", "Message": "Invalid signature"},
-            "ResponseMetadata": {"HTTPStatusCode": 403},
-        },
-        operation_name="Converse",
-    )
-
-
-@pytest.fixture
-def expired_token_error() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "ExpiredTokenException", "Message": "Token expired"},
-            "ResponseMetadata": {"HTTPStatusCode": 403},
-        },
-        operation_name="Converse",
-    )
-
-
-@pytest.fixture
-def resource_not_found_error() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "ResourceNotFoundException", "Message": "Model not found"},
-            "ResponseMetadata": {"HTTPStatusCode": 404},
-        },
-        operation_name="Converse",
-    )
-
-
-@pytest.fixture
-def internal_server_error() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "InternalServerException", "Message": "Internal error"},
-            "ResponseMetadata": {"HTTPStatusCode": 500},
-        },
-        operation_name="Converse",
-    )
-
-
-@pytest.fixture
-def unknown_client_error() -> ClientError:
-    return ClientError(
-        error_response={  # ty: ignore[invalid-argument-type]
-            "Error": {"Code": "SomeUnknownError", "Message": "Something unexpected"},
-            "ResponseMetadata": {"HTTPStatusCode": 418},
-        },
-        operation_name="Converse",
-    )
-
-
-@pytest.fixture
-def no_credentials_error() -> NoCredentialsError:
-    return NoCredentialsError()
-
-
-@pytest.fixture
-def partial_credentials_error() -> PartialCredentialsError:
-    return PartialCredentialsError(provider="env", cred_var="AWS_SECRET_ACCESS_KEY")
-
-
-@pytest.fixture
-def read_timeout_error() -> ReadTimeoutError:
-    return ReadTimeoutError(endpoint_url="https://bedrock.us-east-1.amazonaws.com")
-
-
-@pytest.fixture
-def connect_timeout_error() -> ConnectTimeoutError:
-    return ConnectTimeoutError(endpoint_url="https://bedrock.us-east-1.amazonaws.com")
-
-
-@pytest.fixture
-def endpoint_connection_error() -> EndpointConnectionError:
-    return EndpointConnectionError(endpoint_url="https://bedrock.us-east-1.amazonaws.com")
-
-
-@pytest.fixture
-def generic_botocore_error() -> BotoCoreError:
-    return BotoCoreError()
-
-
-# MARK: Tests
-
-
-class TestMapBedrockError:
-    def test_throttling_exception(self, throttling_error: ClientError) -> None:
-        result = map_bedrock_error(throttling_error)
-        assert isinstance(result, RateLimitError)
-        assert result.provider == "aws-bedrock"
-        assert result.status_code == 429
-
-    def test_throttling_with_retry_after(self, throttling_error_with_retry_after: ClientError) -> None:
-        result = map_bedrock_error(throttling_error_with_retry_after)
-        assert isinstance(result, RateLimitError)
-        assert result.provider == "aws-bedrock"
-        assert result.status_code == 429
-        assert result.retry_after == 30.5
-
-    def test_throttling_invalid_retry_after(self, throttling_error_invalid_retry_after: ClientError) -> None:
-        result = map_bedrock_error(throttling_error_invalid_retry_after)
-        assert isinstance(result, RateLimitError)
-        assert result.provider == "aws-bedrock"
-        assert result.retry_after is None
-
-    def test_throttling_no_retry_header(self, throttling_error_no_retry_header: ClientError) -> None:
-        result = map_bedrock_error(throttling_error_no_retry_header)
-        assert isinstance(result, RateLimitError)
-        assert result.provider == "aws-bedrock"
-        assert result.retry_after is None
-
-    def test_validation_exception(self, validation_error: ClientError) -> None:
-        result = map_bedrock_error(validation_error)
-        assert isinstance(result, InvalidRequestError)
-        assert result.provider == "aws-bedrock"
+class TestErrorFromResponse:
+    def test_auth_by_error_type(self) -> None:
+        result = error_from_response(_response(400, error_type="AccessDeniedException", json={"message": "denied"}))
+        assert isinstance(result, AuthenticationError)
         assert result.status_code == 400
 
-    def test_access_denied(self, access_denied_error: ClientError) -> None:
-        result = map_bedrock_error(access_denied_error)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "aws-bedrock"
-        assert result.status_code == 403
+    def test_auth_by_status_401(self) -> None:
+        assert isinstance(error_from_response(_response(401, json={"message": "no"})), AuthenticationError)
 
-    def test_unrecognized_client(self, unrecognized_client_error: ClientError) -> None:
-        result = map_bedrock_error(unrecognized_client_error)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "aws-bedrock"
-        assert result.status_code == 403
+    def test_auth_by_status_403(self) -> None:
+        assert isinstance(error_from_response(_response(403, json={"message": "no"})), AuthenticationError)
 
-    def test_invalid_signature(self, invalid_signature_error: ClientError) -> None:
-        result = map_bedrock_error(invalid_signature_error)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "aws-bedrock"
-        assert result.status_code == 403
+    def test_throttling_by_error_type_with_retry_after(self) -> None:
+        result = error_from_response(
+            _response(400, error_type="ThrottlingException", retry_after="30.5", json={"message": "slow"})
+        )
+        assert isinstance(result, RateLimitError)
+        assert result.retry_after == 30.5
 
-    def test_expired_token(self, expired_token_error: ClientError) -> None:
-        result = map_bedrock_error(expired_token_error)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "aws-bedrock"
-        assert result.status_code == 403
+    def test_rate_limit_by_status(self) -> None:
+        result = error_from_response(_response(429, json={"message": "slow"}))
+        assert isinstance(result, RateLimitError)
+        assert result.retry_after is None
 
-    def test_resource_not_found(self, resource_not_found_error: ClientError) -> None:
-        result = map_bedrock_error(resource_not_found_error)
+    def test_validation_by_error_type(self) -> None:
+        result = error_from_response(_response(500, error_type="ValidationException", json={"message": "bad"}))
+        assert isinstance(result, InvalidRequestError)
+
+    def test_invalid_request_by_status(self) -> None:
+        assert isinstance(error_from_response(_response(400, json={"message": "bad"})), InvalidRequestError)
+
+    def test_not_found_by_error_type(self) -> None:
+        result = error_from_response(_response(500, error_type="ResourceNotFoundException", json={"message": "gone"}))
         assert isinstance(result, NotFoundError)
-        assert result.provider == "aws-bedrock"
-        assert result.status_code == 404
 
-    def test_internal_server_error(self, internal_server_error: ClientError) -> None:
-        result = map_bedrock_error(internal_server_error)
+    def test_not_found_by_status(self) -> None:
+        assert isinstance(error_from_response(_response(404, json={"message": "gone"})), NotFoundError)
+
+    def test_fallback_provider_error(self) -> None:
+        result = error_from_response(_response(503, json={"message": "boom"}))
         assert isinstance(result, ProviderError)
-        assert result.provider == "aws-bedrock"
-        assert result.status_code == 500
+        assert result.status_code == 503
 
-    def test_unknown_client_error(self, unknown_client_error: ClientError) -> None:
-        result = map_bedrock_error(unknown_client_error)
-        assert isinstance(result, ProviderError)
-        assert result.provider == "aws-bedrock"
-        assert result.status_code == 418
 
-    def test_no_credentials_error(self, no_credentials_error: NoCredentialsError) -> None:
-        result = map_bedrock_error(no_credentials_error)
+# MARK: Error-type header parsing
+
+
+class TestErrorTypeParsing:
+    def test_type_with_colon_suffix(self) -> None:
+        result = error_from_response(_response(400, error_type="AccessDeniedException:http://internal", json={}))
         assert isinstance(result, AuthenticationError)
-        assert result.provider == "aws-bedrock"
 
-    def test_partial_credentials_error(self, partial_credentials_error: PartialCredentialsError) -> None:
-        result = map_bedrock_error(partial_credentials_error)
-        assert isinstance(result, AuthenticationError)
-        assert result.provider == "aws-bedrock"
+    def test_type_with_hash_prefix(self) -> None:
+        result = error_from_response(_response(500, error_type="coral#ValidationException", json={}))
+        assert isinstance(result, InvalidRequestError)
 
-    def test_read_timeout_error(self, read_timeout_error: ReadTimeoutError) -> None:
-        result = map_bedrock_error(read_timeout_error)
+
+# MARK: Message extraction
+
+
+class TestMessage:
+    def test_lowercase_message_key(self) -> None:
+        result = error_from_response(_response(400, json={"message": "lower"}))
+        assert "lower" in str(result)
+
+    def test_uppercase_message_key(self) -> None:
+        result = error_from_response(_response(400, json={"Message": "upper"}))
+        assert "upper" in str(result)
+
+    def test_json_without_message_falls_back_to_text(self) -> None:
+        result = error_from_response(_response(400, json={"foo": "bar"}))
+        assert isinstance(result, InvalidRequestError)
+
+    def test_non_json_body_uses_text(self) -> None:
+        result = error_from_response(_response(400, content=b"plain text error"))
+        assert "plain text error" in str(result)
+
+    def test_non_dict_json_body_falls_back_to_text(self) -> None:
+        result = error_from_response(_response(400, json=["not", "a", "dict"]))
+        assert isinstance(result, InvalidRequestError)
+        assert "not" in str(result)
+
+
+# MARK: retry-after parsing
+
+
+class TestRetryAfter:
+    def test_invalid_retry_after_is_none(self) -> None:
+        result = error_from_response(_response(429, retry_after="not-a-number", json={"message": "slow"}))
+        assert isinstance(result, RateLimitError)
+        assert result.retry_after is None
+
+
+# MARK: map_transport_error
+
+
+class TestMapTransportError:
+    def test_timeout(self) -> None:
+        result = map_transport_error(httpx.ConnectTimeout("slow"))
         assert isinstance(result, TimeoutError)
         assert result.provider == "aws-bedrock"
 
-    def test_connect_timeout_error(self, connect_timeout_error: ConnectTimeoutError) -> None:
-        result = map_bedrock_error(connect_timeout_error)
-        assert isinstance(result, TimeoutError)
-        assert result.provider == "aws-bedrock"
+    def test_no_credentials(self) -> None:
+        result = map_transport_error(NoCredentialsError())
+        assert isinstance(result, AuthenticationError)
 
-    def test_endpoint_connection_error(self, endpoint_connection_error: EndpointConnectionError) -> None:
-        result = map_bedrock_error(endpoint_connection_error)
+    def test_partial_credentials(self) -> None:
+        result = map_transport_error(PartialCredentialsError(provider="env", cred_var="AWS_SECRET_ACCESS_KEY"))
+        assert isinstance(result, AuthenticationError)
+
+    def test_generic_error(self) -> None:
+        result = map_transport_error(RuntimeError("boom"))
         assert isinstance(result, ProviderError)
         assert result.provider == "aws-bedrock"
 
-    def test_generic_botocore_error(self, generic_botocore_error: BotoCoreError) -> None:
-        result = map_bedrock_error(generic_botocore_error)
+    def test_connect_error(self) -> None:
+        result = map_transport_error(httpx.ConnectError("refused"))
         assert isinstance(result, ProviderError)
-        assert result.provider == "aws-bedrock"
 
-    def test_generic_exception(self) -> None:
-        error = RuntimeError("something broke")
-        result = map_bedrock_error(error)
-        assert isinstance(result, ProviderError)
-        assert result.provider == "aws-bedrock"
-
-    @pytest.mark.parametrize(
-        "error",
-        [
-            pytest.param(
-                ClientError(
-                    error_response={  # ty: ignore[invalid-argument-type]
-                        "Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"},
-                        "ResponseMetadata": {"HTTPStatusCode": 429},
-                    },
-                    operation_name="Converse",
-                ),
-                id="throttling",
-            ),
-            pytest.param(
-                ClientError(
-                    error_response={  # ty: ignore[invalid-argument-type]
-                        "Error": {"Code": "ValidationException", "Message": "Invalid"},
-                        "ResponseMetadata": {"HTTPStatusCode": 400},
-                    },
-                    operation_name="Converse",
-                ),
-                id="validation",
-            ),
-            pytest.param(
-                ClientError(
-                    error_response={  # ty: ignore[invalid-argument-type]
-                        "Error": {"Code": "AccessDeniedException", "Message": "Denied"},
-                        "ResponseMetadata": {"HTTPStatusCode": 403},
-                    },
-                    operation_name="Converse",
-                ),
-                id="access_denied",
-            ),
-            pytest.param(
-                ClientError(
-                    error_response={  # ty: ignore[invalid-argument-type]
-                        "Error": {"Code": "ResourceNotFoundException", "Message": "Not found"},
-                        "ResponseMetadata": {"HTTPStatusCode": 404},
-                    },
-                    operation_name="Converse",
-                ),
-                id="resource_not_found",
-            ),
-            pytest.param(
-                ClientError(
-                    error_response={  # ty: ignore[invalid-argument-type]
-                        "Error": {"Code": "InternalServerException", "Message": "Internal"},
-                        "ResponseMetadata": {"HTTPStatusCode": 500},
-                    },
-                    operation_name="Converse",
-                ),
-                id="internal_server",
-            ),
-            pytest.param(
-                ClientError(
-                    error_response={  # ty: ignore[invalid-argument-type]
-                        "Error": {"Code": "UnknownCode", "Message": "Unknown"},
-                        "ResponseMetadata": {"HTTPStatusCode": 500},
-                    },
-                    operation_name="Converse",
-                ),
-                id="unknown_client",
-            ),
-            pytest.param(NoCredentialsError(), id="no_credentials"),
-            pytest.param(
-                PartialCredentialsError(provider="env", cred_var="AWS_SECRET_ACCESS_KEY"),
-                id="partial_credentials",
-            ),
-            pytest.param(ReadTimeoutError(endpoint_url="https://test.com"), id="read_timeout"),
-            pytest.param(ConnectTimeoutError(endpoint_url="https://test.com"), id="connect_timeout"),
-            pytest.param(EndpointConnectionError(endpoint_url="https://test.com"), id="endpoint_connection"),
-            pytest.param(BotoCoreError(), id="botocore"),
-            pytest.param(RuntimeError("fallback"), id="runtime"),
-        ],
-    )
-    def test_all_errors_are_lmux_errors(self, error: Exception) -> None:
-        result = map_bedrock_error(error)
-        assert isinstance(result, LmuxError)
-        assert result.provider == "aws-bedrock"
+    def test_all_map_to_lmux_error(self) -> None:
+        for error in (
+            httpx.ConnectTimeout("slow"),
+            NoCredentialsError(),
+            RuntimeError("boom"),
+        ):
+            assert isinstance(map_transport_error(error), LmuxError)

--- a/packages/lmux-aws-bedrock/tests/test_exceptions.py
+++ b/packages/lmux-aws-bedrock/tests/test_exceptions.py
@@ -9,6 +9,7 @@ from lmux.exceptions import (
     InvalidRequestError,
     LmuxError,
     NotFoundError,
+    PermissionDeniedError,
     ProviderError,
     RateLimitError,
     TimeoutError,  # noqa: A004
@@ -51,15 +52,20 @@ class TestRaiseForStatus:
 
 class TestErrorFromResponse:
     def test_auth_by_error_type(self) -> None:
-        result = error_from_response(_response(400, error_type="AccessDeniedException", json={"message": "denied"}))
+        result = error_from_response(_response(400, error_type="ExpiredTokenException", json={"message": "expired"}))
         assert isinstance(result, AuthenticationError)
         assert result.status_code == 400
 
     def test_auth_by_status_401(self) -> None:
         assert isinstance(error_from_response(_response(401, json={"message": "no"})), AuthenticationError)
 
-    def test_auth_by_status_403(self) -> None:
-        assert isinstance(error_from_response(_response(403, json={"message": "no"})), AuthenticationError)
+    def test_permission_by_error_type(self) -> None:
+        result = error_from_response(_response(400, error_type="AccessDeniedException", json={"message": "denied"}))
+        assert isinstance(result, PermissionDeniedError)
+        assert result.status_code == 400
+
+    def test_permission_by_status_403(self) -> None:
+        assert isinstance(error_from_response(_response(403, json={"message": "no"})), PermissionDeniedError)
 
     def test_throttling_by_error_type_with_retry_after(self) -> None:
         result = error_from_response(
@@ -99,7 +105,7 @@ class TestErrorFromResponse:
 class TestErrorTypeParsing:
     def test_type_with_colon_suffix(self) -> None:
         result = error_from_response(_response(400, error_type="AccessDeniedException:http://internal", json={}))
-        assert isinstance(result, AuthenticationError)
+        assert isinstance(result, PermissionDeniedError)
 
     def test_type_with_hash_prefix(self) -> None:
         result = error_from_response(_response(500, error_type="coral#ValidationException", json={}))

--- a/packages/lmux-aws-bedrock/tests/test_exceptions.py
+++ b/packages/lmux-aws-bedrock/tests/test_exceptions.py
@@ -13,7 +13,7 @@ from lmux.exceptions import (
     RateLimitError,
     TimeoutError,  # noqa: A004
 )
-from lmux_aws_bedrock._exceptions import error_from_response, map_transport_error, raise_for_status
+from lmux_aws_bedrock._exceptions import error_from_response, map_transport_error, parse_json, raise_for_status
 
 
 def _response(
@@ -175,3 +175,16 @@ class TestMapTransportError:
             RuntimeError("boom"),
         ):
             assert isinstance(map_transport_error(error), LmuxError)
+
+
+class TestParseJson:
+    def test_valid_body(self) -> None:
+        assert parse_json(_response(200, json={"ok": 1})) == {"ok": 1}
+
+    def test_malformed_body_maps_to_provider_error(self) -> None:
+        with pytest.raises(ProviderError):
+            parse_json(_response(200, content=b"not json"))
+
+    def test_non_object_body_maps_to_provider_error(self) -> None:
+        with pytest.raises(ProviderError):
+            parse_json(_response(200, json=["not", "an", "object"]))

--- a/packages/lmux-aws-bedrock/tests/test_exceptions.py
+++ b/packages/lmux-aws-bedrock/tests/test_exceptions.py
@@ -14,7 +14,13 @@ from lmux.exceptions import (
     RateLimitError,
     TimeoutError,  # noqa: A004
 )
-from lmux_aws_bedrock._exceptions import error_from_response, map_transport_error, parse_body, raise_for_status
+from lmux_aws_bedrock._exceptions import (
+    error_from_response,
+    error_from_stream_exception,
+    map_transport_error,
+    parse_body,
+    raise_for_status,
+)
 from lmux_aws_bedrock._wire import WireConverseResponse
 
 
@@ -98,6 +104,25 @@ class TestErrorFromResponse:
         result = error_from_response(_response(503, json={"message": "boom"}))
         assert isinstance(result, ProviderError)
         assert result.status_code == 503
+
+
+# MARK: error_from_stream_exception
+
+
+class TestErrorFromStreamException:
+    def test_throttling_maps_to_rate_limit(self) -> None:
+        # Stream frames carry camelCase exception types with no HTTP status.
+        result = error_from_stream_exception("throttlingException", "slow down")
+        assert isinstance(result, RateLimitError)
+        assert result.status_code is None
+        assert "slow down" in str(result)
+
+    def test_validation_maps_to_invalid_request(self) -> None:
+        assert isinstance(error_from_stream_exception("validationException", "bad"), InvalidRequestError)
+
+    def test_unknown_type_falls_back_to_provider_error(self) -> None:
+        result = error_from_stream_exception("modelStreamErrorException", "boom")
+        assert isinstance(result, ProviderError)
 
 
 # MARK: Error-type header parsing

--- a/packages/lmux-aws-bedrock/tests/test_mappers.py
+++ b/packages/lmux-aws-bedrock/tests/test_mappers.py
@@ -46,6 +46,11 @@ from lmux_aws_bedrock._mappers import (
     map_tools,
     model_uses_adaptive_thinking,
 )
+from lmux_aws_bedrock._wire import (
+    WireConverseResponse,
+    WireEmbeddingResponse,
+    WireStreamEvent,
+)
 
 # MARK: Fixtures
 
@@ -425,7 +430,9 @@ class TestMapConverseResponse:
             "stopReason": "end_turn",
             "usage": {"inputTokens": 10, "outputTokens": 5},
         }
-        result = map_converse_response(response, "anthropic.claude-3", "aws-bedrock", noop_cost_fn)
+        result = map_converse_response(
+            WireConverseResponse.model_validate(response), "anthropic.claude-3", "aws-bedrock", noop_cost_fn
+        )
         assert result == ChatResponse(
             content="Hello!",
             tool_calls=None,
@@ -454,7 +461,9 @@ class TestMapConverseResponse:
             "stopReason": "tool_use",
             "usage": {"inputTokens": 15, "outputTokens": 8},
         }
-        result = map_converse_response(response, "anthropic.claude-3", "aws-bedrock", noop_cost_fn)
+        result = map_converse_response(
+            WireConverseResponse.model_validate(response), "anthropic.claude-3", "aws-bedrock", noop_cost_fn
+        )
         assert result == ChatResponse(
             content=None,
             tool_calls=[
@@ -475,7 +484,9 @@ class TestMapConverseResponse:
             "output": {"message": {"content": [{"text": "Hi"}]}},
             "stopReason": "end_turn",
         }
-        result = map_converse_response(response, "anthropic.claude-3", "aws-bedrock", noop_cost_fn)
+        result = map_converse_response(
+            WireConverseResponse.model_validate(response), "anthropic.claude-3", "aws-bedrock", noop_cost_fn
+        )
         assert result.usage is None
         assert result.cost is None
 
@@ -490,7 +501,9 @@ class TestMapConverseResponse:
                 "cacheWriteInputTokens": 20,
             },
         }
-        result = map_converse_response(response, "anthropic.claude-3", "aws-bedrock", noop_cost_fn)
+        result = map_converse_response(
+            WireConverseResponse.model_validate(response), "anthropic.claude-3", "aws-bedrock", noop_cost_fn
+        )
         assert result.usage is not None
         # inputTokens is normalized to the inclusive total (10 + 50 + 20)
         assert result.usage.input_tokens == 80
@@ -514,7 +527,9 @@ class TestMapConverseResponse:
                 ],
             },
         }
-        result = map_converse_response(response, "anthropic.claude-3", "aws-bedrock", lambda _m, _u: None)
+        result = map_converse_response(
+            WireConverseResponse.model_validate(response), "anthropic.claude-3", "aws-bedrock", lambda _m, _u: None
+        )
         assert result.usage is not None
         assert result.usage.input_tokens == 2010
         assert result.usage.cache_creation_tokens_by_ttl == {"5m": 500, "1h": 1500}
@@ -525,7 +540,9 @@ class TestMapConverseResponse:
             "stopReason": "end_turn",
             "usage": {"inputTokens": 10, "outputTokens": 5},
         }
-        result = map_converse_response(response, "m", "aws-bedrock", lambda _m, _u: None)
+        result = map_converse_response(
+            WireConverseResponse.model_validate(response), "m", "aws-bedrock", lambda _m, _u: None
+        )
         assert result.usage is not None
         assert result.usage.cache_creation_tokens_by_ttl is None
         assert result.usage.input_tokens == 10
@@ -536,7 +553,7 @@ class TestMapConverseResponse:
             "stopReason": "end_turn",
             "usage": {"inputTokens": 1, "outputTokens": 0},
         }
-        result = map_converse_response(response, "m", "aws-bedrock", noop_cost_fn)
+        result = map_converse_response(WireConverseResponse.model_validate(response), "m", "aws-bedrock", noop_cost_fn)
         assert result.content is None
         assert result.tool_calls is None
 
@@ -546,7 +563,7 @@ class TestMapConverseResponse:
             "stopReason": "end_turn",
             "usage": {"inputTokens": 1, "outputTokens": 0},
         }
-        result = map_converse_response(response, "m", "aws-bedrock", noop_cost_fn)
+        result = map_converse_response(WireConverseResponse.model_validate(response), "m", "aws-bedrock", noop_cost_fn)
         assert result.content is None
         assert result.tool_calls is None
 
@@ -563,7 +580,9 @@ class TestMapConverseResponse:
             "stopReason": "end_turn",
             "usage": {"inputTokens": 10, "outputTokens": 5},
         }
-        result = map_converse_response(response, "anthropic.claude-3", "aws-bedrock", noop_cost_fn)
+        result = map_converse_response(
+            WireConverseResponse.model_validate(response), "anthropic.claude-3", "aws-bedrock", noop_cost_fn
+        )
         assert result.content == "Answer"
         assert result.reasoning == "Let me think..."
 
@@ -580,7 +599,9 @@ class TestMapConverseResponse:
             "stopReason": "end_turn",
             "usage": {"inputTokens": 10, "outputTokens": 5},
         }
-        result = map_converse_response(response, "anthropic.claude-3", "aws-bedrock", noop_cost_fn)
+        result = map_converse_response(
+            WireConverseResponse.model_validate(response), "anthropic.claude-3", "aws-bedrock", noop_cost_fn
+        )
         assert result.content == "Answer"
         assert result.reasoning is None
 
@@ -590,7 +611,9 @@ class TestMapConverseResponse:
             "stopReason": "end_turn",
             "usage": {"inputTokens": 10, "outputTokens": 5},
         }
-        result = map_converse_response(response, "unknown-model", "aws-bedrock", none_cost_fn)
+        result = map_converse_response(
+            WireConverseResponse.model_validate(response), "unknown-model", "aws-bedrock", none_cost_fn
+        )
         assert result.cost is None
 
 
@@ -598,14 +621,14 @@ class TestMapConverseResponse:
 
 
 class TestMapStopReason:
-    def _make_response(self, stop_reason: str | None) -> Any:  # noqa: ANN401
+    def _make_response(self, stop_reason: str | None) -> WireConverseResponse:
         response: Any = {
             "output": {"message": {"content": [{"text": "x"}]}},
             "usage": {"inputTokens": 1, "outputTokens": 1},
         }
         if stop_reason is not None:
             response["stopReason"] = stop_reason
-        return response
+        return WireConverseResponse.model_validate(response)
 
     def test_end_turn(self, noop_cost_fn: Any) -> None:  # noqa: ANN401
         result = map_converse_response(self._make_response("end_turn"), "m", "p", noop_cost_fn)
@@ -639,7 +662,7 @@ class TestMapStreamEvent:
                 "delta": {"text": "Hello"},
             }
         }
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result == ChatChunk(delta="Hello")
 
     def test_content_block_delta_tool_use(self) -> None:
@@ -649,7 +672,7 @@ class TestMapStreamEvent:
                 "delta": {"toolUse": {"input": '{"city":'}},
             }
         }
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result == ChatChunk(
             tool_call_deltas=[
                 ToolCallDelta(
@@ -671,7 +694,7 @@ class TestMapStreamEvent:
                 },
             }
         }
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result == ChatChunk(
             tool_call_deltas=[
                 ToolCallDelta(
@@ -685,7 +708,7 @@ class TestMapStreamEvent:
 
     def test_message_stop(self) -> None:
         event: Any = {"messageStop": {"stopReason": "end_turn"}}
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result == ChatChunk(finish_reason="stop")
 
     def test_metadata_with_usage(self) -> None:
@@ -694,17 +717,17 @@ class TestMapStreamEvent:
                 "usage": {"inputTokens": 10, "outputTokens": 5},
             }
         }
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result == ChatChunk(usage=Usage(input_tokens=10, output_tokens=5))
 
     def test_metadata_without_usage(self) -> None:
         event: Any = {"metadata": {"requestId": "abc"}}
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result is None
 
     def test_unknown_event_returns_none(self) -> None:
         event: Any = {"messageStart": {"role": "assistant"}}
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result is None
 
     def test_content_block_start_text_returns_none(self) -> None:
@@ -714,7 +737,7 @@ class TestMapStreamEvent:
                 "start": {"text": ""},
             }
         }
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result is None
 
     def test_content_block_delta_reasoning(self) -> None:
@@ -724,7 +747,7 @@ class TestMapStreamEvent:
                 "delta": {"reasoningContent": {"text": "thinking..."}},
             }
         }
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result is not None
         assert result.reasoning_delta == "thinking..."
 
@@ -735,7 +758,7 @@ class TestMapStreamEvent:
                 "delta": {"reasoningContent": {}},
             }
         }
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result is None
 
     def test_content_block_delta_unknown_returns_none(self) -> None:
@@ -745,7 +768,7 @@ class TestMapStreamEvent:
                 "delta": {"unknownType": "data"},
             }
         }
-        result = map_stream_event(event)
+        result = map_stream_event(WireStreamEvent.model_validate(event))
         assert result is None
 
 
@@ -758,7 +781,12 @@ class TestMapEmbeddingResponse:
             "embedding": [0.1, 0.2, 0.3],
             "inputTextTokenCount": 5,
         }
-        result = map_embedding_response(response_body, "amazon.titan-embed-text-v1", "aws-bedrock", noop_cost_fn)
+        result = map_embedding_response(
+            WireEmbeddingResponse.model_validate(response_body),
+            "amazon.titan-embed-text-v1",
+            "aws-bedrock",
+            noop_cost_fn,
+        )
         assert result == EmbeddingResponse(
             embeddings=[[0.1, 0.2, 0.3]],
             usage=Usage(input_tokens=5, output_tokens=0),
@@ -772,7 +800,9 @@ class TestMapEmbeddingResponse:
             "embedding": [0.5],
             "inputTextTokenCount": 3,
         }
-        result = map_embedding_response(response_body, "unknown-model", "aws-bedrock", none_cost_fn)
+        result = map_embedding_response(
+            WireEmbeddingResponse.model_validate(response_body), "unknown-model", "aws-bedrock", none_cost_fn
+        )
         assert result.cost is None
         assert result.usage == Usage(input_tokens=3, output_tokens=0)
 

--- a/packages/lmux-aws-bedrock/tests/test_mappers.py
+++ b/packages/lmux-aws-bedrock/tests/test_mappers.py
@@ -101,7 +101,8 @@ class TestMapMessages:
         assert len(messages) == 1
         content = messages[0]["content"]
         assert content[0] == {"text": "What is this?"}
-        assert content[1] == {"image": {"format": "png", "source": {"bytes": raw_bytes}}}
+        # The blob is the base64 string (JSON-serializable), not raw bytes.
+        assert content[1] == {"image": {"format": "png", "source": {"bytes": b64_data}}}
 
     def test_user_message_multimodal_url_raises(self) -> None:
         parts: list[ContentPart] = [ImageContent(url="https://example.com/image.png")]

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -824,6 +824,17 @@ class TestClientManagement:
         provider.chat(MODEL, [UserMessage(content="Hi")])
         assert route.called
 
+    def test_use_fips_selects_fips_host(
+        self, fake_auth: FakeAuth, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        base = "https://bedrock-runtime-fips.us-east-1.amazonaws.com"
+        route = respx_mock.post(_url(MODEL, "converse", base=base)).mock(
+            return_value=httpx.Response(200, json=converse_response)
+        )
+        provider = BedrockProvider(auth=fake_auth, use_fips=True)
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
+
     def test_timeout_and_retries_forwarded(self, fake_auth: FakeAuth, mock_create_sync: MagicMock) -> None:
         provider = BedrockProvider(auth=fake_auth, timeout=30.0, max_retries=5)
         provider._get_sync_client()

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -23,6 +23,7 @@ from lmux.exceptions import (
     AuthenticationError,
     InvalidRequestError,
     ProviderError,
+    RateLimitError,
     TimeoutError,  # noqa: A004
     UnsupportedFeatureError,
 )
@@ -170,6 +171,16 @@ def async_create_two_clients(mocker: MockerFixture) -> tuple[MagicMock, MagicMoc
     c1, c2 = MagicMock(), MagicMock()
     create = mocker.patch("lmux_aws_bedrock.provider.create_async_client", side_effect=[c1, c2])
     return create, c1, c2
+
+
+@pytest.fixture
+def mock_create_sync(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_aws_bedrock.provider.create_sync_client", return_value=MagicMock())
+
+
+@pytest.fixture
+def mock_create_async(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_aws_bedrock.provider.create_async_client", return_value=MagicMock())
 
 
 @pytest.fixture
@@ -564,16 +575,16 @@ class TestChatStream:
         with pytest.raises(ProviderError, match="slow down"):
             list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
-    def test_exception_frame_without_event_type(
+    def test_exception_frame_maps_to_typed_error(
         self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter
     ) -> None:
-        # A real exception frame carries :exception-type and no :event-type; indexing :event-type
-        # first would KeyError before the error could be surfaced.
+        # A real exception frame carries a camelCase :exception-type and no :event-type; it must both
+        # avoid a KeyError on :event-type and classify to the typed error (RateLimitError here).
         content = _encode(
-            {":message-type": "exception", ":exception-type": "ThrottlingException"}, b'{"message": "slow down"}'
+            {":message-type": "exception", ":exception-type": "throttlingException"}, b'{"message": "slow down"}'
         )
         respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=content))
-        with pytest.raises(ProviderError, match="slow down"):
+        with pytest.raises(RateLimitError, match="slow down"):
             list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
     def test_client_init_failure(self, fake_auth: FakeAuth, sync_create_raises: MagicMock) -> None:
@@ -805,6 +816,20 @@ class TestClientManagement:
         provider.chat(MODEL, [UserMessage(content="Hi")])
         assert route.called
 
+    def test_timeout_and_retries_forwarded(self, fake_auth: FakeAuth, mock_create_sync: MagicMock) -> None:
+        provider = BedrockProvider(auth=fake_auth, timeout=30.0, max_retries=5)
+        provider._get_sync_client()
+        mock_create_sync.assert_called_once_with(
+            base_url="https://bedrock-runtime.us-east-1.amazonaws.com", timeout=30.0, max_retries=5
+        )
+
+    async def test_async_timeout_and_retries_forwarded(self, fake_auth: FakeAuth, mock_create_async: MagicMock) -> None:
+        provider = BedrockProvider(auth=fake_auth, timeout=30.0, max_retries=5)
+        await provider._get_async_client()
+        mock_create_async.assert_called_once_with(
+            base_url="https://bedrock-runtime.us-east-1.amazonaws.com", timeout=30.0, max_retries=5
+        )
+
     def test_no_credentials_raises_auth_error(
         self, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
@@ -886,10 +911,25 @@ class TestBearerAuth:
     ) -> None:
         monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bt-secret")
         route = _ok_converse(converse_response, respx_mock)
-        provider = BedrockProvider()  # no auth provider needed in bearer mode
+        # A session with no region falls back to us-east-1 (the default _url region).
+        provider = BedrockProvider(auth=FakeAuth())
         result = provider.chat(MODEL, [UserMessage(content="Hi")])
         assert result.content == "Hello!"
         assert route.calls.last.request.headers["authorization"] == "Bearer bt-secret"
+
+    def test_bearer_token_honors_session_region(
+        self, converse_response: dict[str, Any], respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bt-secret")
+        base = "https://bedrock-runtime.eu-west-1.amazonaws.com"
+        route = respx_mock.post(_url(MODEL, "converse", base=base)).mock(
+            return_value=httpx.Response(200, json=converse_response)
+        )
+        # No constructor region, but the session is configured for eu-west-1 — bearer mode must use it
+        # instead of silently defaulting to us-east-1.
+        provider = BedrockProvider(auth=FakeAuth(_Session(region_name="eu-west-1")))
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
 
     def test_bearer_token_respects_region(
         self, converse_response: dict[str, Any], respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -1,15 +1,30 @@
-"""Tests for AWS Bedrock provider."""
+"""Tests for the AWS Bedrock provider (SDK-lite, respx)."""
 
+import asyncio
 import json
+import struct
+import zlib
 from datetime import date
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock
 
+import httpx
 import pytest
+import respx
 from pytest_mock import MockerFixture
 
+if TYPE_CHECKING:
+    import boto3
+    from aiobotocore.session import AioSession
+
 from lmux.cost import ModelPricing, PricingTier
-from lmux.exceptions import ProviderError, UnsupportedFeatureError
+from lmux.exceptions import (
+    AuthenticationError,
+    InvalidRequestError,
+    ProviderError,
+    TimeoutError,  # noqa: A004
+    UnsupportedFeatureError,
+)
 from lmux.types import (
     ChatChunk,
     ChatResponse,
@@ -27,29 +42,116 @@ from lmux_aws_bedrock import preload
 from lmux_aws_bedrock.params import BedrockParams, GuardrailConfig
 from lmux_aws_bedrock.provider import BedrockProvider
 
-# MARK: Shared Fixtures
+_BASE = "https://bedrock-runtime.us-east-1.amazonaws.com"
+MODEL = "anthropic.claude-sonnet-4"
+EMBED_MODEL = "amazon.titan-embed-text-v2"
+
+
+def _url(model: str, action: str, *, base: str = _BASE) -> str:
+    return f"{base}/model/{model}/{action}"
+
+
+# MARK: Fake Auth (SigV4 credential resolution)
+
+
+class _FrozenCreds:
+    access_key = "AKIAFAKEEXAMPLE"
+    secret_key = "fake-secret-key"  # noqa: S105
+    token = None
+
+
+class _Credentials:
+    def get_frozen_credentials(self) -> _FrozenCreds:
+        return _FrozenCreds()
+
+
+_DEFAULT_CREDENTIALS = _Credentials()
+
+
+class _Session:
+    def __init__(
+        self, *, region_name: str | None = None, credentials: _Credentials | None = _DEFAULT_CREDENTIALS
+    ) -> None:
+        self.region_name = region_name
+        self._credentials = credentials
+
+    def get_credentials(self) -> _Credentials | None:
+        return self._credentials
 
 
 class FakeAuth:
-    """Fake auth provider for testing."""
+    """Fake auth provider returning a boto3-Session-like object for SigV4 signing.
 
-    def __init__(self, async_session: MagicMock | None = None) -> None:
-        self.async_session: MagicMock = async_session or MagicMock()
-        self.get_credentials_calls: int = 0
-        self.aget_credentials_calls: int = 0
+    Credentials are resolved synchronously, so only ``get_credentials`` is exercised;
+    ``aget_credentials`` exists to satisfy the ``AuthProvider`` protocol.
+    """
 
-    def get_credentials(self) -> MagicMock:
-        self.get_credentials_calls += 1
-        return MagicMock()
+    def __init__(self, session: _Session | None = None) -> None:
+        self._session = session if session is not None else _Session()
+        self.get_calls = 0
 
-    async def aget_credentials(self) -> MagicMock:
-        self.aget_credentials_calls += 1
-        return self.async_session
+    def get_credentials(self) -> "boto3.Session":
+        self.get_calls += 1
+        return cast("boto3.Session", self._session)
+
+    async def aget_credentials(self) -> "AioSession":  # pragma: no cover - protocol conformance only
+        return cast("AioSession", self._session)
+
+
+# MARK: Event-stream framing (mirrors tests/test_eventstream.py)
+
+
+def _encode(headers: dict[str, str], payload: bytes) -> bytes:
+    hb = b""
+    for name, value in headers.items():
+        nb, vb = name.encode(), value.encode()
+        hb += bytes([len(nb)]) + nb + bytes([7]) + struct.pack(">H", len(vb)) + vb
+    total = 16 + len(hb) + len(payload)
+    prelude = struct.pack(">II", total, len(hb))
+    body = prelude + struct.pack(">I", zlib.crc32(prelude) & 0xFFFFFFFF) + hb + payload
+    return body + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
+
+
+def _frame(event_type: str, payload: dict[str, Any] | None, *, message_type: str = "event") -> bytes:
+    data = json.dumps(payload).encode() if payload is not None else b""
+    return _encode({":event-type": event_type, ":message-type": message_type}, data)
+
+
+def _stream_bytes(events: list[tuple[str, dict[str, Any] | None]]) -> bytes:
+    return b"".join(_frame(event_type, payload) for event_type, payload in events)
+
+
+_STREAM_EVENTS: list[tuple[str, dict[str, Any] | None]] = [
+    ("messageStart", {"role": "assistant"}),
+    ("contentBlockDelta", {"delta": {"text": "Hello"}, "contentBlockIndex": 0}),
+    ("contentBlockStop", None),  # empty payload -> skipped, exercises the empty-payload branch
+    ("messageStop", {"stopReason": "end_turn"}),
+    ("metadata", {"usage": {"inputTokens": 10, "outputTokens": 5}, "metrics": {"latencyMs": 100}}),
+]
+
+
+# MARK: Shared Fixtures
+
+
+@pytest.fixture(autouse=True)
+def _no_bearer_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every test to the SigV4 path; bearer-token tests opt back in."""
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
 
 
 @pytest.fixture
 def fake_auth() -> FakeAuth:
     return FakeAuth()
+
+
+@pytest.fixture
+def sync_provider(fake_auth: FakeAuth) -> BedrockProvider:
+    return BedrockProvider(auth=fake_auth)
+
+
+@pytest.fixture
+def async_provider(fake_auth: FakeAuth) -> BedrockProvider:
+    return BedrockProvider(auth=fake_auth)
 
 
 @pytest.fixture
@@ -62,89 +164,31 @@ def converse_response() -> dict[str, Any]:
 
 
 @pytest.fixture
-def stream_events() -> list[dict[str, Any]]:
-    return [
-        {"messageStart": {"role": "assistant"}},
-        {"contentBlockDelta": {"delta": {"text": "Hello"}, "contentBlockIndex": 0}},
-        {"messageStop": {"stopReason": "end_turn"}},
-        {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}, "metrics": {"latencyMs": 100}}},
-    ]
+def embedding_response() -> dict[str, Any]:
+    return {"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5}
 
 
-def _make_embedding_body(embedding: list[float], token_count: int) -> MagicMock:
-    """Create a mock streaming body for invoke_model embedding responses."""
-    body = MagicMock()
-    body.read.return_value = json.dumps({"embedding": embedding, "inputTextTokenCount": token_count}).encode()
-    return body
+def _ok_converse(response: dict[str, Any], respx_mock: respx.MockRouter, *, model: str = MODEL) -> respx.Route:
+    return respx_mock.post(_url(model, "converse")).mock(return_value=httpx.Response(200, json=response))
 
 
-@pytest.fixture
-def embedding_invoke_response() -> dict[str, Any]:
-    return {"body": _make_embedding_body([0.1, 0.2, 0.3], 5)}
+def _ok_embed(response: dict[str, Any], respx_mock: respx.MockRouter) -> respx.Route:
+    return respx_mock.post(_url(EMBED_MODEL, "invoke")).mock(return_value=httpx.Response(200, json=response))
 
 
-@pytest.fixture
-def mock_sync_client() -> MagicMock:
-    return MagicMock()
-
-
-@pytest.fixture
-def mock_sync_create(mock_sync_client: MagicMock, mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("lmux_aws_bedrock.provider.create_sync_client", return_value=mock_sync_client)
-
-
-@pytest.fixture
-def sync_provider(fake_auth: FakeAuth, mock_sync_create: MagicMock) -> BedrockProvider:
-    provider = BedrockProvider(auth=fake_auth)
-    mock_sync_create.assert_not_called()  # client created lazily, not at init
-    return provider
-
-
-@pytest.fixture
-def mock_async_client() -> AsyncMock:
-    return AsyncMock()
-
-
-@pytest.fixture
-def mock_async_client_ctx(mock_async_client: AsyncMock) -> AsyncMock:
-    mock_ctx_manager = AsyncMock()
-    mock_ctx_manager.__aenter__ = AsyncMock(return_value=mock_async_client)
-    mock_ctx_manager.__aexit__ = AsyncMock(return_value=None)
-    return mock_ctx_manager
-
-
-@pytest.fixture
-def mock_async_create(mock_async_client_ctx: AsyncMock, mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("lmux_aws_bedrock.provider.create_async_client", return_value=mock_async_client_ctx)
-
-
-@pytest.fixture
-def async_provider(fake_auth: FakeAuth, mock_async_create: MagicMock) -> BedrockProvider:
-    provider = BedrockProvider(auth=fake_auth)
-    mock_async_create.assert_not_called()  # client created lazily, not at init
-    return provider
-
-
-@pytest.fixture
-def server_error() -> Exception:
-    """Create a generic exception for server-side errors."""
-    return Exception("test error")
-
-
-# MARK: Chat
+# MARK: Pricing As-Of
 
 
 class TestPricingAsOf:
     def test_live_cost_uses_current_date(
         self,
         sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
         converse_response: dict[str, Any],
+        respx_mock: respx.MockRouter,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Live Sonnet 5 cost reflects the current date (introductory rate before 2026-09-01)."""
         monkeypatch.setattr("lmux_aws_bedrock.provider._today", lambda: date(2026, 7, 1))
-        mock_sync_client.converse.return_value = converse_response
+        _ok_converse(converse_response, respx_mock, model="anthropic.claude-sonnet-5")
         result = sync_provider.chat("anthropic.claude-sonnet-5", [UserMessage(content="Hi")])
         assert result.cost is not None
         assert result.cost.input_cost == pytest.approx(10 * 2.2 / 1_000_000)
@@ -152,140 +196,120 @@ class TestPricingAsOf:
     def test_pricing_as_of_override_wins_over_clock(
         self,
         sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
         converse_response: dict[str, Any],
+        respx_mock: respx.MockRouter,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """An explicit pricing_as_of overrides the current date (e.g. for cost replay)."""
         monkeypatch.setattr("lmux_aws_bedrock.provider._today", lambda: date(2026, 9, 15))
-        mock_sync_client.converse.return_value = converse_response
+        _ok_converse(converse_response, respx_mock, model="anthropic.claude-sonnet-5")
         result = sync_provider.chat(
             "anthropic.claude-sonnet-5",
             [UserMessage(content="Hi")],
             provider_params=BedrockParams(pricing_as_of=date(2026, 7, 1)),
         )
         assert result.cost is not None
-        # The override date lands in the intro window, so the introductory rate wins.
         assert result.cost.input_cost == pytest.approx(10 * 2.2 / 1_000_000)
 
     def test_live_cost_uses_current_date_after_switch(
         self,
         sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
         converse_response: dict[str, Any],
+        respx_mock: respx.MockRouter,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """After 2026-09-01, the clock-resolved date bills the standard (1.5x) rate."""
         monkeypatch.setattr("lmux_aws_bedrock.provider._today", lambda: date(2026, 9, 15))
-        mock_sync_client.converse.return_value = converse_response
+        _ok_converse(converse_response, respx_mock, model="anthropic.claude-sonnet-5")
         result = sync_provider.chat("anthropic.claude-sonnet-5", [UserMessage(content="Hi")])
         assert result.cost is not None
         assert result.cost.input_cost == pytest.approx(10 * 3.3 / 1_000_000)
 
 
+# MARK: Chat
+
+
 class TestChat:
     def test_basic_chat(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
+        route = _ok_converse(converse_response, respx_mock, model="amazon.nova-pro-v1")
         result = sync_provider.chat("amazon.nova-pro-v1", [UserMessage(content="Hi")])
 
         assert result == ChatResponse(
             content="Hello!",
             tool_calls=None,
             usage=Usage(input_tokens=10, output_tokens=5),
-            cost=result.cost,  # Cost is calculated, just verify it's present
+            cost=result.cost,
             model="amazon.nova-pro-v1",
             provider="aws-bedrock",
             finish_reason="stop",
         )
         assert result.cost is not None
         assert result.cost.total_cost > 0
-        mock_sync_client.converse.assert_called_once()
-        mock_sync_client.invoke_model.assert_not_called()
+        assert route.called
+        # Request is signed with SigV4 and carries no bearer token.
+        assert route.calls.last.request.headers["authorization"].startswith("AWS4-HMAC-SHA256")
+        assert "x-amz-date" in route.calls.last.request.headers
 
-    def test_chat_with_params(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+    def test_request_body_omits_model_id(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], temperature=0.5, max_tokens=100, top_p=0.9, stop=["END"])
+        body = json.loads(route.calls.last.request.content)
+        assert body == {
+            "messages": [{"role": "user", "content": [{"text": "Hi"}]}],
+            "inferenceConfig": {"temperature": 0.5, "maxTokens": 100, "topP": 0.9, "stopSequences": ["END"]},
+        }
 
-        _ = sync_provider.chat(
-            "anthropic.claude-sonnet-4",
+    def test_chat_with_tools_and_choice(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
-            temperature=0.5,
-            max_tokens=100,
-            top_p=0.9,
-            stop=["END"],
+            tools=[Tool(function=FunctionDefinition(name="get_weather"))],
+            tool_choice="required",
         )
+        body = json.loads(route.calls.last.request.content)
+        assert body["toolConfig"] == {
+            "tools": [{"toolSpec": {"name": "get_weather", "inputSchema": {"json": {"type": "object"}}}}],
+            "toolChoice": {"any": {}},
+        }
 
-        mock_sync_client.converse.assert_called_once_with(
-            modelId="anthropic.claude-sonnet-4",
-            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
-            inferenceConfig={"temperature": 0.5, "maxTokens": 100, "topP": 0.9, "stopSequences": ["END"]},
-        )
-
-    def test_chat_with_tools(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+    def test_chat_with_tools_no_choice(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        tools = [Tool(function=FunctionDefinition(name="get_weather"))]
-        _ = sync_provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")], tools=tools)
-
-        mock_sync_client.converse.assert_called_once_with(
-            modelId="anthropic.claude-sonnet-4",
-            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
-            toolConfig={"tools": [{"toolSpec": {"name": "get_weather", "inputSchema": {"json": {"type": "object"}}}}]},
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            tools=[Tool(function=FunctionDefinition(name="get_weather"))],
         )
-
-    def test_chat_with_tool_choice(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
-    ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        tools = [Tool(function=FunctionDefinition(name="get_weather"))]
-        _ = sync_provider.chat(
-            "anthropic.claude-sonnet-4", [UserMessage(content="Hi")], tools=tools, tool_choice="required"
-        )
-
-        mock_sync_client.converse.assert_called_once_with(
-            modelId="anthropic.claude-sonnet-4",
-            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
-            toolConfig={
-                "tools": [{"toolSpec": {"name": "get_weather", "inputSchema": {"json": {"type": "object"}}}}],
-                "toolChoice": {"any": {}},
-            },
-        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["toolConfig"] == {
+            "tools": [{"toolSpec": {"name": "get_weather", "inputSchema": {"json": {"type": "object"}}}}],
+        }
 
     def test_chat_with_text_response_format(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        result = sync_provider.chat(
-            "anthropic.claude-sonnet-4", [UserMessage(content="Hi")], response_format=TextResponseFormat()
-        )
-
+        route = _ok_converse(converse_response, respx_mock)
+        result = sync_provider.chat(MODEL, [UserMessage(content="Hi")], response_format=TextResponseFormat())
         assert result.content == "Hello!"
-        mock_sync_client.converse.assert_called_once_with(
-            modelId="anthropic.claude-sonnet-4",
-            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
-        )
+        body = json.loads(route.calls.last.request.content)
+        assert "outputConfig" not in body
 
     def test_chat_json_object_raises(self, sync_provider: BedrockProvider) -> None:
         with pytest.raises(UnsupportedFeatureError, match="JsonObjectResponseFormat is not supported"):
-            _ = sync_provider.chat(
-                "anthropic.claude-sonnet-4", [UserMessage(content="Hi")], response_format=JsonObjectResponseFormat()
-            )
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")], response_format=JsonObjectResponseFormat())
 
     def test_chat_with_json_schema_response_format(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        _ = sync_provider.chat(
-            "anthropic.claude-sonnet-4",
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             response_format=JsonSchemaResponseFormat(
                 name="weather_response",
@@ -293,162 +317,116 @@ class TestChat:
                 json_schema={"type": "object", "properties": {"city": {"type": "string"}}},
             ),
         )
-
-        mock_sync_client.converse.assert_called_once_with(
-            modelId="anthropic.claude-sonnet-4",
-            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
-            outputConfig={
-                "textFormat": {
-                    "type": "json_schema",
-                    "structure": {
-                        "jsonSchema": {
-                            "schema": json.dumps(
-                                {
-                                    "additionalProperties": False,
-                                    "properties": {"city": {"type": "string"}},
-                                    "type": "object",
-                                },
-                                sort_keys=True,
-                            ),
-                            "name": "weather_response",
-                            "description": "Structured weather payload",
-                        }
-                    },
-                }
-            },
-        )
-
-    def test_chat_with_provider_params(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
-    ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        _ = sync_provider.chat(
-            "anthropic.claude-sonnet-4",
-            [UserMessage(content="Hi")],
-            provider_params=BedrockParams(
-                guardrail_config=GuardrailConfig(guardrail_identifier="g1", guardrail_version="1"),
-            ),
-        )
-
-        mock_sync_client.converse.assert_called_once_with(
-            modelId="anthropic.claude-sonnet-4",
-            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
-            guardrailConfig={"guardrailIdentifier": "g1", "guardrailVersion": "1"},
-        )
-
-    def test_chat_exception_mapping(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, server_error: Exception
-    ) -> None:
-        mock_sync_client.converse.side_effect = server_error
-
-        with pytest.raises(ProviderError):
-            _ = sync_provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-
-    def test_chat_with_system_message(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
-    ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        _ = sync_provider.chat(
-            "anthropic.claude-sonnet-4",
-            [SystemMessage(content="Be helpful."), UserMessage(content="Hi")],
-        )
-
-        mock_sync_client.converse.assert_called_once_with(
-            modelId="anthropic.claude-sonnet-4",
-            messages=[{"role": "user", "content": [{"text": "Hi"}]}],
-            system=[{"text": "Be helpful."}],
-        )
-
-    def test_chat_with_stop_string(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
-    ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        _ = sync_provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")], stop="STOP")
-
-        call_kwargs = mock_sync_client.converse.call_args.kwargs
-        assert call_kwargs["inferenceConfig"]["stopSequences"] == ["STOP"]
-
-    def test_chat_with_reasoning_effort(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
-    ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        _ = sync_provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")], reasoning_effort="medium")
-
-        call_kwargs = mock_sync_client.converse.call_args.kwargs
-        assert call_kwargs["additionalModelRequestFields"]["thinking"] == {
-            "type": "enabled",
-            "budget_tokens": 8192,
+        body = json.loads(route.calls.last.request.content)
+        assert body["outputConfig"] == {
+            "textFormat": {
+                "type": "json_schema",
+                "structure": {
+                    "jsonSchema": {
+                        "schema": json.dumps(
+                            {
+                                "additionalProperties": False,
+                                "properties": {"city": {"type": "string"}},
+                                "type": "object",
+                            },
+                            sort_keys=True,
+                        ),
+                        "name": "weather_response",
+                        "description": "Structured weather payload",
+                    }
+                },
+            }
         }
 
-    def test_chat_reasoning_effort_deep_merges_with_provider_params(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+    def test_chat_with_system_message(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(MODEL, [SystemMessage(content="Be helpful."), UserMessage(content="Hi")])
+        body = json.loads(route.calls.last.request.content)
+        assert body["system"] == [{"text": "Be helpful."}]
 
-        _ = sync_provider.chat(
-            "anthropic.claude-sonnet-4",
+    def test_chat_with_stop_string(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], stop="STOP")
+        body = json.loads(route.calls.last.request.content)
+        assert body["inferenceConfig"]["stopSequences"] == ["STOP"]
+
+    def test_chat_with_reasoning_effort(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], reasoning_effort="medium")
+        body = json.loads(route.calls.last.request.content)
+        assert body["additionalModelRequestFields"]["thinking"] == {"type": "enabled", "budget_tokens": 8192}
+
+    def test_reasoning_effort_deep_merges_with_provider_params(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             reasoning_effort="high",
             provider_params=BedrockParams(additional_model_request_fields={"some_field": "value"}),
         )
-
-        call_kwargs = mock_sync_client.converse.call_args.kwargs
-        additional = call_kwargs["additionalModelRequestFields"]
+        additional = json.loads(route.calls.last.request.content)["additionalModelRequestFields"]
         assert additional["thinking"] == {"type": "enabled", "budget_tokens": 32768}
         assert additional["some_field"] == "value"
 
-    def test_chat_provider_params_thinking_overrides_reasoning_effort(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+    def test_provider_params_thinking_overrides_reasoning_effort(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        _ = sync_provider.chat(
-            "anthropic.claude-sonnet-4",
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             reasoning_effort="high",
             provider_params=BedrockParams(
                 additional_model_request_fields={"thinking": {"type": "enabled", "budget_tokens": 99999}}
             ),
         )
+        additional = json.loads(route.calls.last.request.content)["additionalModelRequestFields"]
+        assert additional["thinking"] == {"type": "enabled", "budget_tokens": 99999}
 
-        call_kwargs = mock_sync_client.converse.call_args.kwargs
-        assert call_kwargs["additionalModelRequestFields"]["thinking"] == {
-            "type": "enabled",
-            "budget_tokens": 99999,
-        }
-
-    def test_chat_reasoning_effort_does_not_mutate_provider_params(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+    def test_reasoning_effort_does_not_mutate_provider_params(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
+        _ok_converse(converse_response, respx_mock)
         fields: dict[str, Any] = {"some_field": "value"}
-        params = BedrockParams(additional_model_request_fields=fields)
-
-        _ = sync_provider.chat(
-            "anthropic.claude-sonnet-4",
+        sync_provider.chat(
+            MODEL,
             [UserMessage(content="Hi")],
             reasoning_effort="high",
-            provider_params=params,
+            provider_params=BedrockParams(additional_model_request_fields=fields),
         )
-
-        # The original dict must not have been mutated
         assert "thinking" not in fields
 
-    def test_chat_reasoning_effort_adaptive_model(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+    def test_reasoning_effort_adaptive_model(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        # A 4.6+ model uses adaptive thinking + output_config.effort, not budget_tokens.
-        _ = sync_provider.chat("anthropic.claude-opus-4-8", [UserMessage(content="Hi")], reasoning_effort="high")
-
-        additional = mock_sync_client.converse.call_args.kwargs["additionalModelRequestFields"]
+        route = _ok_converse(converse_response, respx_mock, model="anthropic.claude-opus-4-8")
+        sync_provider.chat("anthropic.claude-opus-4-8", [UserMessage(content="Hi")], reasoning_effort="high")
+        additional = json.loads(route.calls.last.request.content)["additionalModelRequestFields"]
         assert additional["thinking"] == {"type": "adaptive"}
         assert additional["output_config"] == {"effort": "high"}
+
+    def test_status_error_mapped(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse")).mock(return_value=httpx.Response(400, json={"message": "bad"}))
+        with pytest.raises(InvalidRequestError):
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    def test_transport_error_mapped(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse")).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    def test_timeout_error_mapped(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse")).mock(side_effect=httpx.ConnectTimeout("slow"))
+        with pytest.raises(TimeoutError):
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")])
 
 
 # MARK: Achat
@@ -456,195 +434,156 @@ class TestChat:
 
 class TestAchat:
     async def test_basic_achat(
-        self, async_provider: BedrockProvider, mock_async_client: AsyncMock, converse_response: dict[str, Any]
+        self, async_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_async_client.converse.return_value = converse_response
-
-        result = await async_provider.achat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-
+        _ok_converse(converse_response, respx_mock)
+        result = await async_provider.achat(MODEL, [UserMessage(content="Hi")])
         assert result.content == "Hello!"
         assert result.provider == "aws-bedrock"
-        mock_async_client.converse.assert_awaited_once()
-        mock_async_client.invoke_model.assert_not_called()
 
-    async def test_achat_exception_mapping(
-        self, async_provider: BedrockProvider, mock_async_client: AsyncMock, server_error: Exception
-    ) -> None:
-        mock_async_client.converse.side_effect = server_error
+    async def test_status_error_mapped(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse")).mock(return_value=httpx.Response(401, json={"message": "no"}))
+        with pytest.raises(AuthenticationError):
+            await async_provider.achat(MODEL, [UserMessage(content="Hi")])
 
-        with pytest.raises(ProviderError):
-            _ = await async_provider.achat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
+    async def test_transport_error_mapped(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse")).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            await async_provider.achat(MODEL, [UserMessage(content="Hi")])
 
 
 # MARK: ChatStream
 
 
 class TestChatStream:
-    def test_yields_chunks(
-        self,
-        sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[dict[str, Any]],
-    ) -> None:
-        mock_sync_client.converse_stream.return_value = {"stream": iter(stream_events)}
-
-        chunks = list(sync_provider.chat_stream("anthropic.claude-sonnet-4", [UserMessage(content="Hi")]))
-
-        # messageStart is skipped (returns None), contentBlockDelta yields text,
-        # messageStop yields finish_reason, metadata yields usage
+    def test_yields_chunks(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(_url(MODEL, "converse-stream")).mock(
+            return_value=httpx.Response(200, content=_stream_bytes(_STREAM_EVENTS))
+        )
+        chunks = list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
         assert len(chunks) == 3
         assert chunks[0].delta == "Hello"
         assert chunks[1].finish_reason == "stop"
         assert chunks[2].usage is not None
         assert chunks[2].usage.input_tokens == 10
         assert chunks[2].usage.output_tokens == 5
+        body = json.loads(route.calls.last.request.content)
+        assert "modelId" not in body
 
     def test_terminal_chunk_stamps_model_and_provider(
-        self,
-        sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[dict[str, Any]],
+        self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse_stream.return_value = {"stream": iter(stream_events)}
-
-        chunks = list(sync_provider.chat_stream("anthropic.claude-sonnet-4", [UserMessage(content="Hi")]))
-
-        # Only the terminal (usage-bearing) chunk carries the endpoint identity.
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(
+            return_value=httpx.Response(200, content=_stream_bytes(_STREAM_EVENTS))
+        )
+        chunks = list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
         assert chunks[0].model is None
         assert chunks[0].provider is None
-        assert chunks[2].model == "anthropic.claude-sonnet-4"
+        assert chunks[2].model == MODEL
         assert chunks[2].provider == "aws-bedrock"
 
-    def test_cost_on_metadata_chunk(
-        self,
-        sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[dict[str, Any]],
-    ) -> None:
-        mock_sync_client.converse_stream.return_value = {"stream": iter(stream_events)}
-
+    def test_cost_on_metadata_chunk(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url("amazon.nova-pro-v1", "converse-stream")).mock(
+            return_value=httpx.Response(200, content=_stream_bytes(_STREAM_EVENTS))
+        )
         chunks = list(sync_provider.chat_stream("amazon.nova-pro-v1", [UserMessage(content="Hi")]))
-
         assert chunks[0].cost is None
         assert chunks[1].cost is None
         assert chunks[2].cost is not None
         assert chunks[2].cost.total_cost > 0
 
-    def test_stream_exception_on_create(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, server_error: Exception
+    def test_chunk_without_usage_has_no_cost(
+        self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse_stream.side_effect = server_error
-
-        with pytest.raises(ProviderError):
-            _ = list(sync_provider.chat_stream("anthropic.claude-sonnet-4", [UserMessage(content="Hi")]))
-
-    def test_stream_exception_during_iteration(
-        self,
-        sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
-        stream_events: list[dict[str, Any]],
-        server_error: Exception,
-    ) -> None:
-        def _failing_iter() -> Any:  # noqa: ANN401
-            yield stream_events[1]  # contentBlockDelta
-            raise server_error
-
-        mock_sync_client.converse_stream.return_value = {"stream": _failing_iter()}
-
-        with pytest.raises(ProviderError, match="test error"):
-            _ = list(sync_provider.chat_stream("anthropic.claude-sonnet-4", [UserMessage(content="Hi")]))
-
-    def test_stream_chunk_without_usage_has_no_cost(
-        self,
-        sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
-    ) -> None:
-        """Chunks that have no usage (non-metadata chunks) should have cost=None."""
-        events = [
-            {"contentBlockDelta": {"delta": {"text": "Hi"}, "contentBlockIndex": 0}},
-            {"messageStop": {"stopReason": "end_turn"}},
+        events: list[tuple[str, dict[str, Any] | None]] = [
+            ("contentBlockDelta", {"delta": {"text": "Hi"}, "contentBlockIndex": 0}),
+            ("messageStop", {"stopReason": "end_turn"}),
         ]
-        mock_sync_client.converse_stream.return_value = {"stream": iter(events)}
-
-        chunks = list(sync_provider.chat_stream("anthropic.claude-sonnet-4", [UserMessage(content="Hi")]))
-
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(
+            return_value=httpx.Response(200, content=_stream_bytes(events))
+        )
+        chunks = list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
         assert chunks[0] == ChatChunk(delta="Hi")
         assert chunks[0].cost is None
         assert chunks[1].cost is None
+
+    def test_status_error_on_open(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(500, json={"message": "boom"}))
+        with pytest.raises(ProviderError):
+            list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
+    def test_transport_error_on_open(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
+    def test_malformed_frame_mapped(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        bad = _encode({":event-type": "contentBlockDelta", ":message-type": "event"}, b"{not json}")
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=bad))
+        with pytest.raises(ProviderError):
+            list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
+    def test_stream_exception_frame(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        content = _frame("contentBlockDelta", {"delta": {"text": "Hi"}, "contentBlockIndex": 0}) + _frame(
+            "throttlingException", {"message": "slow down"}, message_type="exception"
+        )
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=content))
+        with pytest.raises(ProviderError, match="slow down"):
+            list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
+    def test_client_init_failure(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_aws_bedrock.provider.create_sync_client", side_effect=RuntimeError("boom"))
+        provider = BedrockProvider(auth=fake_auth)
+        with pytest.raises(ProviderError, match="boom"):
+            list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
 
 # MARK: AchatStream
 
 
 class TestAchatStream:
-    async def test_yields_chunks(
-        self,
-        async_provider: BedrockProvider,
-        mock_async_client: AsyncMock,
-        stream_events: list[dict[str, Any]],
-    ) -> None:
-        async def _async_iter() -> Any:  # noqa: ANN401
-            for event in stream_events:
-                yield event
-
-        mock_async_client.converse_stream.return_value = {"stream": _async_iter()}
-
-        chunks = [
-            chunk async for chunk in async_provider.achat_stream("amazon.nova-pro-v1", [UserMessage(content="Hi")])
-        ]
-
+    async def test_yields_chunks(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url("amazon.nova-pro-v1", "converse-stream")).mock(
+            return_value=httpx.Response(200, content=_stream_bytes(_STREAM_EVENTS))
+        )
+        chunks = [c async for c in async_provider.achat_stream("amazon.nova-pro-v1", [UserMessage(content="Hi")])]
         assert len(chunks) == 3
         assert chunks[0].delta == "Hello"
         assert chunks[1].finish_reason == "stop"
         assert chunks[2].cost is not None
 
     async def test_terminal_chunk_stamps_model_and_provider(
-        self,
-        async_provider: BedrockProvider,
-        mock_async_client: AsyncMock,
-        stream_events: list[dict[str, Any]],
+        self, async_provider: BedrockProvider, respx_mock: respx.MockRouter
     ) -> None:
-        async def _async_iter() -> Any:  # noqa: ANN401
-            for event in stream_events:
-                yield event
-
-        mock_async_client.converse_stream.return_value = {"stream": _async_iter()}
-
-        chunks = [
-            chunk
-            async for chunk in async_provider.achat_stream("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-        ]
-
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(
+            return_value=httpx.Response(200, content=_stream_bytes(_STREAM_EVENTS))
+        )
+        chunks = [c async for c in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")])]
         assert chunks[0].model is None
-        assert chunks[0].provider is None
-        assert chunks[2].model == "anthropic.claude-sonnet-4"
+        assert chunks[2].model == MODEL
         assert chunks[2].provider == "aws-bedrock"
 
-    async def test_exception_on_create(
-        self, async_provider: BedrockProvider, mock_async_client: AsyncMock, server_error: Exception
-    ) -> None:
-        mock_async_client.converse_stream.side_effect = server_error
-
-        with pytest.raises(ProviderError):
-            async for _ in async_provider.achat_stream("anthropic.claude-sonnet-4", [UserMessage(content="Hi")]):
+    async def test_transport_error_on_open(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass  # pragma: no cover
 
-    async def test_exception_during_iteration(
-        self,
-        async_provider: BedrockProvider,
-        mock_async_client: AsyncMock,
-        stream_events: list[dict[str, Any]],
-        server_error: Exception,
-    ) -> None:
-        async def _failing_async_iter() -> Any:  # noqa: ANN401
-            yield stream_events[1]  # contentBlockDelta
-            raise server_error
-
-        mock_async_client.converse_stream.return_value = {"stream": _failing_async_iter()}
-
-        with pytest.raises(ProviderError, match="test error"):
-            async for _ in async_provider.achat_stream("anthropic.claude-sonnet-4", [UserMessage(content="Hi")]):
+    async def test_exception_frame(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        content = _frame("contentBlockDelta", {"delta": {"text": "Hi"}, "contentBlockIndex": 0}) + _frame(
+            "validationException", {"message": "invalid"}, message_type="exception"
+        )
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=content))
+        with pytest.raises(ProviderError, match="invalid"):
+            async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass
+
+    async def test_client_init_failure(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_aws_bedrock.provider.create_async_client", side_effect=RuntimeError("boom"))
+        provider = BedrockProvider(auth=fake_auth)
+        with pytest.raises(ProviderError, match="boom"):
+            async for _ in provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
+                pass  # pragma: no cover
 
 
 # MARK: Embed
@@ -652,84 +591,58 @@ class TestAchatStream:
 
 class TestEmbed:
     def test_basic_embed(
-        self,
-        sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
-        embedding_invoke_response: dict[str, Any],
+        self, sync_provider: BedrockProvider, embedding_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.invoke_model.return_value = embedding_invoke_response
-
-        result = sync_provider.embed("amazon.titan-embed-text-v2", "hello")
+        route = _ok_embed(embedding_response, respx_mock)
+        result = sync_provider.embed(EMBED_MODEL, "hello")
 
         assert result == EmbeddingResponse(
             embeddings=[[0.1, 0.2, 0.3]],
             usage=Usage(input_tokens=5, output_tokens=0),
             cost=result.cost,
-            model="amazon.titan-embed-text-v2",
+            model=EMBED_MODEL,
             provider="aws-bedrock",
         )
-        mock_sync_client.invoke_model.assert_called_once_with(
-            modelId="amazon.titan-embed-text-v2",
-            contentType="application/json",
-            body=json.dumps({"inputText": "hello"}),
+        assert json.loads(route.calls.last.request.content) == {"inputText": "hello"}
+
+    def test_embed_list_input(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(EMBED_MODEL, "invoke")).mock(
+            side_effect=[
+                httpx.Response(200, json={"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 3}),
+                httpx.Response(200, json={"embedding": [0.4, 0.5, 0.6], "inputTextTokenCount": 4}),
+            ]
         )
-        mock_sync_client.converse.assert_not_called()
-
-    def test_embed_list_input(
-        self,
-        sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
-    ) -> None:
-        mock_sync_client.invoke_model.side_effect = [
-            {"body": _make_embedding_body([0.1, 0.2, 0.3], 3)},
-            {"body": _make_embedding_body([0.4, 0.5, 0.6], 4)},
-        ]
-
-        result = sync_provider.embed("amazon.titan-embed-text-v2", ["hello", "world"])
-
+        result = sync_provider.embed(EMBED_MODEL, ["hello", "world"])
         assert result == EmbeddingResponse(
             embeddings=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
             usage=Usage(input_tokens=7, output_tokens=0),
             cost=result.cost,
-            model="amazon.titan-embed-text-v2",
+            model=EMBED_MODEL,
             provider="aws-bedrock",
         )
-        assert mock_sync_client.invoke_model.call_count == 2
 
     def test_embed_with_dimensions(
-        self,
-        sync_provider: BedrockProvider,
-        mock_sync_client: MagicMock,
-        embedding_invoke_response: dict[str, Any],
+        self, sync_provider: BedrockProvider, embedding_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.invoke_model.return_value = embedding_invoke_response
+        route = _ok_embed(embedding_response, respx_mock)
+        sync_provider.embed(EMBED_MODEL, "hello", dimensions=256)
+        assert json.loads(route.calls.last.request.content) == {"inputText": "hello", "dimensions": 256}
 
-        _ = sync_provider.embed("amazon.titan-embed-text-v2", "hello", dimensions=256)
+    def test_embed_status_error_mapped(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(EMBED_MODEL, "invoke")).mock(return_value=httpx.Response(400, json={"message": "bad"}))
+        with pytest.raises(InvalidRequestError):
+            sync_provider.embed(EMBED_MODEL, "hello")
 
-        mock_sync_client.invoke_model.assert_called_once_with(
-            modelId="amazon.titan-embed-text-v2",
-            contentType="application/json",
-            body=json.dumps({"inputText": "hello", "dimensions": 256}),
-        )
+    def test_embed_transport_error_mapped(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(EMBED_MODEL, "invoke")).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            sync_provider.embed(EMBED_MODEL, "hello")
 
-    def test_embed_exception_mapping(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, server_error: Exception
-    ) -> None:
-        mock_sync_client.invoke_model.side_effect = server_error
-
-        with pytest.raises(ProviderError):
-            _ = sync_provider.embed("amazon.titan-embed-text-v2", "hello")
-
-    def test_embed_client_init_failure_mapped(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-    ) -> None:
-        mock_sync_create.side_effect = Exception("connection refused")
+    def test_embed_client_init_failure_mapped(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_aws_bedrock.provider.create_sync_client", side_effect=RuntimeError("connection refused"))
         provider = BedrockProvider(auth=fake_auth)
-
         with pytest.raises(ProviderError, match="connection refused"):
-            _ = provider.embed("amazon.titan-embed-text-v2", "hello")
+            provider.embed(EMBED_MODEL, "hello")
 
 
 # MARK: Aembed
@@ -737,198 +650,166 @@ class TestEmbed:
 
 class TestAembed:
     async def test_basic_aembed(
-        self,
-        async_provider: BedrockProvider,
-        mock_async_client: AsyncMock,
+        self, async_provider: BedrockProvider, embedding_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_body = AsyncMock()
-        mock_body.read.return_value = json.dumps({"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5}).encode()
-        mock_async_client.invoke_model.return_value = {"body": mock_body}
-
-        result = await async_provider.aembed("amazon.titan-embed-text-v2", "hello")
-
+        route = _ok_embed(embedding_response, respx_mock)
+        result = await async_provider.aembed(EMBED_MODEL, "hello")
         assert result.embeddings == [[0.1, 0.2, 0.3]]
         assert result.usage == Usage(input_tokens=5, output_tokens=0)
         assert result.provider == "aws-bedrock"
-        mock_async_client.invoke_model.assert_awaited_once_with(
-            modelId="amazon.titan-embed-text-v2",
-            contentType="application/json",
-            body=json.dumps({"inputText": "hello"}),
+        assert json.loads(route.calls.last.request.content) == {"inputText": "hello"}
+
+    async def test_aembed_list_input(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(EMBED_MODEL, "invoke")).mock(
+            side_effect=[
+                httpx.Response(200, json={"embedding": [0.1, 0.2], "inputTextTokenCount": 3}),
+                httpx.Response(200, json={"embedding": [0.3, 0.4], "inputTextTokenCount": 4}),
+            ]
         )
-        mock_async_client.converse.assert_not_called()
-
-    async def test_aembed_list_input(
-        self,
-        async_provider: BedrockProvider,
-        mock_async_client: AsyncMock,
-    ) -> None:
-        mock_body1 = AsyncMock()
-        mock_body1.read.return_value = json.dumps({"embedding": [0.1, 0.2], "inputTextTokenCount": 3}).encode()
-        mock_body2 = AsyncMock()
-        mock_body2.read.return_value = json.dumps({"embedding": [0.3, 0.4], "inputTextTokenCount": 4}).encode()
-        mock_async_client.invoke_model.side_effect = [{"body": mock_body1}, {"body": mock_body2}]
-
-        result = await async_provider.aembed("amazon.titan-embed-text-v2", ["hello", "world"])
-
+        result = await async_provider.aembed(EMBED_MODEL, ["hello", "world"])
         assert result.embeddings == [[0.1, 0.2], [0.3, 0.4]]
         assert result.usage == Usage(input_tokens=7, output_tokens=0)
-        assert mock_async_client.invoke_model.call_count == 2
 
     async def test_aembed_with_dimensions(
-        self,
-        async_provider: BedrockProvider,
-        mock_async_client: AsyncMock,
+        self, async_provider: BedrockProvider, embedding_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_body = AsyncMock()
-        mock_body.read.return_value = json.dumps({"embedding": [0.1, 0.2, 0.3], "inputTextTokenCount": 5}).encode()
-        mock_async_client.invoke_model.return_value = {"body": mock_body}
+        route = _ok_embed(embedding_response, respx_mock)
+        await async_provider.aembed(EMBED_MODEL, "hello", dimensions=256)
+        assert json.loads(route.calls.last.request.content) == {"inputText": "hello", "dimensions": 256}
 
-        _ = await async_provider.aembed("amazon.titan-embed-text-v2", "hello", dimensions=256)
-
-        mock_async_client.invoke_model.assert_awaited_once_with(
-            modelId="amazon.titan-embed-text-v2",
-            contentType="application/json",
-            body=json.dumps({"inputText": "hello", "dimensions": 256}),
-        )
-
-    async def test_aembed_exception_mapping(
-        self, async_provider: BedrockProvider, mock_async_client: AsyncMock, server_error: Exception
+    async def test_aembed_status_error_mapped(
+        self, async_provider: BedrockProvider, respx_mock: respx.MockRouter
     ) -> None:
-        mock_async_client.invoke_model.side_effect = server_error
+        respx_mock.post(_url(EMBED_MODEL, "invoke")).mock(return_value=httpx.Response(400, json={"message": "no"}))
+        with pytest.raises(InvalidRequestError):
+            await async_provider.aembed(EMBED_MODEL, "hello")
 
-        with pytest.raises(ProviderError):
-            _ = await async_provider.aembed("amazon.titan-embed-text-v2", "hello")
+    async def test_aembed_transport_error_mapped(
+        self, async_provider: BedrockProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        respx_mock.post(_url(EMBED_MODEL, "invoke")).mock(side_effect=httpx.ConnectError("refused"))
+        with pytest.raises(ProviderError, match="refused"):
+            await async_provider.aembed(EMBED_MODEL, "hello")
 
 
-# MARK: Client Management
+# MARK: Client & Auth Management
 
 
 class TestClientManagement:
     def test_sync_client_reused(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
+        _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="a")])
+        client = sync_provider._sync_client  # pyright: ignore[reportPrivateUsage]
+        sync_provider.chat(MODEL, [UserMessage(content="b")])
+        assert sync_provider._sync_client is client  # pyright: ignore[reportPrivateUsage]
 
-        _ = sync_provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-        _ = sync_provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi again")])
-
-        assert mock_sync_client.converse.call_count == 2
-
-    def test_region_passed(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-        mock_sync_client: MagicMock,
-        converse_response: dict[str, Any],
+    def test_auth_resolved_once(
+        self, fake_auth: FakeAuth, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-        provider = BedrockProvider(auth=fake_auth, region="us-west-2")
-        _ = provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-
-        mock_sync_create.assert_called_once()
-        call_kwargs = mock_sync_create.call_args.kwargs
-        assert call_kwargs["region_name"] == "us-west-2"
-
-    def test_endpoint_url_passed(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-        mock_sync_client: MagicMock,
-        converse_response: dict[str, Any],
-    ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-        provider = BedrockProvider(auth=fake_auth, endpoint_url="https://custom.bedrock.endpoint")
-        _ = provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-
-        mock_sync_create.assert_called_once()
-        call_kwargs = mock_sync_create.call_args.kwargs
-        assert call_kwargs["endpoint_url"] == "https://custom.bedrock.endpoint"
-
-    def test_create_sync_client_called_once(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-        mock_sync_client: MagicMock,
-        converse_response: dict[str, Any],
-    ) -> None:
-        mock_sync_client.converse.return_value = converse_response
+        _ok_converse(converse_response, respx_mock)
         provider = BedrockProvider(auth=fake_auth)
-        _ = provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-        _ = provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi again")])
+        provider.chat(MODEL, [UserMessage(content="a")])
+        provider.chat(MODEL, [UserMessage(content="b")])
+        assert fake_auth.get_calls == 1
 
-        mock_sync_create.assert_called_once()
-
-    async def test_async_session_reused(
-        self,
-        fake_auth: FakeAuth,
-        mock_async_create: MagicMock,
-        mock_async_client: AsyncMock,
-        converse_response: dict[str, Any],
+    def test_region_selects_endpoint_host(
+        self, fake_auth: FakeAuth, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_async_client.converse.return_value = converse_response
-        provider = BedrockProvider(auth=fake_auth)
-        _ = await provider.achat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-        _ = await provider.achat("anthropic.claude-sonnet-4", [UserMessage(content="Hi again")])
-
-        assert fake_auth.aget_credentials_calls == 1
-        assert mock_async_create.call_count == 2
-
-    async def test_async_region_passed(
-        self,
-        fake_auth: FakeAuth,
-        mock_async_create: MagicMock,
-        mock_async_client: AsyncMock,
-        converse_response: dict[str, Any],
-    ) -> None:
-        mock_async_client.converse.return_value = converse_response
-        provider = BedrockProvider(auth=fake_auth, region="eu-west-1")
-        _ = await provider.achat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-
-        mock_async_create.assert_called_once_with(fake_auth.async_session, region_name="eu-west-1", endpoint_url=None)
-
-    async def test_async_endpoint_url_passed(
-        self,
-        fake_auth: FakeAuth,
-        mock_async_create: MagicMock,
-        mock_async_client: AsyncMock,
-        converse_response: dict[str, Any],
-    ) -> None:
-        mock_async_client.converse.return_value = converse_response
-        provider = BedrockProvider(auth=fake_auth, endpoint_url="https://custom.endpoint")
-        _ = await provider.achat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-
-        mock_async_create.assert_called_once_with(
-            fake_auth.async_session,
-            region_name=None,
-            endpoint_url="https://custom.endpoint",
+        base = "https://bedrock-runtime.us-west-2.amazonaws.com"
+        route = respx_mock.post(_url(MODEL, "converse", base=base)).mock(
+            return_value=httpx.Response(200, json=converse_response)
         )
+        provider = BedrockProvider(auth=fake_auth, region="us-west-2")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
 
-    def test_sync_client_init_failure_mapped(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
+    def test_session_region_selects_endpoint_host(
+        self, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_create.side_effect = Exception("connection refused")
-        provider = BedrockProvider(auth=fake_auth)
+        base = "https://bedrock-runtime.ap-south-1.amazonaws.com"
+        route = respx_mock.post(_url(MODEL, "converse", base=base)).mock(
+            return_value=httpx.Response(200, json=converse_response)
+        )
+        provider = BedrockProvider(auth=FakeAuth(_Session(region_name="ap-south-1")))
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
 
+    def test_endpoint_url_override(
+        self, fake_auth: FakeAuth, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        base = "https://custom.bedrock.endpoint"
+        route = respx_mock.post(_url(MODEL, "converse", base=base)).mock(
+            return_value=httpx.Response(200, json=converse_response)
+        )
+        provider = BedrockProvider(auth=fake_auth, endpoint_url=base)
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
+
+    def test_no_credentials_raises_auth_error(
+        self, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        _ok_converse(converse_response, respx_mock)
+        provider = BedrockProvider(auth=FakeAuth(_Session(credentials=None)))
+        with pytest.raises(AuthenticationError):
+            provider.chat(MODEL, [UserMessage(content="Hi")])
+
+    async def test_async_client_reused(
+        self, async_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        _ok_converse(converse_response, respx_mock)
+        await async_provider.achat(MODEL, [UserMessage(content="a")])
+        client = async_provider._async_client  # pyright: ignore[reportPrivateUsage]
+        await async_provider.achat(MODEL, [UserMessage(content="b")])
+        assert async_provider._async_client is client  # pyright: ignore[reportPrivateUsage]
+
+    async def test_async_client_recreated_on_new_loop(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        c1, c2 = MagicMock(), MagicMock()
+        create = mocker.patch("lmux_aws_bedrock.provider.create_async_client", side_effect=[c1, c2])
+        get_loop = mocker.patch("lmux_aws_bedrock.provider.asyncio.get_running_loop")
+        loop1, loop2 = asyncio.new_event_loop(), asyncio.new_event_loop()
+        get_loop.side_effect = [loop1, loop2]
+        provider = BedrockProvider(auth=fake_auth)
+        r1 = await provider._get_async_client()  # pyright: ignore[reportPrivateUsage]
+        r2 = await provider._get_async_client()  # pyright: ignore[reportPrivateUsage]
+        assert (r1, r2) == (c1, c2)
+        assert create.call_count == 2
+        loop1.close()
+        loop2.close()
+
+    def test_sync_client_init_failure_mapped(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
+        mocker.patch("lmux_aws_bedrock.provider.create_sync_client", side_effect=RuntimeError("connection refused"))
+        provider = BedrockProvider(auth=fake_auth)
         with pytest.raises(ProviderError, match="connection refused"):
-            _ = provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
+            provider.chat(MODEL, [UserMessage(content="Hi")])
 
-    def test_no_region_no_endpoint_defaults_to_none(
-        self,
-        fake_auth: FakeAuth,
-        mock_sync_create: MagicMock,
-        mock_sync_client: MagicMock,
-        converse_response: dict[str, Any],
+
+# MARK: Bearer Token Auth
+
+
+class TestBearerAuth:
+    def test_bearer_token_sets_authorization(
+        self, converse_response: dict[str, Any], respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-        provider = BedrockProvider(auth=fake_auth)
-        _ = provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bt-secret")
+        route = _ok_converse(converse_response, respx_mock)
+        provider = BedrockProvider()  # no auth provider needed in bearer mode
+        result = provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result.content == "Hello!"
+        assert route.calls.last.request.headers["authorization"] == "Bearer bt-secret"
 
-        mock_sync_create.assert_called_once()
-        call_kwargs = mock_sync_create.call_args.kwargs
-        assert call_kwargs["region_name"] is None
-        assert call_kwargs["endpoint_url"] is None
+    def test_bearer_token_respects_region(
+        self, converse_response: dict[str, Any], respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bt-secret")
+        base = "https://bedrock-runtime.eu-central-1.amazonaws.com"
+        route = respx_mock.post(_url(MODEL, "converse", base=base)).mock(
+            return_value=httpx.Response(200, json=converse_response)
+        )
+        provider = BedrockProvider(region="eu-central-1")
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert route.called
 
 
 # MARK: Register Pricing
@@ -936,16 +817,14 @@ class TestClientManagement:
 
 class TestRegisterPricing:
     def test_custom_pricing_for_unknown_model(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock
+        self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter
     ) -> None:
-        """Custom pricing populates cost for models not in built-in PRICING."""
-        custom_response: dict[str, Any] = {
+        response = {
             "output": {"message": {"role": "assistant", "content": [{"text": "Hello!"}]}},
             "stopReason": "end_turn",
             "usage": {"inputTokens": 1000, "outputTokens": 500, "totalTokens": 1500},
         }
-        mock_sync_client.converse.return_value = custom_response
-
+        respx_mock.post(_url("custom.my-model-v1", "converse")).mock(return_value=httpx.Response(200, json=response))
         sync_provider.register_pricing(
             "custom.my-model-v1",
             ModelPricing(
@@ -953,40 +832,35 @@ class TestRegisterPricing:
             ),
         )
         result = sync_provider.chat("custom.my-model-v1", [UserMessage(content="Hi")])
-
         assert result.cost is not None
         assert result.cost.input_cost == pytest.approx(1000 * 5.0 / 1_000_000)
         assert result.cost.output_cost == pytest.approx(500 * 15.0 / 1_000_000)
 
     def test_custom_pricing_overrides_builtin(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        """User-registered pricing takes precedence over built-in pricing."""
-        mock_sync_client.converse.return_value = converse_response
-
-        custom_pricing = ModelPricing(
-            tiers=[PricingTier(input_cost_per_token=99.0 / 1_000_000, output_cost_per_token=199.0 / 1_000_000)]
+        _ok_converse(converse_response, respx_mock)
+        sync_provider.register_pricing(
+            MODEL,
+            ModelPricing(
+                tiers=[PricingTier(input_cost_per_token=99.0 / 1_000_000, output_cost_per_token=199.0 / 1_000_000)]
+            ),
         )
-        sync_provider.register_pricing("anthropic.claude-sonnet-4", custom_pricing)
-        result = sync_provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")])
-
+        result = sync_provider.chat(MODEL, [UserMessage(content="Hi")])
         assert result.cost is not None
         assert result.cost.input_cost == pytest.approx(10 * 99.0 / 1_000_000)
         assert result.cost.output_cost == pytest.approx(5 * 199.0 / 1_000_000)
 
     def test_unregistered_unknown_model_returns_none_cost(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock
+        self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter
     ) -> None:
-        """Without registration, unknown models return cost=None."""
-        unknown_response: dict[str, Any] = {
+        response = {
             "output": {"message": {"role": "assistant", "content": [{"text": "Hello!"}]}},
             "stopReason": "end_turn",
             "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
         }
-        mock_sync_client.converse.return_value = unknown_response
-
+        respx_mock.post(_url("totally-unknown-model", "converse")).mock(return_value=httpx.Response(200, json=response))
         result = sync_provider.chat("totally-unknown-model", [UserMessage(content="Hi")])
-
         assert result.cost is None
 
 
@@ -995,52 +869,57 @@ class TestRegisterPricing:
 
 class TestProviderParamsKwargs:
     def test_empty_params(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
-        _ = sync_provider.chat(
-            "anthropic.claude-sonnet-4", [UserMessage(content="Hi")], provider_params=BedrockParams()
-        )
-
-        call_kwargs = mock_sync_client.converse.call_args.kwargs
-        assert "guardrailConfig" not in call_kwargs
-        assert "additionalModelRequestFields" not in call_kwargs
-        assert "additionalModelResponseFieldPaths" not in call_kwargs
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=BedrockParams())
+        body = json.loads(route.calls.last.request.content)
+        assert "guardrailConfig" not in body
+        assert "additionalModelRequestFields" not in body
+        assert "additionalModelResponseFieldPaths" not in body
 
     def test_all_params(
-        self, sync_provider: BedrockProvider, mock_sync_client: MagicMock, converse_response: dict[str, Any]
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        mock_sync_client.converse.return_value = converse_response
-
+        route = _ok_converse(converse_response, respx_mock)
         params = BedrockParams(
             guardrail_config=GuardrailConfig(guardrail_identifier="g1", guardrail_version="1", trace="enabled"),
             additional_model_request_fields={"custom_field": "value"},
             additional_model_response_field_paths=["$.path.to.field"],
         )
-        _ = sync_provider.chat("anthropic.claude-sonnet-4", [UserMessage(content="Hi")], provider_params=params)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=params)
+        body = json.loads(route.calls.last.request.content)
+        assert body["guardrailConfig"] == {"guardrailIdentifier": "g1", "guardrailVersion": "1", "trace": "enabled"}
+        assert body["additionalModelRequestFields"] == {"custom_field": "value"}
+        assert body["additionalModelResponseFieldPaths"] == ["$.path.to.field"]
 
-        call_kwargs = mock_sync_client.converse.call_args.kwargs
-        assert call_kwargs["guardrailConfig"] == {
-            "guardrailIdentifier": "g1",
-            "guardrailVersion": "1",
-            "trace": "enabled",
-        }
-        assert call_kwargs["additionalModelRequestFields"] == {"custom_field": "value"}
-        assert call_kwargs["additionalModelResponseFieldPaths"] == ["$.path.to.field"]
+    def test_guardrail_without_trace(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock)
+        params = BedrockParams(guardrail_config=GuardrailConfig(guardrail_identifier="g1", guardrail_version="1"))
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=params)
+        body = json.loads(route.calls.last.request.content)
+        assert body["guardrailConfig"] == {"guardrailIdentifier": "g1", "guardrailVersion": "1"}
 
 
-# MARK: Preload
+# MARK: Aclose & Preload
+
+
+class TestAclose:
+    async def test_closes_client(
+        self, async_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        _ok_converse(converse_response, respx_mock)
+        await async_provider.achat(MODEL, [UserMessage(content="Hi")])
+        assert async_provider._async_client is not None  # pyright: ignore[reportPrivateUsage]
+        await async_provider.aclose()
+        assert async_provider._async_client is None  # pyright: ignore[reportPrivateUsage]
+
+    async def test_noop_when_no_client(self, async_provider: BedrockProvider) -> None:
+        await async_provider.aclose()
 
 
 class TestPreload:
-    @pytest.fixture
-    def mock_missing_aiobotocore(self, mocker: MockerFixture) -> None:
-        mocker.patch.dict("sys.modules", {"aiobotocore": None})
-
-    def test_preload_imports_boto3_and_aiobotocore(self) -> None:
-        preload()  # should not raise; aiobotocore is installed in dev
-
-    def test_preload_without_aiobotocore(self, mock_missing_aiobotocore: None) -> None:
-        assert mock_missing_aiobotocore is None  # side-effect fixture: patches sys.modules
-        preload()  # should not raise when aiobotocore is missing
+    def test_preload(self) -> None:
+        preload()

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -428,6 +428,11 @@ class TestChat:
         with pytest.raises(TimeoutError):
             sync_provider.chat(MODEL, [UserMessage(content="Hi")])
 
+    def test_non_json_body_mapped(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse")).mock(return_value=httpx.Response(200, content=b"not json"))
+        with pytest.raises(ProviderError):
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")])
+
 
 # MARK: Achat
 
@@ -449,6 +454,11 @@ class TestAchat:
     async def test_transport_error_mapped(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
         respx_mock.post(_url(MODEL, "converse")).mock(side_effect=httpx.ConnectError("refused"))
         with pytest.raises(ProviderError, match="refused"):
+            await async_provider.achat(MODEL, [UserMessage(content="Hi")])
+
+    async def test_non_json_body_mapped(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse")).mock(return_value=httpx.Response(200, content=b"not json"))
+        with pytest.raises(ProviderError):
             await async_provider.achat(MODEL, [UserMessage(content="Hi")])
 
 

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -5,6 +5,7 @@ import json
 import struct
 import zlib
 from datetime import date
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 
@@ -563,6 +564,18 @@ class TestChatStream:
         with pytest.raises(ProviderError, match="slow down"):
             list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
+    def test_exception_frame_without_event_type(
+        self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        # A real exception frame carries :exception-type and no :event-type; indexing :event-type
+        # first would KeyError before the error could be surfaced.
+        content = _encode(
+            {":message-type": "exception", ":exception-type": "ThrottlingException"}, b'{"message": "slow down"}'
+        )
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=content))
+        with pytest.raises(ProviderError, match="slow down"):
+            list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
     def test_client_init_failure(self, fake_auth: FakeAuth, sync_create_raises: MagicMock) -> None:
         provider = BedrockProvider(auth=fake_auth)
         with pytest.raises(ProviderError, match="client init failed"):
@@ -598,6 +611,19 @@ class TestAchatStream:
     async def test_transport_error_on_open(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
         respx_mock.post(_url(MODEL, "converse-stream")).mock(side_effect=httpx.ConnectError("refused"))
         with pytest.raises(ProviderError, match="refused"):
+            async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
+                pass  # pragma: no cover
+
+    async def test_status_error_on_open(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(500, json={"message": "boom"}))
+        with pytest.raises(ProviderError):
+            async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
+                pass  # pragma: no cover
+
+    async def test_malformed_frame_mapped(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+        bad = _encode({":event-type": "contentBlockDelta", ":message-type": "event"}, b"{not json}")
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=bad))
+        with pytest.raises(ProviderError):
             async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass  # pragma: no cover
 
@@ -818,6 +844,37 @@ class TestClientManagement:
         with pytest.raises(ProviderError, match="client init failed"):
             provider.chat(MODEL, [UserMessage(content="Hi")])
         sync_create_raises.assert_called_once()
+
+
+# MARK: SigV4 Auth
+
+
+class TestSigV4Auth:
+    def test_freezes_credentials_per_request(
+        self, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        class _RotatingCredentials:
+            def __init__(self) -> None:
+                self.calls = 0
+
+            def get_frozen_credentials(self) -> Any:  # noqa: ANN401
+                self.calls += 1
+                return SimpleNamespace(
+                    access_key="AKIAFAKEEXAMPLE",
+                    secret_key="fake-secret-key",  # noqa: S106
+                    token=f"session-token-{self.calls}",
+                )
+
+        creds = _RotatingCredentials()
+        provider = BedrockProvider(auth=FakeAuth(_Session(credentials=cast("_Credentials", creds))))
+        route = _ok_converse(converse_response, respx_mock)
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        provider.chat(MODEL, [UserMessage(content="Hi")])
+        # Credentials are frozen once per request (not cached at client creation), so a rotating
+        # source flows a fresh token into each signature.
+        assert creds.calls == 2
+        assert route.calls[0].request.headers["x-amz-security-token"] == "session-token-1"
+        assert route.calls[1].request.headers["x-amz-security-token"] == "session-token-2"
 
 
 # MARK: Bearer Token Auth

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -593,6 +593,18 @@ class TestChatStream:
         with pytest.raises(RateLimitError, match="slow down"):
             list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
+    def test_stream_error_frame_surfaces_service_error(
+        self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        # An unmodeled error frame carries :error-code/:error-message and no :event-type; the real
+        # service error must surface, not a KeyError-wrapped "':event-type'".
+        content = _encode(
+            {":message-type": "error", ":error-code": "internalServerException", ":error-message": "boom"}, b""
+        )
+        respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=content))
+        with pytest.raises(ProviderError, match="boom"):
+            list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+
     def test_client_init_failure(self, fake_auth: FakeAuth, sync_create_raises: MagicMock) -> None:
         provider = BedrockProvider(auth=fake_auth)
         with pytest.raises(ProviderError, match="client init failed"):

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -155,6 +155,28 @@ def async_provider(fake_auth: FakeAuth) -> BedrockProvider:
 
 
 @pytest.fixture
+def sync_create_raises(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_aws_bedrock.provider.create_sync_client", side_effect=RuntimeError("client init failed"))
+
+
+@pytest.fixture
+def async_create_raises(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_aws_bedrock.provider.create_async_client", side_effect=RuntimeError("client init failed"))
+
+
+@pytest.fixture
+def async_create_two_clients(mocker: MockerFixture) -> tuple[MagicMock, MagicMock, MagicMock]:
+    c1, c2 = MagicMock(), MagicMock()
+    create = mocker.patch("lmux_aws_bedrock.provider.create_async_client", side_effect=[c1, c2])
+    return create, c1, c2
+
+
+@pytest.fixture
+def mock_get_running_loop(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_aws_bedrock.provider.asyncio.get_running_loop")
+
+
+@pytest.fixture
 def converse_response() -> dict[str, Any]:
     return {
         "output": {"message": {"role": "assistant", "content": [{"text": "Hello!"}]}},
@@ -541,11 +563,11 @@ class TestChatStream:
         with pytest.raises(ProviderError, match="slow down"):
             list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
-    def test_client_init_failure(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_aws_bedrock.provider.create_sync_client", side_effect=RuntimeError("boom"))
+    def test_client_init_failure(self, fake_auth: FakeAuth, sync_create_raises: MagicMock) -> None:
         provider = BedrockProvider(auth=fake_auth)
-        with pytest.raises(ProviderError, match="boom"):
+        with pytest.raises(ProviderError, match="client init failed"):
             list(provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
+        sync_create_raises.assert_called_once()
 
 
 # MARK: AchatStream
@@ -588,12 +610,12 @@ class TestAchatStream:
             async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass
 
-    async def test_client_init_failure(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_aws_bedrock.provider.create_async_client", side_effect=RuntimeError("boom"))
+    async def test_client_init_failure(self, fake_auth: FakeAuth, async_create_raises: MagicMock) -> None:
         provider = BedrockProvider(auth=fake_auth)
-        with pytest.raises(ProviderError, match="boom"):
+        with pytest.raises(ProviderError, match="client init failed"):
             async for _ in provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass  # pragma: no cover
+        async_create_raises.assert_called_once()
 
 
 # MARK: Embed
@@ -648,11 +670,11 @@ class TestEmbed:
         with pytest.raises(ProviderError, match="refused"):
             sync_provider.embed(EMBED_MODEL, "hello")
 
-    def test_embed_client_init_failure_mapped(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_aws_bedrock.provider.create_sync_client", side_effect=RuntimeError("connection refused"))
+    def test_embed_client_init_failure_mapped(self, fake_auth: FakeAuth, sync_create_raises: MagicMock) -> None:
         provider = BedrockProvider(auth=fake_auth)
-        with pytest.raises(ProviderError, match="connection refused"):
+        with pytest.raises(ProviderError, match="client init failed"):
             provider.embed(EMBED_MODEL, "hello")
+        sync_create_raises.assert_called_once()
 
 
 # MARK: Aembed
@@ -711,9 +733,9 @@ class TestClientManagement:
     ) -> None:
         _ok_converse(converse_response, respx_mock)
         sync_provider.chat(MODEL, [UserMessage(content="a")])
-        client = sync_provider._sync_client  # pyright: ignore[reportPrivateUsage]
+        client = sync_provider._sync_client
         sync_provider.chat(MODEL, [UserMessage(content="b")])
-        assert sync_provider._sync_client is client  # pyright: ignore[reportPrivateUsage]
+        assert sync_provider._sync_client is client
 
     def test_auth_resolved_once(
         self, fake_auth: FakeAuth, converse_response: dict[str, Any], respx_mock: respx.MockRouter
@@ -770,29 +792,32 @@ class TestClientManagement:
     ) -> None:
         _ok_converse(converse_response, respx_mock)
         await async_provider.achat(MODEL, [UserMessage(content="a")])
-        client = async_provider._async_client  # pyright: ignore[reportPrivateUsage]
+        client = async_provider._async_client
         await async_provider.achat(MODEL, [UserMessage(content="b")])
-        assert async_provider._async_client is client  # pyright: ignore[reportPrivateUsage]
+        assert async_provider._async_client is client
 
-    async def test_async_client_recreated_on_new_loop(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        c1, c2 = MagicMock(), MagicMock()
-        create = mocker.patch("lmux_aws_bedrock.provider.create_async_client", side_effect=[c1, c2])
-        get_loop = mocker.patch("lmux_aws_bedrock.provider.asyncio.get_running_loop")
+    async def test_async_client_recreated_on_new_loop(
+        self,
+        fake_auth: FakeAuth,
+        async_create_two_clients: tuple[MagicMock, MagicMock, MagicMock],
+        mock_get_running_loop: MagicMock,
+    ) -> None:
+        create, c1, c2 = async_create_two_clients
         loop1, loop2 = asyncio.new_event_loop(), asyncio.new_event_loop()
-        get_loop.side_effect = [loop1, loop2]
+        mock_get_running_loop.side_effect = [loop1, loop2]
         provider = BedrockProvider(auth=fake_auth)
-        r1 = await provider._get_async_client()  # pyright: ignore[reportPrivateUsage]
-        r2 = await provider._get_async_client()  # pyright: ignore[reportPrivateUsage]
+        r1 = await provider._get_async_client()
+        r2 = await provider._get_async_client()
         assert (r1, r2) == (c1, c2)
         assert create.call_count == 2
         loop1.close()
         loop2.close()
 
-    def test_sync_client_init_failure_mapped(self, fake_auth: FakeAuth, mocker: MockerFixture) -> None:
-        mocker.patch("lmux_aws_bedrock.provider.create_sync_client", side_effect=RuntimeError("connection refused"))
+    def test_sync_client_init_failure_mapped(self, fake_auth: FakeAuth, sync_create_raises: MagicMock) -> None:
         provider = BedrockProvider(auth=fake_auth)
-        with pytest.raises(ProviderError, match="connection refused"):
+        with pytest.raises(ProviderError, match="client init failed"):
             provider.chat(MODEL, [UserMessage(content="Hi")])
+        sync_create_raises.assert_called_once()
 
 
 # MARK: Bearer Token Auth
@@ -922,9 +947,9 @@ class TestAclose:
     ) -> None:
         _ok_converse(converse_response, respx_mock)
         await async_provider.achat(MODEL, [UserMessage(content="Hi")])
-        assert async_provider._async_client is not None  # pyright: ignore[reportPrivateUsage]
+        assert async_provider._async_client is not None
         await async_provider.aclose()
-        assert async_provider._async_client is None  # pyright: ignore[reportPrivateUsage]
+        assert async_provider._async_client is None
 
     async def test_noop_when_no_client(self, async_provider: BedrockProvider) -> None:
         await async_provider.aclose()

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 
+import botocore.exceptions
 import httpx
 import pytest
 import respx
@@ -100,6 +101,16 @@ class FakeAuth:
         return cast("AioSession", self._session)
 
 
+class _RaisingSessionAuth:
+    """Auth provider whose session construction fails, e.g. a stale AWS_PROFILE."""
+
+    def get_credentials(self) -> "boto3.Session":
+        raise botocore.exceptions.ProfileNotFound(profile="missing-profile")
+
+    async def aget_credentials(self) -> "AioSession":  # pragma: no cover - protocol conformance only
+        raise botocore.exceptions.ProfileNotFound(profile="missing-profile")
+
+
 # MARK: Event-stream framing (mirrors tests/test_eventstream.py)
 
 
@@ -116,6 +127,9 @@ def _encode(headers: dict[str, str], payload: bytes) -> bytes:
 
 def _frame(event_type: str, payload: dict[str, Any] | None, *, message_type: str = "event") -> bytes:
     data = json.dumps(payload).encode() if payload is not None else b""
+    if message_type == "exception":
+        # Real exception frames carry a camelCase :exception-type and no :event-type.
+        return _encode({":message-type": "exception", ":exception-type": event_type}, data)
     return _encode({":event-type": event_type, ":message-type": message_type}, data)
 
 
@@ -567,21 +581,13 @@ class TestChatStream:
         with pytest.raises(ProviderError):
             list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
 
-    def test_stream_exception_frame(self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
-        content = _frame("contentBlockDelta", {"delta": {"text": "Hi"}, "contentBlockIndex": 0}) + _frame(
-            "throttlingException", {"message": "slow down"}, message_type="exception"
-        )
-        respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=content))
-        with pytest.raises(ProviderError, match="slow down"):
-            list(sync_provider.chat_stream(MODEL, [UserMessage(content="Hi")]))
-
-    def test_exception_frame_maps_to_typed_error(
+    def test_stream_exception_frame_maps_to_typed_error(
         self, sync_provider: BedrockProvider, respx_mock: respx.MockRouter
     ) -> None:
         # A real exception frame carries a camelCase :exception-type and no :event-type; it must both
         # avoid a KeyError on :event-type and classify to the typed error (RateLimitError here).
-        content = _encode(
-            {":message-type": "exception", ":exception-type": "throttlingException"}, b'{"message": "slow down"}'
+        content = _frame("contentBlockDelta", {"delta": {"text": "Hi"}, "contentBlockIndex": 0}) + _frame(
+            "throttlingException", {"message": "slow down"}, message_type="exception"
         )
         respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=content))
         with pytest.raises(RateLimitError, match="slow down"):
@@ -638,12 +644,14 @@ class TestAchatStream:
             async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass  # pragma: no cover
 
-    async def test_exception_frame(self, async_provider: BedrockProvider, respx_mock: respx.MockRouter) -> None:
+    async def test_exception_frame_maps_to_typed_error(
+        self, async_provider: BedrockProvider, respx_mock: respx.MockRouter
+    ) -> None:
         content = _frame("contentBlockDelta", {"delta": {"text": "Hi"}, "contentBlockIndex": 0}) + _frame(
             "validationException", {"message": "invalid"}, message_type="exception"
         )
         respx_mock.post(_url(MODEL, "converse-stream")).mock(return_value=httpx.Response(200, content=content))
-        with pytest.raises(ProviderError, match="invalid"):
+        with pytest.raises(InvalidRequestError, match="invalid"):
             async for _ in async_provider.achat_stream(MODEL, [UserMessage(content="Hi")]):
                 pass
 
@@ -939,9 +947,21 @@ class TestBearerAuth:
         route = respx_mock.post(_url(MODEL, "converse", base=base)).mock(
             return_value=httpx.Response(200, json=converse_response)
         )
-        provider = BedrockProvider(region="eu-central-1")
+        provider = BedrockProvider(auth=FakeAuth(), region="eu-central-1")
         provider.chat(MODEL, [UserMessage(content="Hi")])
         assert route.called
+
+    def test_bearer_token_survives_unconstructable_session(
+        self, converse_response: dict[str, Any], respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bt-secret")
+        route = _ok_converse(converse_response, respx_mock)  # default us-east-1 endpoint
+        # A stale AWS_PROFILE makes boto3.Session() raise at construction; bearer mode must not fail —
+        # it falls back to the default region since it never needs the session.
+        provider = BedrockProvider(auth=_RaisingSessionAuth())
+        result = provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result.content == "Hello!"
+        assert route.calls.last.request.headers["authorization"] == "Bearer bt-secret"
 
 
 # MARK: Register Pricing

--- a/packages/lmux-aws-bedrock/tests/test_sigv4.py
+++ b/packages/lmux-aws-bedrock/tests/test_sigv4.py
@@ -1,0 +1,58 @@
+"""Regression tests for the vendored SigV4 signer.
+
+The golden signatures below were validated for byte-parity against
+``botocore.auth.SigV4Auth`` during the SDK-lite PoC; they guard against
+regressions without pulling botocore into the test path.
+"""
+
+import datetime
+
+from lmux_aws_bedrock._sigv4 import sign
+
+_NOW = datetime.datetime(2026, 7, 11, 12, 0, 0, tzinfo=datetime.UTC)
+
+
+def _sign(url: str, body: bytes, token: str | None) -> dict[str, str]:
+    return sign(
+        method="POST", url=url, headers={"Content-Type": "application/json"}, body=body,
+        access_key="AKIDEXAMPLE", secret_key="SECRETKEY", region="us-east-1",  # noqa: S106
+        service="bedrock", now=_NOW, session_token=token,
+    )  # fmt: skip
+
+
+def _signature(signed: dict[str, str]) -> str:
+    return signed["Authorization"].split("Signature=")[1]
+
+
+class TestSigV4Signature:
+    def test_with_session_token(self) -> None:
+        url = "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2/invoke"
+        assert (
+            _signature(_sign(url, b'{"x":1}', "TOKEN"))
+            == "d29aa3fe44b845ce1c56a8a0c15fe8f395e4478c7aca3fd8aa9352b9073c0564"
+        )
+
+    def test_without_session_token(self) -> None:
+        url = "https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse"
+        assert (
+            _signature(_sign(url, b'{"a":2}', None))
+            == "ab3e75faeaa140ce4b34217725698bf637ee92c316cc89ea4b17b668044ce409"
+        )
+
+
+class TestSigV4Output:
+    def test_headers_added_no_token(self) -> None:
+        signed = _sign("https://host.example.com/path", b"{}", None)
+        assert signed["X-Amz-Date"] == "20260711T120000Z"
+        assert signed["Authorization"].startswith(
+            "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20260711/us-east-1/bedrock/aws4_request"
+        )
+        assert "X-Amz-Security-Token" not in signed
+
+    def test_session_token_header(self) -> None:
+        assert _sign("https://host.example.com/path", b"{}", "TT")["X-Amz-Security-Token"] == "TT"
+
+    def test_root_path_and_query_branches(self) -> None:
+        # empty path -> "/" canonical uri; query present -> non-empty canonical query
+        assert "Authorization" in _sign("https://host.example.com", b"", None)
+        assert "Authorization" in _sign("https://host.example.com/p?b=2&a=1", b"", None)

--- a/uv.lock
+++ b/uv.lock
@@ -700,6 +700,7 @@ version = "0.9.1"
 source = { editable = "packages/lmux-aws-bedrock" }
 dependencies = [
     { name = "boto3" },
+    { name = "httpx" },
     { name = "lmux" },
 ]
 
@@ -712,6 +713,7 @@ async = [
 requires-dist = [
     { name = "aiobotocore", marker = "extra == 'async'", specifier = "~=3.3.0" },
     { name = "boto3", specifier = ">=1.42.31,<2" },
+    { name = "httpx", specifier = "~=0.28" },
     { name = "lmux", editable = "packages/lmux" },
 ]
 provides-extras = ["async"]


### PR DESCRIPTION
Converts the AWS Bedrock provider off boto3's client to a direct httpx transport, completing the SDK-lite conversion across all providers (#91, #92, #94, #97, #99).

- **SDK-lite**: httpx for the Converse and InvokeModel calls, with a vendored SigV4 signer and event-stream decoder; boto3 is kept only to resolve AWS credentials and never sits in the request path.
- **Auth**: SigV4 with credentials frozen per request (a refreshable source keeps signing after token expiry), plus `AWS_BEARER_TOKEN_BEDROCK` bearer mode; the region is resolved from the configured session in both modes.
- **Wire models**: the Converse response and streaming events parse into validated Pydantic models.
- **Streaming**: converse-stream is decoded incrementally with CRC-validated frames; mid-stream exception frames map to the typed error hierarchy (`ThrottlingException` → `RateLimitError`, etc.).
- **Config**: `use_fips` targets the FIPS endpoint; `timeout`/`max_retries` are exposed.
