### PR TITLE
Bump versions for the SDK-lite release

### DIFF
--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-anthropic"
-version = "0.10.0"
+version = "0.11.0"
 description = "Anthropic provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-aws-bedrock/pyproject.toml
+++ b/packages/lmux-aws-bedrock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-aws-bedrock"
-version = "0.9.1"
+version = "0.10.0"
 description = "AWS Bedrock provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-google/pyproject.toml
+++ b/packages/lmux-google/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-google"
-version = "0.8.1"
+version = "0.9.0"
 description = "Google (Gemini) provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-groq/pyproject.toml
+++ b/packages/lmux-groq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-groq"
-version = "0.5.0"
+version = "0.6.0"
 description = "Groq provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-load-balancer/pyproject.toml
+++ b/packages/lmux-load-balancer/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-load-balancer"
-version = "0.1.0"
+version = "0.1.1"
 description = "Weighted, sticky load balancing across lmux providers, with failover"
 requires-python = ">=3.13"
 license = "MIT"
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "lmux~=0.9",
+  "lmux~=0.10",
 ]
 
 [project.urls]

--- a/packages/lmux-openai/pyproject.toml
+++ b/packages/lmux-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-openai"
-version = "0.7.0"
+version = "0.8.0"
 description = "OpenAI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -674,7 +674,7 @@ requires-dist = [{ name = "pydantic", specifier = "~=2.10" }]
 
 [[package]]
 name = "lmux-anthropic"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "packages/lmux-anthropic" }
 dependencies = [
     { name = "httpx" },
@@ -696,7 +696,7 @@ provides-extras = ["vertex"]
 
 [[package]]
 name = "lmux-aws-bedrock"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "packages/lmux-aws-bedrock" }
 dependencies = [
     { name = "boto3" },
@@ -753,7 +753,7 @@ requires-dist = [{ name = "lmux-google", editable = "packages/lmux-google" }]
 
 [[package]]
 name = "lmux-google"
-version = "0.8.1"
+version = "0.9.0"
 source = { editable = "packages/lmux-google" }
 dependencies = [
     { name = "google-auth" },
@@ -770,7 +770,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-groq"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/lmux-groq" }
 dependencies = [
     { name = "httpx" },
@@ -785,7 +785,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-load-balancer"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/lmux-load-balancer" }
 dependencies = [
     { name = "lmux" },
@@ -796,7 +796,7 @@ requires-dist = [{ name = "lmux", editable = "packages/lmux" }]
 
 [[package]]
 name = "lmux-openai"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "packages/lmux-openai" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Version bumps to release the SDK-lite conversion (minor bumps — httpx transport + `transport`/`async_transport` injection; public API otherwise unchanged).

- `lmux-openai` 0.7.0 → 0.8.0
- `lmux-anthropic` 0.10.0 → 0.11.0
- `lmux-aws-bedrock` 0.9.1 → 0.10.0
- `lmux-google` 0.8.1 → 0.9.0
- `lmux-groq` 0.5.0 → 0.6.0
- `lmux-load-balancer` 0.1.0 → 0.1.1 — raises its `lmux` pin `~=0.9` → `~=0.10` so it stays installable alongside the new providers (no code change)

Core `lmux` is already at 0.10.0 and releases first. `lmux-azure-foundry` is **held** — its SDK-lite conversion isn't integration-tested yet (blocked on Azure access). `lmux-gcp-vertex` is the deprecated shim.