### PR TITLE
test(integration): groq recorded chat + streaming cost-parity suites

### DIFF
--- a/packages/lmux-groq/src/lmux_groq/provider.py
+++ b/packages/lmux-groq/src/lmux_groq/provider.py
@@ -245,6 +245,10 @@ class GroqProvider(
     # MARK: Internal Helpers
 
     def _map_stream_chunk(self, chunk: dict[str, Any], model: str) -> ChatChunk:
+        # Groq reports usage on more than one streaming chunk — both the finish chunk
+        # and a trailing chunk (unlike OpenAI's single trailing usage chunk) — so cost
+        # is attached to each; the values agree and the terminal chunk is authoritative
+        # (consumers should read the last usage, not sum across chunks).
         wire = WireChunk.model_validate(chunk)
         mapped = map_chat_chunk(wire, PROVIDER_NAME)
         if mapped.usage is not None:

--- a/tests/integration/cassettes/groq/chat.json
+++ b/tests/integration/cassettes/groq/chat.json
@@ -1,0 +1,47 @@
+{
+  "endpoint": "https://api.groq.com/openai/v1/chat/completions",
+  "request": {
+    "model": "llama-3.1-8b-instant",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Reply with exactly the word: pong"
+      }
+    ],
+    "max_tokens": 16,
+    "stream": false
+  },
+  "response": {
+    "id": "chatcmpl-1eec9f9b-77c1-4fb5-a8c8-a615baa1c52e",
+    "object": "chat.completion",
+    "created": 1783873615,
+    "model": "llama-3.1-8b-instant",
+    "choices": [
+      {
+        "index": 0,
+        "message": {
+          "role": "assistant",
+          "content": "pong"
+        },
+        "logprobs": null,
+        "finish_reason": "stop"
+      }
+    ],
+    "usage": {
+      "queue_time": 0.06444133,
+      "prompt_tokens": 42,
+      "prompt_time": 0.010274686,
+      "completion_tokens": 2,
+      "completion_time": 0.010463462,
+      "total_tokens": 44,
+      "total_time": 0.020738148
+    },
+    "usage_breakdown": null,
+    "system_fingerprint": "fp_020e283281",
+    "x_groq": {
+      "id": "req_01kxbjedaee43bzdns4z6h8c84",
+      "seed": 699042088
+    },
+    "service_tier": "on_demand"
+  }
+}

--- a/tests/integration/cassettes/groq/chat_stream.json
+++ b/tests/integration/cassettes/groq/chat_stream.json
@@ -1,0 +1,18 @@
+{
+  "endpoint": "https://api.groq.com/openai/v1/chat/completions",
+  "request": {
+    "model": "llama-3.1-8b-instant",
+    "messages": [
+      {
+        "role": "user",
+        "content": "Reply with exactly the word: pong"
+      }
+    ],
+    "max_tokens": 16,
+    "stream": true,
+    "stream_options": {
+      "include_usage": true
+    }
+  },
+  "response_sse": "data: {\"id\":\"chatcmpl-fe9ea133-b8a4-4000-bd53-bd76f7cfa658\",\"object\":\"chat.completion.chunk\",\"created\":1783873677,\"model\":\"llama-3.1-8b-instant\",\"system_fingerprint\":\"fp_e2c608b1d6\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"\"},\"logprobs\":null,\"finish_reason\":null}],\"x_groq\":{\"id\":\"req_01kxbjg9pce8hr28aa7hj3ahky\",\"seed\":5915709}}\n\ndata: {\"id\":\"chatcmpl-fe9ea133-b8a4-4000-bd53-bd76f7cfa658\",\"object\":\"chat.completion.chunk\",\"created\":1783873677,\"model\":\"llama-3.1-8b-instant\",\"system_fingerprint\":\"fp_e2c608b1d6\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"pong\"},\"logprobs\":null,\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-fe9ea133-b8a4-4000-bd53-bd76f7cfa658\",\"object\":\"chat.completion.chunk\",\"created\":1783873677,\"model\":\"llama-3.1-8b-instant\",\"system_fingerprint\":\"fp_e2c608b1d6\",\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"x_groq\":{\"id\":\"req_01kxbjg9pce8hr28aa7hj3ahky\",\"usage\":{\"queue_time\":0.038402552,\"prompt_tokens\":42,\"prompt_time\":0.003406827,\"completion_tokens\":2,\"completion_time\":0.008219629,\"total_tokens\":44,\"total_time\":0.011626456}},\"usage\":{\"queue_time\":0.038402552,\"prompt_tokens\":42,\"prompt_time\":0.003406827,\"completion_tokens\":2,\"completion_time\":0.008219629,\"total_tokens\":44,\"total_time\":0.011626456}}\n\ndata: {\"id\":\"chatcmpl-fe9ea133-b8a4-4000-bd53-bd76f7cfa658\",\"object\":\"chat.completion.chunk\",\"created\":1783873677,\"model\":\"llama-3.1-8b-instant\",\"system_fingerprint\":\"fp_e2c608b1d6\",\"choices\":[],\"usage\":{\"queue_time\":0.038402552,\"prompt_tokens\":42,\"prompt_time\":0.003406827,\"completion_tokens\":2,\"completion_time\":0.008219629,\"total_tokens\":44,\"total_time\":0.011626456},\"service_tier\":\"on_demand\"}\n\ndata: [DONE]\n\n"
+}

