### PR TITLE
Populate Usage.reasoning_tokens for Anthropic extended thinking

### DIFF
--- a/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
@@ -43,6 +43,7 @@ from lmux_anthropic._wire import (
     WireMessage,
     WireMessageDeltaEvent,
     WireMessageStartEvent,
+    WireOutputTokensDetails,
     WireTextBlock,
     WireTextDelta,
     WireThinkingBlock,
@@ -328,7 +329,13 @@ def _map_usage(usage: WireUsage) -> Usage:
         cache_read_tokens=cache_read or None,
         cache_creation_tokens=cache_creation or None,
         cache_creation_tokens_by_ttl=_map_cache_creation_breakdown(usage.cache_creation),
+        reasoning_tokens=_thinking_tokens(usage.output_tokens_details),
     )
+
+
+def _thinking_tokens(details: WireOutputTokensDetails | None) -> int | None:
+    """Extended-thinking tokens (a subset of output_tokens), or None when absent/zero."""
+    return (details.thinking_tokens if details else None) or None
 
 
 def _map_cache_creation_breakdown(cache_creation: WireCacheCreation | None) -> dict[str, int] | None:
@@ -404,4 +411,5 @@ def _map_delta_usage(delta_usage: WireDeltaUsage, start_usage: Usage) -> Usage:
         cache_read_tokens=start_usage.cache_read_tokens,
         cache_creation_tokens=start_usage.cache_creation_tokens,
         cache_creation_tokens_by_ttl=start_usage.cache_creation_tokens_by_ttl,
+        reasoning_tokens=_thinking_tokens(delta_usage.output_tokens_details),
     )

--- a/packages/lmux-anthropic/src/lmux_anthropic/_wire.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_wire.py
@@ -18,18 +18,27 @@ class WireCacheCreation(BaseModel):
     ephemeral_1h_input_tokens: int | None = None
 
 
+class WireOutputTokensDetails(BaseModel):
+    """Breakdown of ``output_tokens``; ``thinking_tokens`` is the extended-thinking subset."""
+
+    thinking_tokens: int | None = None
+
+
 class WireUsage(BaseModel):
     input_tokens: int
     output_tokens: int
     cache_read_input_tokens: int | None = None
     cache_creation_input_tokens: int | None = None
     cache_creation: WireCacheCreation | None = None
+    output_tokens_details: WireOutputTokensDetails | None = None
 
 
 class WireDeltaUsage(BaseModel):
-    """The message_delta ``usage`` object carries only output tokens; input usage came in message_start."""
+    """The message_delta ``usage`` object carries output tokens (and their thinking breakdown);
+    input usage came in message_start."""
 
     output_tokens: int
+    output_tokens_details: WireOutputTokensDetails | None = None
 
 
 # MARK: Content blocks (response ``content[]`` and content_block_start)

--- a/packages/lmux-anthropic/tests/test_mappers.py
+++ b/packages/lmux-anthropic/tests/test_mappers.py
@@ -708,6 +708,29 @@ class TestMapMessageResponse:
         assert result.usage is not None
         assert result.usage.cache_creation_tokens_by_ttl is None
 
+    def test_thinking_tokens_populate_reasoning(self) -> None:
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Hello"}],
+            "usage": self._usage(output_tokens=140, output_tokens_details={"thinking_tokens": 121}),
+        }
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", lambda _m, _u: None)
+        assert result.usage is not None
+        assert result.usage.output_tokens == 140  # includes the thinking subset
+        assert result.usage.reasoning_tokens == 121
+
+    def test_zero_thinking_tokens_is_none(self) -> None:
+        message = {
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "end_turn",
+            "content": [{"type": "text", "text": "Hello"}],
+            "usage": self._usage(output_tokens_details={"thinking_tokens": 0}),
+        }
+        result = map_message_response(WireMessage.model_validate(message), "anthropic", lambda _m, _u: None)
+        assert result.usage is not None
+        assert result.usage.reasoning_tokens is None
+
 
 class TestMapMessageStart:
     def test_extracts_model_and_usage(self) -> None:
@@ -804,6 +827,18 @@ class TestMapMessageDelta:
             cache_creation_tokens=2000,
             cache_creation_tokens_by_ttl={"1h": 2000},
         )
+
+    def test_delta_usage_carries_thinking_tokens(self) -> None:
+        start_usage = Usage(input_tokens=51, output_tokens=0)
+        event = {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn"},
+            "usage": {"output_tokens": 66, "output_tokens_details": {"thinking_tokens": 51}},
+        }
+        chunk = map_message_delta(WireMessageDeltaEvent.model_validate(event), start_usage)
+        assert chunk.usage is not None
+        assert chunk.usage.output_tokens == 66  # includes the thinking subset
+        assert chunk.usage.reasoning_tokens == 51
 
 
 class TestMapToolChoice:

--- a/tests/integration/anthropic/test_thinking.py
+++ b/tests/integration/anthropic/test_thinking.py
@@ -33,4 +33,7 @@ def test_thinking(
     assert_chat(resp, provider="anthropic")
     assert resp.reasoning
     assert "391" in resp.content  # the thinking produced the correct answer (17 * 23)
+    assert resp.usage is not None
+    assert resp.usage.reasoning_tokens is not None
+    assert resp.usage.reasoning_tokens > 0  # thinking tokens surfaced (subset of output_tokens)
     assert_cost(resp, **_RATES)


### PR DESCRIPTION
Populates `Usage.reasoning_tokens` for the Anthropic provider's extended thinking — it was always `None` even when the API reported the count, unlike OpenAI and Gemini.

- Parse `output_tokens_details.thinking_tokens` from both the non-streaming response and the streaming `message_delta`, and set `reasoning_tokens` (a subset of `output_tokens`; `0`/absent → `None`, matching the OpenAI convention).
- Cost is unaffected — thinking is already billed within `output_tokens`.

Closes #105.