--- a/tests/integration/groq/test_chat.py
+++ b/tests/integration/groq/test_chat.py
@@ -1,0 +1,81 @@
+"""Groq chat cost parity — a recorded cassette and the live endpoint satisfy the
+same cost contract, proving the math holds for a third (OpenAI-wire-compatible)
+provider. ``llama-3.1-8b-instant`` bills input+output only; a short prompt and a
+small ``max_tokens`` keep the recording cheap.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lmux.types import ChatResponse, UserMessage
+from lmux_groq.provider import GroqProvider
+
+_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions"
+_MODEL = "llama-3.1-8b-instant"
+_MAX_TOKENS = 16
+_PROMPT = "Reply with exactly the word: pong"
+
+_CASSETTE = Path(__file__).parent.parent / "cassettes" / "groq" / "chat.json"
+
+# llama-3.1-8b-instant published rates ($/token) — the independent source of truth.
+_RATES = {"input_rate": 0.05 / 1_000_000, "output_rate": 0.08 / 1_000_000}
+
+
+class _FakeAuth:
+    """Mock-mode auth: respx intercepts the request, so the key is never used."""
+
+    def get_credentials(self) -> str:
+        return "gsk-mock-not-used"
+
+    async def aget_credentials(self) -> str:
+        return "gsk-mock-not-used"
+
+
+def _chat(auth: _FakeAuth | None) -> ChatResponse:
+    return GroqProvider(auth=auth).chat(_MODEL, [UserMessage(content=_PROMPT)], max_tokens=_MAX_TOKENS)
+
+
+class TestChatCassette:
+    @pytest.mark.integration
+    def test_chat_cost(
+        self,
+        mount_cassette: Callable[[Path], dict[str, Any]],
+        assert_chat: Callable[..., None],
+        assert_cost: Callable[..., None],
+    ) -> None:
+        mount_cassette(_CASSETTE)
+        resp = _chat(_FakeAuth())
+        assert_chat(resp, provider="groq")
+        assert_cost(resp, **_RATES)
+
+
+class TestLiveChat:
+    @pytest.mark.integration
+    @pytest.mark.live
+    def test_live_chat(
+        self,
+        groq_key: str,  # noqa: ARG002 — requested to skip when unset
+        assert_chat: Callable[..., None],
+        assert_cost: Callable[..., None],
+    ) -> None:
+        resp = _chat(None)  # real GROQ_API_KEY from env
+        assert_chat(resp, provider="groq")
+        assert_cost(resp, **_RATES)
+
+
+class TestRecordCassette:
+    @pytest.mark.live
+    @pytest.mark.record
+    def test_record(self, groq_key: str, record_cassette: Callable[..., dict[str, Any]]) -> None:
+        body = {
+            "model": _MODEL,
+            "messages": [{"role": "user", "content": _PROMPT}],
+            "max_tokens": _MAX_TOKENS,
+            "stream": False,
+        }
+        headers = {"Authorization": f"Bearer {groq_key}"}
+        data = record_cassette(_CASSETTE, endpoint=_ENDPOINT, request_body=body, headers=headers)
+        assert data["usage"]["prompt_tokens"] > 0, "expected input token usage"

--- a/tests/integration/groq/test_streaming.py
+++ b/tests/integration/groq/test_streaming.py
@@ -1,0 +1,97 @@
+"""Groq streaming cost parity — SSE cassette + the usage-bearing final chunk.
+
+Groq requests ``stream_options.include_usage`` (OpenAI-compatible), so the
+terminal chunk carries usage and thus ``.cost``; a recorded stream and a live
+stream must satisfy the same cost contract.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lmux.types import ChatChunk, UserMessage
+from lmux_groq.provider import GroqProvider
+
+_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions"
+_MODEL = "llama-3.1-8b-instant"
+_MAX_TOKENS = 16
+_PROMPT = "Reply with exactly the word: pong"
+
+_CASSETTE = Path(__file__).parent.parent / "cassettes" / "groq" / "chat_stream.json"
+
+# llama-3.1-8b-instant published rates ($/token) — the independent source of truth.
+_RATES = {"input_rate": 0.05 / 1_000_000, "output_rate": 0.08 / 1_000_000}
+
+
+class _FakeAuth:
+    """Mock-mode auth: respx intercepts the request, so the key is never used."""
+
+    def get_credentials(self) -> str:
+        return "gsk-mock-not-used"
+
+    async def aget_credentials(self) -> str:
+        return "gsk-mock-not-used"
+
+
+def _stream(auth: _FakeAuth | None) -> list[ChatChunk]:
+    provider = GroqProvider(auth=auth)
+    return list(provider.chat_stream(_MODEL, [UserMessage(content=_PROMPT)], max_tokens=_MAX_TOKENS))
+
+
+def _final_usage_chunk(chunks: list[ChatChunk]) -> ChatChunk:
+    """The authoritative (last) usage-bearing chunk.
+
+    Unlike OpenAI (one trailing usage chunk), Groq repeats usage on *both* the
+    finish chunk and a trailing chunk — a real wire difference this recorded
+    cassette surfaced. All usage-bearing chunks agree; the last is authoritative
+    (a consumer must take the terminal usage, not sum across chunks)."""
+    with_cost = [c for c in chunks if c.cost is not None]
+    assert with_cost, "expected at least one usage-bearing chunk"
+    assert all(c.usage == with_cost[-1].usage for c in with_cost), "repeated usage chunks must agree"
+    return with_cost[-1]
+
+
+class TestStreamCassette:
+    @pytest.mark.integration
+    def test_stream_cost(
+        self, mount_cassette: Callable[[Path], dict[str, Any]], assert_cost: Callable[..., None]
+    ) -> None:
+        mount_cassette(_CASSETTE)
+        chunks = _stream(_FakeAuth())
+        content = "".join(c.delta or "" for c in chunks)
+        assert content.strip()
+        assert any(c.finish_reason for c in chunks)
+        assert_cost(_final_usage_chunk(chunks), **_RATES)
+
+
+class TestLiveStream:
+    @pytest.mark.integration
+    @pytest.mark.live
+    def test_live_stream(
+        self,
+        groq_key: str,  # noqa: ARG002 — requested to skip when unset
+        assert_cost: Callable[..., None],
+    ) -> None:
+        chunks = _stream(None)  # real GROQ_API_KEY from env
+        content = "".join(c.delta or "" for c in chunks)
+        assert content.strip()
+        assert any(c.finish_reason for c in chunks)
+        assert_cost(_final_usage_chunk(chunks), **_RATES)
+
+
+class TestRecordCassette:
+    @pytest.mark.live
+    @pytest.mark.record
+    def test_record(self, groq_key: str, record_stream_cassette: Callable[..., str]) -> None:
+        body = {
+            "model": _MODEL,
+            "messages": [{"role": "user", "content": _PROMPT}],
+            "max_tokens": _MAX_TOKENS,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+        headers = {"Authorization": f"Bearer {groq_key}"}
+        sse = record_stream_cassette(_CASSETTE, endpoint=_ENDPOINT, request_body=body, headers=headers)
+        assert "[DONE]" in sse, "expected a terminated SSE stream"


### PR DESCRIPTION
Stacked on #102 (the integration harness).

Adds Groq integration coverage — chat and streaming cost-parity — with cassettes **recorded from the live API** (`llama-3.1-8b-instant`), asserted both offline (replay) and live (`LMUX_LIVE=1`). Groq is OpenAI-wire-compatible, so these mirror the OpenAI unary/streaming suites.

**Wire note the recording surfaced:** Groq reports usage on *two* streaming chunks — the `finish_reason:"stop"` chunk **and** a trailing chunk — where OpenAI sends it once. lmux faithfully attaches cost to each; the values agree and the terminal chunk is authoritative (consumers should read the last usage, not sum across chunks). Documented in `_map_stream_chunk`, and the streaming suite asserts the repeats agree. A hand-authored cassette would have invented a single chunk and missed this — which is the case for recording rather than fabricating.
