### PR TITLE
feat: case-insensitive pricing resolver and provider pricing refresh

### DIFF
--- a/.agents/skills/update-pricing/SKILL.md
+++ b/.agents/skills/update-pricing/SKILL.md
@@ -26,20 +26,47 @@ already validated via `lmux-google`.
 
 Build a list of `(provider_name, cost_py_path, pricing_url)` tuples.
 
-### Step 2: Select providers
-
-Create the scratch output directory:
-
-```
-tmp/update-pricing/YYYY-MM-DD/
-```
-
-Use today's date. If the directory already exists from a prior run, files will
-be overwritten.
+### Step 2: Select providers and reserve an isolated run directory
 
 Present a multi-select form to the user using `AskUserQuestion` listing all
 discovered providers. All providers should be selected by default. The user can
 deselect providers they don't want to check.
+
+After provider selection, determine a stable lowercase, kebab-case
+`runner_slug` for the coding agent coordinating the run:
+
+- Codex: `codex`
+- Claude Code: `claude`
+- Other coding agents: their short product name (for example, `cursor`)
+
+Use the coordinating agent's identity, not a provider subagent's identity. All
+subagents launched by one invocation MUST share the same runner slug and run
+directory.
+
+Capture the local date and time once at the start of the run as `RUN_DATE`
+(`YYYY-MM-DD`) and `RUN_TIME` (`HHMMSS`). Do not recalculate either value
+later, including if the run crosses midnight.
+
+Atomically reserve a new scratch directory under:
+
+```
+tmp/update-pricing/<RUN_DATE>/<runner-slug>/<RUN_TIME>/
+```
+
+For example, concurrent runs may use
+`tmp/update-pricing/2026-07-15/codex/091145/` and
+`tmp/update-pricing/2026-07-15/claude/091146/`. Create the date and runner
+parents if needed, then reserve the time directory with an atomic create. If
+that exact time directory already exists, NEVER reuse or overwrite it.
+Atomically try `<RUN_TIME>-2`, then `<RUN_TIME>-3`, and so on until
+directory creation succeeds. Do not use a separate existence check followed by
+creation, because concurrent invocations of the same coding agent can start in
+the same second. Only parent creation may use `mkdir -p`; reserve each
+candidate time directory with plain `mkdir` so the create itself is the
+collision check.
+
+Call the successfully reserved path `RUN_DIR` and use it unchanged for the
+rest of the workflow.
 
 ### Step 3: Launch parallel subagents
 
@@ -52,7 +79,9 @@ Each agent MUST receive the following in its prompt:
 3. The pricing source URL
 4. The complete "Subagent Instructions" section below (copy it verbatim)
 5. The complete "Report Format" section below (copy it verbatim)
-6. The scratch output path: `tmp/update-pricing/YYYY-MM-DD/<provider>.md`
+6. The runner slug, `RUN_DATE`, `RUN_TIME`, `RUN_DIR`, exact report path
+   `<RUN_DIR>/<provider>.md`, and provider work directory
+   `<RUN_DIR>/work/<provider>/` (call this `WORK_DIR`)
 7. If the provider has a subsection under "Provider-specific instructions"
    below, copy that subsection verbatim too — it overrides the generic
    instructions where they conflict
@@ -62,13 +91,24 @@ Each agent MUST:
 1. Read the provider's `cost.py` file
 2. Use the web to retrieve the pricing page
 3. Compare every model and price in the cost.py against the source
-4. Write a detailed findings report to the scratch file
-5. Return ONLY a single-line summary (no other output)
+4. Create its assigned provider work directory, then keep every downloaded
+   page, browser capture, API response, generated diff, stdout/stderr capture,
+   and other intermediate artifact inside it
+5. Write a detailed findings report to the exact report path
+6. Return ONLY a single-line summary (no other output)
+
+Never assign the same report path or `WORK_DIR` to two live subagents. If a
+provider must be retried, wait for or stop the first attempt, then allocate
+new `<provider>-retry-N.md` and `work/<provider>-retry-N/` paths. Preserve
+the first attempt for diagnosis and record which retry report is authoritative.
 
 ### Step 4: Review findings
 
-After ALL agents complete, read each `tmp/update-pricing/YYYY-MM-DD/<provider>.md`
-file. Present a consolidated summary to the user showing:
+After ALL agents complete, read each `<RUN_DIR>/<provider>.md` file. Do not
+discover reports by taking the newest date directory or globbing across sibling
+runner directories; another coding agent may be writing there concurrently.
+Present a consolidated summary to the user, including the exact `RUN_DIR`,
+showing:
 
 - Which providers have discrepancies
 - Which providers have new models available
@@ -80,16 +120,23 @@ file. Present a consolidated summary to the user showing:
 Do NOT automatically apply changes. Ask the user whether to proceed. If
 approved:
 
-1. Update each provider's `cost.py` with corrected prices and new models
-2. Follow existing code patterns exactly:
+1. Re-read every target `cost.py` and confirm it is identical to the version
+   the corresponding subagent audited. Also confirm repository `HEAD` has not
+   moved. If either changed, STOP and reconcile the newer state before editing.
+   Never apply a report against stale source.
+2. Do not enter this mutation phase concurrently with another pricing run in
+   the same worktree. Audits may run concurrently because their `RUN_DIR`
+   values are isolated; tracked-file updates may not.
+3. Update each provider's `cost.py` with corrected prices and new models
+4. Follow existing code patterns exactly:
    - Use `per_million_tokens()` for all per-token prices
    - Maintain alphabetical grouping by model family with comment headers
    - Maintain the `_PRICING_BY_PREFIX` sorted list after `_PRICING`
    - Keep multi-tier pricing for providers that use it (anthropic, google)
    - Keep `cache_creation_cost_per_token` for anthropic models
    - Preserve multiplier constants and `apply_cost_multiplier()` functions
-3. Run verification per AGENTS.md
-4. Fix any issues and re-run verification until all four checks pass
+5. Run verification per AGENTS.md
+6. Fix any issues and re-run verification until all four checks pass
 
 ---
 
@@ -99,13 +146,14 @@ Some pricing pages (notably GCP Vertex AI) are too large for `WebFetch` to
 return in full — it truncates before reaching partner/embedding model sections.
 
 For these pages, subagents should use `curl` via Bash to download the full HTML
-to a temp file, then extract relevant sections with `sed`/`grep`/`python`. For
-example:
+inside their assigned `WORK_DIR`, then extract relevant sections with
+`sed`/`grep`/`python`. Never use a shared path in `/tmp` or the repository
+root. For example:
 
 ```bash
-curl -s 'https://cloud.google.com/vertex-ai/generative-ai/pricing' > /tmp/vertex-pricing.html
+curl -s 'https://cloud.google.com/vertex-ai/generative-ai/pricing' > "{WORK_DIR}/vertex-pricing.html"
 # Extract partner models section (Claude, Mistral, Llama, etc.)
-sed -n '28100,28800p' /tmp/vertex-pricing.html | python3 -c "
+sed -n '28100,28800p' "{WORK_DIR}/vertex-pricing.html" | python3 -c "
 import sys, html, re
 content = sys.stdin.read()
 content = re.sub(r'<tr[^>]*>', '\n|ROW|', content)
@@ -151,7 +199,7 @@ Prefer **structured data over scraping pixels**, in this order:
    playwright-cli open '<pricing_url>'
    # click any toggle that reveals more columns/rows first, e.g.:
    #   playwright-cli find "Long context"; playwright-cli click <ref>
-   playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('table')].map(t=>({head:[...t.querySelectorAll('tr:first-child th')].map(c=>c.textContent.trim()),rows:[...t.querySelectorAll('tbody tr')].map(r=>[...r.querySelectorAll('th,td')].map(c=>c.textContent.trim()))})))" > tables.json
+   playwright-cli --raw eval "JSON.stringify([...document.querySelectorAll('table')].map(t=>({head:[...t.querySelectorAll('tr:first-child th')].map(c=>c.textContent.trim()),rows:[...t.querySelectorAll('tbody tr')].map(r=>[...r.querySelectorAll('th,td')].map(c=>c.textContent.trim()))})))" > "{WORK_DIR}/tables.json"
    playwright-cli close
    ```
 
@@ -270,9 +318,12 @@ You are a pricing validation subagent for the **{provider}** provider.
 5. Check for any pricing complexities (regional differences, deployment-type
    multipliers, tiered pricing) that the code doesn't handle. Report these
    in "Caveats".
-6. Write your findings to the scratch file path provided using the exact
-   report format below.
-7. Return ONLY a single-line summary in one of these formats:
+6. Keep every local intermediate artifact in the assigned `WORK_DIR`. Do not
+   write generic filenames in the repository root or shared `/tmp`, and do
+   not read artifacts from a sibling runner directory.
+7. Write your findings only to the exact report path provided. Do not select or
+   reuse a sibling runner directory. Use the exact report format below.
+8. Return ONLY a single-line summary in one of these formats:
    - `"openai: 3 price updates, 2 new models"`
    - `"anthropic: all 14 models verified"`
    - `"aws-bedrock: FETCH_FAILED — could not retrieve pricing page"`
@@ -290,17 +341,20 @@ that the code doesn't account for, report it in Caveats.
 
 ## Report Format
 
-Write findings to `tmp/update-pricing/YYYY-MM-DD/{provider}.md` using exactly
-this format:
+Write findings to `{RUN_DIR}/{provider}.md` using exactly this format:
 
 ```markdown
 # Status: {DISCREPANCIES_FOUND | ALL_VERIFIED | FETCH_FAILED | PARTIAL_VERIFICATION}
 
 # Provider: {provider-name}
 
+# Runner: {runner-slug}
+
+# Run directory: {RUN_DIR}
+
 # Pricing source: {url}
 
-# Date: {YYYY-MM-DD}
+# Date: {RUN_DATE}
 
 # Models checked: {N}
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For fine-grained control, use provider-specific params instead (e.g., `Anthropic
 
 ### Cost
 
-Every response includes a `.cost` field when the model's pricing is known. Unknown models return `None`, not an error. Built-in pricing is matched by longest key prefix — case-insensitively for every provider except AWS Bedrock — so dated or capitalized model ids (e.g. `gpt-4o-2024-11-20`, `Cohere-command-a`) resolve to their family's rate.
+Every response includes a `.cost` field when the model's pricing is known. Unknown models return `None`, not an error.
 
 Register custom pricing for models not in the built-in tables:
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ For fine-grained control, use provider-specific params instead (e.g., `Anthropic
 
 ### Cost
 
-Every response includes a `.cost` field when the model's pricing is known. Unknown models return `None`, not an error.
+Every response includes a `.cost` field when the model's pricing is known. Unknown models return `None`, not an error. Built-in pricing is matched by longest key prefix — case-insensitively for every provider except AWS Bedrock — so dated or capitalized model ids (e.g. `gpt-4o-2024-11-20`, `Cohere-command-a`) resolve to their family's rate.
 
 Register custom pricing for models not in the built-in tables:
 

--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-anthropic"
-version = "0.11.0"
+version = "0.12.0"
 description = "Anthropic provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "lmux~=0.10",
+  "lmux~=0.11",
   "httpx~=0.28",
 ]
 

--- a/packages/lmux-anthropic/src/lmux_anthropic/cost.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/cost.py
@@ -18,7 +18,15 @@ premium as US_INFERENCE_MULTIPLIER.
 
 from datetime import date
 
-from lmux.cost import ModelPricing, PricingSchedule, PricingTier, calculate_cost, per_million_tokens
+from lmux.cost import (
+    ModelPricing,
+    PricingSchedule,
+    PricingTier,
+    build_pricing_index,
+    calculate_cost,
+    per_million_tokens,
+    resolve_pricing,
+)
 from lmux.types import Cost, Usage
 
 # Standard (global) pricing. Cache writes default to the 5-minute rate (1.25x
@@ -268,7 +276,8 @@ _PRICING: dict[str, ModelPricing] = {
     ),
 }
 
-_PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
+# Case-insensitive, longest-prefix index (see lmux.cost.resolve_pricing).
+_PRICING_BY_PREFIX = build_pricing_index(_PRICING)
 
 US_INFERENCE_MULTIPLIER = 1.1
 
@@ -315,8 +324,9 @@ def has_vertex_regional_premium(model: str) -> bool:
     Unknown models default to True — the premium applies to all models newer
     than the fixed set of exempt older models.
     """
+    model_lower = model.lower()
     for prefix, premium in _VERTEX_PREMIUM_BY_PREFIX:
-        if model.startswith(prefix):
+        if model_lower.startswith(prefix):
             return premium
     return True
 
@@ -328,12 +338,7 @@ def calculate_anthropic_cost(model: str, usage: Usage, as_of: date | None = None
     (e.g. Claude Sonnet 5's introductory period); it defaults to the latest
     schedule. See ``lmux.cost.calculate_cost``.
     """
-    pricing = _PRICING.get(model)
-    if pricing is None:
-        for prefix, p in _PRICING_BY_PREFIX:
-            if model.startswith(prefix):
-                pricing = p
-                break
+    pricing = resolve_pricing(model, _PRICING_BY_PREFIX)
     if pricing is None:
         return None
     return calculate_cost(usage, pricing, as_of)

--- a/packages/lmux-anthropic/tests/test_cost.py
+++ b/packages/lmux-anthropic/tests/test_cost.py
@@ -80,6 +80,15 @@ class TestCalculateAnthropicCost:
         # Both are $15 input, so same price, but they should resolve to different prefixes
         assert cost_41.input_cost == cost_4.input_cost
 
+    def test_case_insensitive_lookup(self) -> None:
+        """A capitalized model id resolves identically to its lowercase form."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        upper = calculate_anthropic_cost("Claude-Sonnet-4-6", usage)
+        lower = calculate_anthropic_cost("claude-sonnet-4-6", usage)
+        assert upper is not None
+        assert lower is not None
+        assert upper.total_cost == pytest.approx(lower.total_cost)
+
     def test_long_context_pricing_at_high_token_count(self) -> None:
         """Claude Sonnet 4 uses long-context pricing above 200K input tokens."""
         usage = Usage(input_tokens=250_000, output_tokens=1000)
@@ -176,3 +185,8 @@ class TestHasVertexRegionalPremium:
 
     def test_unknown_future_models_default_to_premium(self) -> None:
         assert has_vertex_regional_premium("claude-sonnet-6") is True
+
+    def test_case_insensitive(self) -> None:
+        """Premium classification folds case, like the pricing lookup."""
+        assert has_vertex_regional_premium("Claude-Opus-4-8") is True
+        assert has_vertex_regional_premium("CLAUDE-3-5-HAIKU") is False

--- a/packages/lmux-azure-foundry/pyproject.toml
+++ b/packages/lmux-azure-foundry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-azure-foundry"
-version = "0.8.0"
+version = "0.9.0"
 description = "Azure AI Foundry provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "lmux~=0.10",
+  "lmux~=0.11",
   "httpx~=0.28",
 ]
 

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
@@ -711,8 +711,10 @@ _PRICING: dict[str, ModelPricing] = {
     ),
     # --- MoonshotAI Kimi. Runtime `model` ids per the Azure model catalog are Kimi-K2.5 /
     # Kimi-K2.6 / Kimi-K2.7-Code (the "FW-"/"FW Kimi" form is only the Fireworks billing meter,
-    # not the deployable id). Azure publishes only Data Zone meters; the base rates below are the
-    # DZ meter / 1.1 (the DATA_ZONE_MULTIPLIER applied at runtime reconstructs the DZ price). ---
+    # not the deployable id). Azure offers these only as Data Zone deployments; the base rates below
+    # are the DZ meter / 1.1, keeping the base-is-global convention used by every other model. Pass
+    # deployment_type="data_zone" to bill the exact DZ rate — the default, unqualified call
+    # deliberately under-reports ~9% (there is no global tier to fall back to). ---
     "Kimi-K2.5": ModelPricing(
         tiers=[
             PricingTier(

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
@@ -12,7 +12,14 @@ Models pages, e.g. https://azure.microsoft.com/en-us/pricing/details/ai-foundry-
 swap the trailing path segment for the vendor (/deepseek, /grok, /llama, /mistral-ai, /cohere, /kimi).
 """
 
-from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
+from lmux.cost import (
+    ModelPricing,
+    PricingTier,
+    build_pricing_index,
+    calculate_cost,
+    per_million_tokens,
+    resolve_pricing,
+)
 from lmux.types import Cost, Usage
 
 # MARK: Deployment-type multipliers
@@ -63,6 +70,72 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(0.40),
                 cache_read_cost_per_token=per_million_tokens(0.005),
             )
+        ],
+    ),
+    # --- OpenAI: GPT-5.6 family (sol/terra/luna) ---
+    # Azure had not published gpt-5.6 retail meters at the time of writing (GA on Azure but
+    # unpriced), so these mirror OpenAI's Global Standard rates, which Azure AOAI meters match
+    # for every other GPT-5.x model. Cache-write is intentionally omitted: Azure does not meter
+    # cache writes for any AOAI model (unlike OpenAI, which bills gpt-5.6+ cache writes). Replace
+    # with the -glbl meters once Azure publishes them. The bare "gpt-5.6" alias routes to Sol.
+    "gpt-5.6": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(30.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(10.00),
+                output_cost_per_token=per_million_tokens(45.00),
+                cache_read_cost_per_token=per_million_tokens(1.00),
+                min_input_tokens=272_000,
+            ),
+        ],
+    ),
+    "gpt-5.6-sol": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(30.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(10.00),
+                output_cost_per_token=per_million_tokens(45.00),
+                cache_read_cost_per_token=per_million_tokens(1.00),
+                min_input_tokens=272_000,
+            ),
+        ],
+    ),
+    "gpt-5.6-terra": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.50),
+                output_cost_per_token=per_million_tokens(15.00),
+                cache_read_cost_per_token=per_million_tokens(0.25),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(22.50),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+                min_input_tokens=272_000,
+            ),
+        ],
+    ),
+    "gpt-5.6-luna": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.00),
+                output_cost_per_token=per_million_tokens(6.00),
+                cache_read_cost_per_token=per_million_tokens(0.10),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.00),
+                output_cost_per_token=per_million_tokens(9.00),
+                cache_read_cost_per_token=per_million_tokens(0.20),
+                min_input_tokens=272_000,
+            ),
         ],
     ),
     # --- OpenAI: GPT-5.5 family ---
@@ -168,6 +241,16 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    # gpt-5.2-pro is ~12x gpt-5.2 on Azure and has no cached-input meter; explicit key
+    # stops it inheriting the far cheaper "gpt-5.2" prefix (and its spurious cache rate).
+    "gpt-5.2-pro": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(21.00),
+                output_cost_per_token=per_million_tokens(168.00),
+            )
+        ],
+    ),
     "gpt-5.2-chat": ModelPricing(
         tiers=[
             PricingTier(
@@ -239,6 +322,16 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    # Preview chat alias (replacement for the retired gpt-5.1/5.2/5.3-chat models).
+    "gpt-chat-latest": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(30.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+            )
+        ],
+    ),
     # --- OpenAI: GPT-4.1 family ---
     "gpt-4.1": ModelPricing(
         tiers=[
@@ -293,6 +386,16 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(15.00),
                 output_cost_per_token=per_million_tokens(60.00),
                 cache_read_cost_per_token=per_million_tokens(7.50),
+            )
+        ],
+    ),
+    # o1-pro is 10x o1 on Azure; explicit key stops it inheriting the cheaper "o1" prefix.
+    "o1-pro": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(150.00),
+                output_cost_per_token=per_million_tokens(600.00),
+                cache_read_cost_per_token=per_million_tokens(75.00),
             )
         ],
     ),
@@ -424,6 +527,7 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(1.74),
                 output_cost_per_token=per_million_tokens(3.48),
+                cache_read_cost_per_token=per_million_tokens(0.145),
             )
         ],
     ),
@@ -432,6 +536,7 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.19),
                 output_cost_per_token=per_million_tokens(0.51),
+                cache_read_cost_per_token=per_million_tokens(0.028),
             )
         ],
     ),
@@ -469,6 +574,17 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     "grok-4-fast": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.20),
+                output_cost_per_token=per_million_tokens(0.50),
+            )
+        ],
+    ),
+    # "Grok 4.1 Fast" GA (replaces the retired grok-4-fast). Runtime ids are the dash form
+    # grok-4-1-fast-reasoning / grok-4-1-fast-non-reasoning, which the dot-form "grok-4.1" key
+    # never matches; without this key they fall through to "grok-4" (3/15) and overcharge ~30x.
+    "grok-4-1-fast": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.20),
@@ -534,6 +650,25 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    # Mistral-Large-3 — same Global Standard rate as the family; explicit key documents the
+    # current GA id (matched case-insensitively, so casing here is cosmetic).
+    "Mistral-Large-3": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.50),
+                output_cost_per_token=per_million_tokens(1.50),
+            )
+        ],
+    ),
+    # Mistral Medium 3.5 (Preview). Billed via the "MM3.5" Global meter (0.0015/0.0075 per 1K).
+    "mistral-medium-3-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.50),
+                output_cost_per_token=per_million_tokens(7.50),
+            )
+        ],
+    ),
     "codestral": ModelPricing(
         tiers=[
             PricingTier(
@@ -551,8 +686,18 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
-    # --- Cohere ---
-    "cohere-command-a": ModelPricing(
+    # --- Cohere. Lookup is case-insensitive, so the base id resolves regardless of Azure's
+    # runtime casing. "Cohere-command-a-plus" is a version-agnostic prefix so future dated
+    # snapshots keep the Plus rate instead of falling through to the (pricier) base key. ---
+    "Cohere-command-a-plus": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.80),
+                output_cost_per_token=per_million_tokens(3.20),
+            )
+        ],
+    ),
+    "Cohere-command-a": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(2.50),
@@ -560,8 +705,43 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
-    # --- Phi (Microsoft). Keys match Azure's response `model` casing (capitalized), unlike the
-    # lowercase DeepSeek/Grok/etc. keys; the cost lookup is case-sensitive. ---
+    # Cohere Embed v4 text-input rate; image-input is metered separately and not modeled.
+    "embed-v-4-0": ModelPricing(
+        tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.12), output_cost_per_token=0.0)]
+    ),
+    # --- MoonshotAI Kimi. Runtime `model` ids per the Azure model catalog are Kimi-K2.5 /
+    # Kimi-K2.6 / Kimi-K2.7-Code (the "FW-"/"FW Kimi" form is only the Fireworks billing meter,
+    # not the deployable id). Azure publishes only Data Zone meters; the base rates below are the
+    # DZ meter / 1.1 (the DATA_ZONE_MULTIPLIER applied at runtime reconstructs the DZ price). ---
+    "Kimi-K2.5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.60),
+                output_cost_per_token=per_million_tokens(3.00),
+                cache_read_cost_per_token=per_million_tokens(0.10),
+            )
+        ],
+    ),
+    "Kimi-K2.6": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.95),
+                output_cost_per_token=per_million_tokens(4.00),
+                cache_read_cost_per_token=per_million_tokens(0.16),
+            )
+        ],
+    ),
+    "Kimi-K2.7-Code": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.95),
+                output_cost_per_token=per_million_tokens(4.00),
+                cache_read_cost_per_token=per_million_tokens(0.19),
+            )
+        ],
+    ),
+    # --- Phi (Microsoft). Keys mirror Azure's `model` casing for readability; lookup is
+    # case-insensitive (see resolve_pricing), so the capitalization here is cosmetic. ---
     "Phi-4-mini-reasoning": ModelPricing(
         tiers=[
             PricingTier(
@@ -614,18 +794,21 @@ _PRICING: dict[str, ModelPricing] = {
     ),
 }
 
-# Pre-sorted by key length descending for longest-prefix matching
-_PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
+# Case-insensitive, longest-prefix index. Azure's `model` casing varies by vendor
+# (capital Cohere/Phi/Mistral/Kimi ids, lowercase deepseek/grok/gpt), so lookup folds case.
+_PRICING_BY_PREFIX = build_pricing_index(_PRICING)
+
+# Known Azure models with no published Global Standard rate (e.g. the grok-4-20 Preview
+# variants). Returning None is correct — do NOT let them fall through to a broad prefix
+# (e.g. "grok-4") and inherit a fabricated rate. Add real rates once Azure publishes meters.
+_UNPRICED_MODELS = frozenset({"grok-4-20-reasoning", "grok-4-20-non-reasoning"})
 
 
 def calculate_azure_foundry_cost(model: str, usage: Usage) -> Cost | None:
     """Calculate cost for an Azure AI Foundry API call. Returns None if model pricing is unknown."""
-    pricing = _PRICING.get(model)
-    if pricing is None:
-        for prefix, p in _PRICING_BY_PREFIX:
-            if model.startswith(prefix):
-                pricing = p
-                break
+    if model.lower() in _UNPRICED_MODELS:
+        return None
+    pricing = resolve_pricing(model, _PRICING_BY_PREFIX)
     if pricing is None:
         return None
     return calculate_cost(usage, pricing)

--- a/packages/lmux-azure-foundry/tests/test_cost.py
+++ b/packages/lmux-azure-foundry/tests/test_cost.py
@@ -92,12 +92,163 @@ class TestCalculateAzureFoundryCost:
         assert cost.input_cost == pytest.approx(0.50)
         assert cost.output_cost == pytest.approx(1.50)
 
-    def test_cohere_model(self) -> None:
+    @pytest.mark.parametrize("model", ["Cohere-command-a", "cohere-command-a", "COHERE-COMMAND-A"])
+    def test_cohere_command_a_case_insensitive(self, model: str) -> None:
+        # Lookup is case-insensitive, so the base id prices regardless of Azure's runtime casing.
         usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
-        cost = calculate_azure_foundry_cost("cohere-command-a", usage)
+        cost = calculate_azure_foundry_cost(model, usage)
         assert cost is not None
         assert cost.input_cost == pytest.approx(2.50)
         assert cost.output_cost == pytest.approx(10.00)
+
+    @pytest.mark.parametrize("model", ["Cohere-command-a-plus-05-2026", "Cohere-command-a-plus-06-2026"])
+    def test_cohere_command_a_plus_version_agnostic(self, model: str) -> None:
+        # Any dated Plus snapshot must keep the Plus rate, not fall through to the pricier base.
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        cost = calculate_azure_foundry_cost(model, usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(0.80)
+        assert cost.output_cost == pytest.approx(3.20)
+
+    def test_embed_v4(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=0)
+        cost = calculate_azure_foundry_cost("embed-v-4-0", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(0.12)
+        assert cost.output_cost == 0.0
+
+    def test_mistral_large_3_capitalized(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        cost = calculate_azure_foundry_cost("Mistral-Large-3", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(0.50)
+        assert cost.output_cost == pytest.approx(1.50)
+
+    def test_mistral_medium_3_5(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        cost = calculate_azure_foundry_cost("mistral-medium-3-5", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1.50)
+        assert cost.output_cost == pytest.approx(7.50)
+
+    @pytest.mark.parametrize(
+        ("model", "input_rate", "output_rate", "cache_rate"),
+        [
+            ("Kimi-K2.5", 0.60, 3.00, 0.10),
+            ("Kimi-K2.6", 0.95, 4.00, 0.16),
+            ("Kimi-K2.7-Code", 0.95, 4.00, 0.19),
+        ],
+    )
+    def test_kimi_family(self, model: str, input_rate: float, output_rate: float, cache_rate: float) -> None:
+        rates = calculate_azure_foundry_cost(model, Usage(input_tokens=1_000_000, output_tokens=1_000_000))
+        cache = calculate_azure_foundry_cost(
+            model, Usage(input_tokens=1_000_000, output_tokens=0, cache_read_tokens=1_000_000)
+        )
+        assert rates is not None
+        assert cache is not None
+        assert rates.input_cost == pytest.approx(input_rate)
+        assert rates.output_cost == pytest.approx(output_rate)
+        assert cache.cache_read_cost == pytest.approx(cache_rate)
+
+    def test_o1_pro_not_o1_prefix(self) -> None:
+        """o1-pro must use its own 10x rate, not inherit the cheaper o1 prefix."""
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        pro = calculate_azure_foundry_cost("o1-pro", usage)
+        base = calculate_azure_foundry_cost("o1", usage)
+        assert pro is not None
+        assert base is not None
+        assert pro.input_cost == pytest.approx(150.00)
+        assert pro.output_cost == pytest.approx(600.00)
+        assert pro.input_cost > base.input_cost
+        cache = calculate_azure_foundry_cost(
+            "o1-pro", Usage(input_tokens=1_000_000, output_tokens=0, cache_read_tokens=1_000_000)
+        )
+        assert cache is not None
+        assert cache.cache_read_cost == pytest.approx(75.00)
+
+    def test_gpt_5_2_pro_not_gpt_5_2_prefix(self) -> None:
+        """gpt-5.2-pro uses its own ~12x rate with no cache meter, not the gpt-5.2 prefix."""
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        cost = calculate_azure_foundry_cost("gpt-5.2-pro", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(21.00)
+        assert cost.output_cost == pytest.approx(168.00)
+
+    def test_gpt_chat_latest(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        cost = calculate_azure_foundry_cost("gpt-chat-latest", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(5.00)
+        assert cost.output_cost == pytest.approx(30.00)
+
+    def test_grok_4_1_fast_dash_ids(self) -> None:
+        """Dash-form grok-4-1-fast-* ids match grok-4-1-fast (0.20/0.50), not grok-4 (3/15)."""
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        for model in ("grok-4-1-fast-reasoning", "grok-4-1-fast-non-reasoning"):
+            cost = calculate_azure_foundry_cost(model, usage)
+            assert cost is not None
+            assert cost.input_cost == pytest.approx(0.20)
+            assert cost.output_cost == pytest.approx(0.50)
+
+    def test_grok_4_20_preview_unpriced_returns_none(self) -> None:
+        """grok-4-20-* Preview ids have no published rate and must return None, not fall through to grok-4."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        assert calculate_azure_foundry_cost("grok-4-20-reasoning", usage) is None
+        assert calculate_azure_foundry_cost("grok-4-20-non-reasoning", usage) is None
+
+    def test_deepseek_v4_cache_reads(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=0, cache_read_tokens=1_000_000)
+        flash = calculate_azure_foundry_cost("deepseek-v4-flash", usage)
+        pro = calculate_azure_foundry_cost("deepseek-v4-pro", usage)
+        assert flash is not None
+        assert pro is not None
+        assert flash.cache_read_cost == pytest.approx(0.028)
+        assert pro.cache_read_cost == pytest.approx(0.145)
+
+    @pytest.mark.parametrize(
+        ("model", "base_rates", "hi_rates"),
+        [
+            ("gpt-5.6-sol", (5.00, 30.00, 0.50), (10.00, 45.00, 1.00)),
+            ("gpt-5.6-terra", (2.50, 15.00, 0.25), (5.00, 22.50, 0.50)),
+            ("gpt-5.6-luna", (1.00, 6.00, 0.10), (2.00, 9.00, 0.20)),
+        ],
+    )
+    def test_gpt_5_6_family_mirrors_openai_without_cache_write(
+        self,
+        model: str,
+        base_rates: tuple[float, float, float],
+        hi_rates: tuple[float, float, float],
+    ) -> None:
+        """Azure gpt-5.6-* mirror OpenAI input/output/cache-read on both tiers but bill no cache write."""
+        in_base, out_base, cr_base = base_rates
+        in_hi, out_hi, cr_hi = hi_rates
+        base = calculate_azure_foundry_cost(
+            model, Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=100, cache_creation_tokens=200)
+        )
+        assert base is not None
+        assert base.input_cost == pytest.approx((1000 - 100 - 200) * in_base / 1_000_000)
+        assert base.output_cost == pytest.approx(500 * out_base / 1_000_000)
+        assert base.cache_read_cost == pytest.approx(100 * cr_base / 1_000_000)
+        assert base.cache_creation_cost == pytest.approx(0.0)  # Azure meters no cache write for AOAI
+        hi = calculate_azure_foundry_cost(model, Usage(input_tokens=300_000, output_tokens=1000))
+        assert hi is not None
+        assert hi.input_cost == pytest.approx(300_000 * in_hi / 1_000_000)
+        assert hi.output_cost == pytest.approx(1000 * out_hi / 1_000_000)
+        cache_hi = calculate_azure_foundry_cost(
+            model, Usage(input_tokens=300_000, output_tokens=0, cache_read_tokens=300_000)
+        )
+        assert cache_hi is not None
+        assert cache_hi.cache_read_cost == pytest.approx(300_000 * cr_hi / 1_000_000)
+
+    def test_gpt_5_6_bare_alias_matches_sol(self) -> None:
+        """The bare gpt-5.6 alias resolves to Sol rates, not the gpt-5 prefix (1.25/10)."""
+        usage = Usage(input_tokens=100_000, output_tokens=100_000)
+        bare = calculate_azure_foundry_cost("gpt-5.6", usage)
+        sol = calculate_azure_foundry_cost("gpt-5.6-sol", usage)
+        assert bare is not None
+        assert sol is not None
+        assert bare.input_cost == pytest.approx(100_000 * 5.00 / 1_000_000)
+        assert bare.total_cost == pytest.approx(sol.total_cost)
 
     def test_grok_4_2_corrected_pricing(self) -> None:
         usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)

--- a/packages/lmux-azure-foundry/tests/test_cost.py
+++ b/packages/lmux-azure-foundry/tests/test_cost.py
@@ -134,6 +134,7 @@ class TestCalculateAzureFoundryCost:
     @pytest.mark.parametrize(
         ("model", "input_rate", "output_rate", "cache_rate"),
         [
+            # Base is DZ meter / 1.1 (base-is-global convention); DZ deployments reconstruct the DZ rate.
             ("Kimi-K2.5", 0.60, 3.00, 0.10),
             ("Kimi-K2.6", 0.95, 4.00, 0.16),
             ("Kimi-K2.7-Code", 0.95, 4.00, 0.19),

--- a/packages/lmux-google/pyproject.toml
+++ b/packages/lmux-google/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-google"
-version = "0.9.0"
+version = "0.10.0"
 description = "Google (Gemini) provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "lmux~=0.10",
+  "lmux~=0.11",
   "httpx~=0.28",
   "google-auth~=2.0",
 ]

--- a/packages/lmux-google/src/lmux_google/cost.py
+++ b/packages/lmux-google/src/lmux_google/cost.py
@@ -79,7 +79,7 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    # Image-output models (gemini-*-image) are intentionally NOT priced — see _UNPRICED_MODELS
+    # Image-output models (gemini-*-image) are intentionally NOT priced — see _UNPRICED_IMAGE_PREFIXES
     # below. Google bills generated-image output far higher than text output ($30-$120/M vs
     # $1.50-$12/M), which a single output rate cannot represent, so they return None.
     "gemini-3-flash-preview": ModelPricing(
@@ -174,7 +174,7 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # ── Google Gemini (additional) ────────────────────────────
-    # gemini-2.5-flash-image is intentionally unpriced (see _UNPRICED_MODELS) — its image output
+    # gemini-2.5-flash-image is intentionally unpriced (see _UNPRICED_IMAGE_PREFIXES) — its image output
     # is billed far above the modeled text-output rate.
     # Robotics-ER 1.6: text/image/video input $1; audio input ($2) is higher and not modeled.
     "gemini-robotics-er-1.6-preview": ModelPricing(
@@ -256,26 +256,24 @@ _PRICING: dict[str, ModelPricing] = {
 # Case-insensitive, longest-prefix index (see lmux.cost.resolve_pricing).
 _PRICING_BY_PREFIX = build_pricing_index(_PRICING)
 
-# Image-output models: Google bills generated-image output tokens far higher than text output
-# (e.g. $30-$120/M vs $1.50-$12/M), but the provider collapses all output into one token count,
-# so a single output rate would underprice image generation ~10-20x. Return None (unknown) rather
-# than a confidently-wrong cost until modality-aware costing exists. (Checked case-insensitively.)
-_UNPRICED_MODELS = frozenset(
-    {
-        "gemini-2.5-flash-image",
-        "gemini-3.1-flash-image",
-        "gemini-3.1-flash-image-preview",
-        "gemini-3.1-flash-lite-image",
-        "gemini-3.1-flash-lite-image-preview",
-        "gemini-3-pro-image",
-        "gemini-3-pro-image-preview",
-    }
+# Image-output model families: Google bills generated-image output tokens far higher than text
+# output (e.g. $30-$120/M vs $1.50-$12/M), but the provider collapses all output into one token
+# count, so a single output rate would underprice image generation ~10-20x. Return None (unknown)
+# rather than a confidently-wrong cost until modality-aware costing exists. Matched as *prefixes*
+# (case-insensitively) so every dated/`-preview` variant — e.g. gemini-2.5-flash-image-preview — is
+# covered, not just the bare id; a bare prefix would otherwise fall through to the text-priced base.
+_UNPRICED_IMAGE_PREFIXES = (
+    "gemini-2.5-flash-image",
+    "gemini-3.1-flash-image",
+    "gemini-3.1-flash-lite-image",
+    "gemini-3-pro-image",
 )
 
 
 def calculate_google_cost(model: str, usage: Usage) -> Cost | None:
     """Calculate cost for a Google API call. Returns None if model pricing is unknown."""
-    if model.lower() in _UNPRICED_MODELS:
+    model_lower = model.lower()
+    if any(model_lower.startswith(prefix) for prefix in _UNPRICED_IMAGE_PREFIXES):
         return None
     pricing = resolve_pricing(model, _PRICING_BY_PREFIX)
     if pricing is None:

--- a/packages/lmux-google/src/lmux_google/cost.py
+++ b/packages/lmux-google/src/lmux_google/cost.py
@@ -5,7 +5,14 @@ the Gemini Developer API paid tier uses the same per-token rates.
 Pricing source: https://cloud.google.com/vertex-ai/generative-ai/pricing
 """
 
-from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
+from lmux.cost import (
+    ModelPricing,
+    PricingTier,
+    build_pricing_index,
+    calculate_cost,
+    per_million_tokens,
+    resolve_pricing,
+)
 from lmux.types import Cost, Usage
 
 _PRICING: dict[str, ModelPricing] = {
@@ -52,6 +59,17 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    # GA IDs and their shut-down -preview aliases share the same base rates. The
+    # -preview keys are retained for historical cost lookups; new calls use the GA ids.
+    "gemini-3.1-flash-lite": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.25),
+                output_cost_per_token=per_million_tokens(1.50),
+                cache_read_cost_per_token=per_million_tokens(0.025),
+            ),
+        ],
+    ),
     "gemini-3.1-flash-lite-preview": ModelPricing(
         tiers=[
             PricingTier(
@@ -61,31 +79,9 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    "gemini-3.1-flash-image-preview": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(0.50),
-                output_cost_per_token=per_million_tokens(3.00),
-            ),
-        ],
-    ),
-    # Text I/O rates only; image-output tokens are billed separately and not modeled.
-    "gemini-3.1-flash-lite-image-preview": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(0.25),
-                output_cost_per_token=per_million_tokens(1.50),
-            ),
-        ],
-    ),
-    "gemini-3-pro-image-preview": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(2.0),
-                output_cost_per_token=per_million_tokens(12.0),
-            ),
-        ],
-    ),
+    # Image-output models (gemini-*-image) are intentionally NOT priced — see _UNPRICED_MODELS
+    # below. Google bills generated-image output far higher than text output ($30-$120/M vs
+    # $1.50-$12/M), which a single output rate cannot represent, so they return None.
     "gemini-3-flash-preview": ModelPricing(
         tiers=[
             PricingTier(
@@ -178,15 +174,20 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # ── Google Gemini (additional) ────────────────────────────
-    "gemini-2.5-flash-image": ModelPricing(
+    # gemini-2.5-flash-image is intentionally unpriced (see _UNPRICED_MODELS) — its image output
+    # is billed far above the modeled text-output rate.
+    # Robotics-ER 1.6: text/image/video input $1; audio input ($2) is higher and not modeled.
+    "gemini-robotics-er-1.6-preview": ModelPricing(
         tiers=[
             PricingTier(
-                input_cost_per_token=per_million_tokens(0.30),
-                output_cost_per_token=per_million_tokens(2.50),
+                input_cost_per_token=per_million_tokens(1.00),
+                output_cost_per_token=per_million_tokens(5.00),
             ),
         ],
     ),
-    "gemini-2.5-pro-computer-use-preview": ModelPricing(
+    # Real runtime id is gemini-2.5-computer-use-preview-10-2025 (not "...-pro-...");
+    # base rate <=200k, premium rate >200k, no context caching.
+    "gemini-2.5-computer-use-preview-10-2025": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(1.25),
@@ -200,6 +201,16 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # ── Embedding models ───────────────────────────────────────
+    # Text-input rate only; image/audio/video embedding inputs are billed at separate
+    # rates not modeled by the text embedding path. The -preview key is retained for history.
+    "gemini-embedding-2": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.20),
+                output_cost_per_token=0.0,
+            ),
+        ],
+    ),
     "gemini-embedding-2-preview": ModelPricing(
         tiers=[
             PricingTier(
@@ -242,18 +253,31 @@ _PRICING: dict[str, ModelPricing] = {
     ),
 }
 
-# Pre-sorted by key length descending for prefix matching (longest match first)
-_PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
+# Case-insensitive, longest-prefix index (see lmux.cost.resolve_pricing).
+_PRICING_BY_PREFIX = build_pricing_index(_PRICING)
+
+# Image-output models: Google bills generated-image output tokens far higher than text output
+# (e.g. $30-$120/M vs $1.50-$12/M), but the provider collapses all output into one token count,
+# so a single output rate would underprice image generation ~10-20x. Return None (unknown) rather
+# than a confidently-wrong cost until modality-aware costing exists. (Checked case-insensitively.)
+_UNPRICED_MODELS = frozenset(
+    {
+        "gemini-2.5-flash-image",
+        "gemini-3.1-flash-image",
+        "gemini-3.1-flash-image-preview",
+        "gemini-3.1-flash-lite-image",
+        "gemini-3.1-flash-lite-image-preview",
+        "gemini-3-pro-image",
+        "gemini-3-pro-image-preview",
+    }
+)
 
 
 def calculate_google_cost(model: str, usage: Usage) -> Cost | None:
     """Calculate cost for a Google API call. Returns None if model pricing is unknown."""
-    pricing = _PRICING.get(model)
-    if pricing is None:
-        for prefix, p in _PRICING_BY_PREFIX:
-            if model.startswith(prefix):
-                pricing = p
-                break
+    if model.lower() in _UNPRICED_MODELS:
+        return None
+    pricing = resolve_pricing(model, _PRICING_BY_PREFIX)
     if pricing is None:
         return None
     return calculate_cost(usage, pricing)

--- a/packages/lmux-google/tests/test_cost.py
+++ b/packages/lmux-google/tests/test_cost.py
@@ -147,16 +147,19 @@ class TestCalculateGoogleCost:
         [
             "gemini-2.5-flash-image",
             "gemini-3.1-flash-image",
-            "gemini-3.1-flash-image-preview",
             "gemini-3.1-flash-lite-image",
-            "gemini-3.1-flash-lite-image-preview",
             "gemini-3-pro-image",
+            # -preview and dated variants must also be caught (prefix sentinel), or they would
+            # fall through to a text-priced base (e.g. gemini-2.5-flash) and mis-report image gen.
+            "gemini-2.5-flash-image-preview",
+            "gemini-3.1-flash-image-preview",
             "gemini-3-pro-image-preview",
+            "gemini-3-pro-image-001",
         ],
     )
     def test_image_output_models_unpriced(self, model: str) -> None:
-        """Image-output models return None: their image output is billed far above the text rate,
-        which a single output rate would underprice ~10-20x. Checked case-insensitively too."""
+        """Image-output models (and their dated/-preview variants) return None: image output is
+        billed far above the text rate, which a single output rate would underprice ~10-20x."""
         usage = Usage(input_tokens=1000, output_tokens=500)
         assert calculate_google_cost(model, usage) is None
         assert calculate_google_cost(model.upper(), usage) is None

--- a/packages/lmux-google/tests/test_cost.py
+++ b/packages/lmux-google/tests/test_cost.py
@@ -69,16 +69,16 @@ class TestCalculateGoogleCost:
         be non-zero.
         """
         usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=200)
-        cost = calculate_google_cost("gemini-2.5-pro-computer-use-preview", usage)
+        cost = calculate_google_cost("gemini-2.5-computer-use-preview-10-2025", usage)
         assert cost is not None
         assert cost.input_cost == pytest.approx((1000 - 200) * 1.25 / 1_000_000)
         assert cost.output_cost == pytest.approx(500 * 10.00 / 1_000_000)
         assert cost.cache_read_cost == pytest.approx(0.0)
 
     def test_computer_use_long_context_tier(self) -> None:
-        """gemini-2.5-pro-computer-use-preview uses the >200K tier above 200K input tokens."""
+        """gemini-2.5-computer-use-preview-10-2025 uses the >200K tier above 200K input tokens."""
         usage = Usage(input_tokens=250_000, output_tokens=1000)
-        cost = calculate_google_cost("gemini-2.5-pro-computer-use-preview", usage)
+        cost = calculate_google_cost("gemini-2.5-computer-use-preview-10-2025", usage)
         assert cost is not None
         assert cost.input_cost == pytest.approx(250_000 * 2.50 / 1_000_000)
         assert cost.output_cost == pytest.approx(1000 * 15.00 / 1_000_000)
@@ -98,8 +98,78 @@ class TestCalculateGoogleCost:
         assert cost_flash is not None
         assert cost_lite.input_cost < cost_flash.input_cost
 
+    def test_case_insensitive_lookup(self) -> None:
+        """A capitalized model id resolves identically to its lowercase form."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        upper = calculate_google_cost("GEMINI-2.5-PRO", usage)
+        lower = calculate_google_cost("gemini-2.5-pro", usage)
+        assert upper is not None
+        assert lower is not None
+        assert upper.total_cost == pytest.approx(lower.total_cost)
+
     def test_partner_model_not_priced(self) -> None:
         """Partner models (Claude, Mistral, ...) are not servable by this provider, so they have no pricing."""
         usage = Usage(input_tokens=1000, output_tokens=500)
         assert calculate_google_cost("claude-sonnet-4-6", usage) is None
         assert calculate_google_cost("mistral-medium-3", usage) is None
+
+    def test_computer_use_real_id_priced_at_base_rate(self) -> None:
+        """The real computer-use id resolves to the dedicated (no-cache) rate.
+
+        The old mis-named key gemini-2.5-pro-computer-use-preview was never a real runtime id;
+        it now harmlessly prefix-matches gemini-2.5-pro, so it is not asserted here.
+        """
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        real = calculate_google_cost("gemini-2.5-computer-use-preview-10-2025", usage)
+        assert real is not None
+        assert real.input_cost == pytest.approx(1000 * 1.25 / 1_000_000)
+        assert real.output_cost == pytest.approx(500 * 10.00 / 1_000_000)
+
+    @pytest.mark.parametrize(
+        ("ga", "preview", "input_rate"),
+        [
+            ("gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview", 0.25),
+            ("gemini-embedding-2", "gemini-embedding-2-preview", 0.20),
+        ],
+    )
+    def test_ga_ids_match_shutdown_previews_and_pin_rate(self, ga: str, preview: str, input_rate: float) -> None:
+        """GA ids resolve to the same rates as their shut-down -preview aliases, pinned to reality."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        ga_cost = calculate_google_cost(ga, usage)
+        preview_cost = calculate_google_cost(preview, usage)
+        assert ga_cost is not None
+        assert preview_cost is not None
+        assert ga_cost.input_cost == pytest.approx(1000 * input_rate / 1_000_000)
+        assert ga_cost.total_cost == pytest.approx(preview_cost.total_cost)
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini-2.5-flash-image",
+            "gemini-3.1-flash-image",
+            "gemini-3.1-flash-image-preview",
+            "gemini-3.1-flash-lite-image",
+            "gemini-3.1-flash-lite-image-preview",
+            "gemini-3-pro-image",
+            "gemini-3-pro-image-preview",
+        ],
+    )
+    def test_image_output_models_unpriced(self, model: str) -> None:
+        """Image-output models return None: their image output is billed far above the text rate,
+        which a single output rate would underprice ~10-20x. Checked case-insensitively too."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        assert calculate_google_cost(model, usage) is None
+        assert calculate_google_cost(model.upper(), usage) is None
+
+    def test_robotics_er_priced(self) -> None:
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        cost = calculate_google_cost("gemini-robotics-er-1.6-preview", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1000 * 1.00 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 5.00 / 1_000_000)
+
+    def test_gemini_3_1_flash_lite_cache_rate(self) -> None:
+        usage = Usage(input_tokens=1000, output_tokens=0, cache_read_tokens=500)
+        cost = calculate_google_cost("gemini-3.1-flash-lite", usage)
+        assert cost is not None
+        assert cost.cache_read_cost == pytest.approx(500 * 0.025 / 1_000_000)

--- a/packages/lmux-groq/pyproject.toml
+++ b/packages/lmux-groq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-groq"
-version = "0.6.0"
+version = "0.7.0"
 description = "Groq provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "lmux~=0.10",
+  "lmux~=0.11",
   "httpx~=0.28",
 ]
 

--- a/packages/lmux-groq/src/lmux_groq/cost.py
+++ b/packages/lmux-groq/src/lmux_groq/cost.py
@@ -3,7 +3,14 @@
 Pricing source: https://groq.com/pricing/
 """
 
-from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
+from lmux.cost import (
+    ModelPricing,
+    PricingTier,
+    build_pricing_index,
+    calculate_cost,
+    per_million_tokens,
+    resolve_pricing,
+)
 from lmux.types import Cost, Usage
 
 _PRICING: dict[str, ModelPricing] = {
@@ -22,6 +29,7 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.075),
                 output_cost_per_token=per_million_tokens(0.30),
+                cache_read_cost_per_token=per_million_tokens(0.0375),
             )
         ],
     ),
@@ -64,6 +72,17 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(input_cost_per_token=per_million_tokens(0.20), output_cost_per_token=per_million_tokens(0.60))
         ],
     ),
+    # Llama Prompt Guard 2 (preview classifiers; evaluation-only per Groq)
+    "meta-llama/llama-prompt-guard-2-22m": ModelPricing(
+        tiers=[
+            PricingTier(input_cost_per_token=per_million_tokens(0.03), output_cost_per_token=per_million_tokens(0.03))
+        ],
+    ),
+    "meta-llama/llama-prompt-guard-2-86m": ModelPricing(
+        tiers=[
+            PricingTier(input_cost_per_token=per_million_tokens(0.04), output_cost_per_token=per_million_tokens(0.04))
+        ],
+    ),
     # Qwen family
     "qwen/qwen3-32b": ModelPricing(
         tiers=[
@@ -88,18 +107,13 @@ _PRICING: dict[str, ModelPricing] = {
     ),
 }
 
-# Pre-sorted by key length descending for prefix matching (longest match first)
-_PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
+# Case-insensitive, longest-prefix index (see lmux.cost.resolve_pricing).
+_PRICING_BY_PREFIX = build_pricing_index(_PRICING)
 
 
 def calculate_groq_cost(model: str, usage: Usage) -> Cost | None:
     """Calculate cost for a Groq API call. Returns None if model pricing is unknown."""
-    pricing = _PRICING.get(model)
-    if pricing is None:
-        for prefix, p in _PRICING_BY_PREFIX:
-            if model.startswith(prefix):
-                pricing = p
-                break
+    pricing = resolve_pricing(model, _PRICING_BY_PREFIX)
     if pricing is None:
         return None
     return calculate_cost(usage, pricing)

--- a/packages/lmux-groq/tests/test_cost.py
+++ b/packages/lmux-groq/tests/test_cost.py
@@ -49,6 +49,20 @@ class TestCalculateGroqCost:
         assert cost.input_cost == pytest.approx(1000 * 0.20 / 1_000_000)
         assert cost.output_cost == pytest.approx(500 * 0.60 / 1_000_000)
 
+    @pytest.mark.parametrize(
+        ("model", "rate"),
+        [
+            ("meta-llama/llama-prompt-guard-2-22m", 0.03),
+            ("meta-llama/llama-prompt-guard-2-86m", 0.04),
+        ],
+    )
+    def test_prompt_guard_pricing(self, model: str, rate: float) -> None:
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        cost = calculate_groq_cost(model, usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1000 * rate / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * rate / 1_000_000)
+
     def test_llama31_8b_pricing(self) -> None:
         usage = Usage(input_tokens=1000, output_tokens=500)
         cost = calculate_groq_cost("llama-3.1-8b-instant", usage)
@@ -72,6 +86,15 @@ class TestCalculateGroqCost:
         # These should resolve to different prefixes with different pricing
         assert cost_maverick.input_cost != cost_scout.input_cost
 
+    def test_case_insensitive_lookup(self) -> None:
+        """A capitalized model id resolves identically to its lowercase form."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        upper = calculate_groq_cost("LLAMA-3.3-70B-VERSATILE", usage)
+        lower = calculate_groq_cost("llama-3.3-70b-versatile", usage)
+        assert upper is not None
+        assert lower is not None
+        assert upper.total_cost == pytest.approx(lower.total_cost)
+
     def test_qwen_pricing(self) -> None:
         usage = Usage(input_tokens=1000, output_tokens=500)
         cost = calculate_groq_cost("qwen/qwen3-32b", usage)
@@ -85,6 +108,13 @@ class TestCalculateGroqCost:
         assert cost is not None
         # 200 cached tokens at 50% discount ($0.0375/M), 800 regular input at $0.075/M
         assert cost.cache_read_cost is not None
+        assert cost.cache_read_cost == pytest.approx(200 * 0.0375 / 1_000_000)
+        assert cost.input_cost == pytest.approx(800 * 0.075 / 1_000_000)
+
+    def test_with_cache_tokens_safeguard(self) -> None:
+        usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=200)
+        cost = calculate_groq_cost("openai/gpt-oss-safeguard-20b", usage)
+        assert cost is not None
         assert cost.cache_read_cost == pytest.approx(200 * 0.0375 / 1_000_000)
         assert cost.input_cost == pytest.approx(800 * 0.075 / 1_000_000)
 

--- a/packages/lmux-openai/pyproject.toml
+++ b/packages/lmux-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-openai"
-version = "0.8.0"
+version = "0.9.0"
 description = "OpenAI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"
@@ -14,7 +14,7 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-  "lmux~=0.10",
+  "lmux~=0.11",
   "httpx~=0.28",
 ]
 

--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -3,7 +3,14 @@
 Pricing source: https://developers.openai.com/api/docs/pricing
 """
 
-from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
+from lmux.cost import (
+    ModelPricing,
+    PricingTier,
+    build_pricing_index,
+    calculate_cost,
+    per_million_tokens,
+    resolve_pricing,
+)
 from lmux.types import Cost, Usage
 
 _PRICING: dict[str, ModelPricing] = {
@@ -57,6 +64,25 @@ _PRICING: dict[str, ModelPricing] = {
                 output_cost_per_token=per_million_tokens(9.00),
                 cache_read_cost_per_token=per_million_tokens(0.20),
                 cache_creation_cost_per_token=per_million_tokens(2.50),
+                min_input_tokens=272_000,
+            ),
+        ],
+    ),
+    # The bare "gpt-5.6" alias routes to gpt-5.6-sol; mirror Sol's rates so it does not
+    # fall through to the broad "gpt-5" prefix and get under-priced at 1.25/10.
+    "gpt-5.6": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(30.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(10.00),
+                output_cost_per_token=per_million_tokens(45.00),
+                cache_read_cost_per_token=per_million_tokens(1.00),
+                cache_creation_cost_per_token=per_million_tokens(12.50),
                 min_input_tokens=272_000,
             ),
         ],
@@ -344,6 +370,35 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    # The 2024-05-13 snapshot is priced higher than the current gpt-4o (5/15 vs 2.50/10) and
+    # has no cached-input rate; an explicit key stops it inheriting the cheaper gpt-4o prefix.
+    "gpt-4o-2024-05-13": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(15.00),
+            )
+        ],
+    ),
+    # Search-preview models: same input/output as their base family but OpenAI publishes NO
+    # cached-input price, so an explicit key drops the spurious cache rate the prefix would add.
+    # (Per-tool-call web-search fees are separate and not modeled here.)
+    "gpt-4o-search-preview": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.50),
+                output_cost_per_token=per_million_tokens(10.00),
+            )
+        ],
+    ),
+    "gpt-4o-mini-search-preview": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.15),
+                output_cost_per_token=per_million_tokens(0.60),
+            )
+        ],
+    ),
     "chatgpt-4o-latest": ModelPricing(
         tiers=[
             PricingTier(
@@ -471,8 +526,13 @@ _PRICING: dict[str, ModelPricing] = {
     ),
 }
 
-# Pre-sorted by key length descending for prefix matching (longest match first)
-_PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
+# Case-insensitive, longest-prefix index (see lmux.cost.resolve_pricing).
+_PRICING_BY_PREFIX = build_pricing_index(_PRICING)
+
+# Models OpenAI lists without a published token price (e.g. gpt-5.4-cyber, shown with blank
+# pricing columns). Returning None is correct — do NOT let them fall through to a broad family
+# prefix (e.g. gpt-5.4) and inherit a fabricated rate, and do not report a regional uplift for them.
+_UNPRICED_MODELS = frozenset({"gpt-5.4-cyber"})
 
 # 10% uplift for regional processing (data residency) endpoints. Per OpenAI, this
 # applies to the gpt-5.4 family (gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro),
@@ -483,12 +543,9 @@ _REGIONAL_UPLIFT_PREFIXES = ("gpt-5.4", "gpt-5.5", "gpt-5.6")
 
 def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:
     """Calculate cost for an OpenAI API call. Returns None if model pricing is unknown."""
-    pricing = _PRICING.get(model)
-    if pricing is None:
-        for prefix, p in _PRICING_BY_PREFIX:
-            if model.startswith(prefix):
-                pricing = p
-                break
+    if model.lower() in _UNPRICED_MODELS:
+        return None
+    pricing = resolve_pricing(model, _PRICING_BY_PREFIX)
     if pricing is None:
         return None
     return calculate_cost(usage, pricing)
@@ -496,7 +553,10 @@ def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:
 
 def regional_uplift_applies(model: str) -> bool:
     """Whether the regional processing (data residency) uplift applies to this model."""
-    return any(model.startswith(prefix) for prefix in _REGIONAL_UPLIFT_PREFIXES)
+    model_lower = model.lower()
+    if model_lower in _UNPRICED_MODELS:
+        return False
+    return any(model_lower.startswith(prefix) for prefix in _REGIONAL_UPLIFT_PREFIXES)
 
 
 def apply_cost_multiplier(cost: Cost, multiplier: float) -> Cost:

--- a/packages/lmux-openai/tests/test_cost.py
+++ b/packages/lmux-openai/tests/test_cost.py
@@ -62,6 +62,15 @@ class TestCalculateOpenAICost:
         assert mini_cost is not None
         assert cost.total_cost == pytest.approx(mini_cost.total_cost)
 
+    def test_case_insensitive_lookup(self) -> None:
+        """A capitalized model id resolves identically to its lowercase form."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        upper = calculate_openai_cost("GPT-4O", usage)
+        lower = calculate_openai_cost("gpt-4o", usage)
+        assert upper is not None
+        assert lower is not None
+        assert upper.total_cost == pytest.approx(lower.total_cost)
+
     def test_gpt_5_5_cyber_has_dedicated_pricing(self) -> None:
         """gpt-5.5-cyber must use its own (pricier) rate, not prefix-match gpt-5.5."""
         usage = Usage(input_tokens=1000, output_tokens=500)
@@ -107,6 +116,45 @@ class TestCalculateOpenAICost:
         assert cost.input_cost == pytest.approx(300_000 * 10.00 / 1_000_000)
         assert cost.output_cost == pytest.approx(1000 * 45.00 / 1_000_000)
 
+    def test_gpt_5_6_bare_alias_matches_sol(self) -> None:
+        """The bare gpt-5.6 alias mirrors gpt-5.6-sol, not the cheaper gpt-5 prefix."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        bare = calculate_openai_cost("gpt-5.6", usage)
+        sol = calculate_openai_cost("gpt-5.6-sol", usage)
+        assert bare is not None
+        assert sol is not None
+        assert bare.input_cost == pytest.approx(1000 * 5.00 / 1_000_000)
+        assert bare.total_cost == pytest.approx(sol.total_cost)
+
+    def test_gpt_4o_2024_05_13_snapshot(self) -> None:
+        """The 2024-05-13 snapshot is priced above current gpt-4o (5/15) with no cached-input rate."""
+        usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=100)
+        cost = calculate_openai_cost("gpt-4o-2024-05-13", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx((1000 - 100) * 5.00 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 15.00 / 1_000_000)
+        assert cost.cache_read_cost == pytest.approx(0.0)
+
+    def test_search_preview_models_have_no_cached_input(self) -> None:
+        """search-preview models keep base input/output but publish no cached-input price."""
+        usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=100)
+        full = calculate_openai_cost("gpt-4o-search-preview", usage)
+        mini = calculate_openai_cost("gpt-4o-mini-search-preview", usage)
+        assert full is not None
+        assert mini is not None
+        assert full.input_cost == pytest.approx((1000 - 100) * 2.50 / 1_000_000)
+        assert full.output_cost == pytest.approx(500 * 10.00 / 1_000_000)
+        assert full.cache_read_cost == pytest.approx(0.0)
+        assert mini.input_cost == pytest.approx((1000 - 100) * 0.15 / 1_000_000)
+        assert mini.cache_read_cost == pytest.approx(0.0)
+
+    def test_gpt_5_4_cyber_unpriced_returns_none(self) -> None:
+        """gpt-5.4-cyber is listed without a price; it must return None while its gpt-5.4 sibling stays priced."""
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        assert calculate_openai_cost("gpt-5.4-cyber", usage) is None
+        sibling = calculate_openai_cost("gpt-5.4", usage)
+        assert sibling is not None  # the sentinel is narrow: the family base must still price
+
 
 class TestRegionalUpliftApplies:
     @pytest.mark.parametrize(
@@ -122,9 +170,10 @@ class TestRegionalUpliftApplies:
 
     @pytest.mark.parametrize(
         "model",
-        ["gpt-4o", "gpt-5", "gpt-5.3-codex", "o3", "text-embedding-3-small", "unknown-model"],
+        ["gpt-4o", "gpt-5", "gpt-5.3-codex", "o3", "text-embedding-3-small", "unknown-model", "gpt-5.4-cyber"],
     )
     def test_does_not_apply_to_other_models(self, model: str) -> None:
+        # gpt-5.4-cyber starts with "gpt-5.4" but is unpriced, so the uplift must not apply.
         assert regional_uplift_applies(model) is False
 
 

--- a/packages/lmux/pyproject.toml
+++ b/packages/lmux/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux"
-version = "0.10.0"
+version = "0.11.0"
 description = "Core types, protocols, and utilities for the lmux language model multiplexer"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux/src/lmux/__init__.py
+++ b/packages/lmux/src/lmux/__init__.py
@@ -1,6 +1,14 @@
 """lmux — Modular Python language model multiplexer."""
 
-from lmux.cost import ModelPricing, PricingSchedule, PricingTier, calculate_cost, per_million_tokens
+from lmux.cost import (
+    ModelPricing,
+    PricingSchedule,
+    PricingTier,
+    build_pricing_index,
+    calculate_cost,
+    per_million_tokens,
+    resolve_pricing,
+)
 from lmux.exceptions import (
     AuthenticationError,
     InvalidRequestError,
@@ -119,6 +127,8 @@ __all__ = [
     "UnsupportedFeatureError",
     "Usage",
     "UserMessage",
+    "build_pricing_index",
     "calculate_cost",
     "per_million_tokens",
+    "resolve_pricing",
 ]

--- a/packages/lmux/src/lmux/cost.py
+++ b/packages/lmux/src/lmux/cost.py
@@ -1,5 +1,6 @@
 """Cost calculation utility functions."""
 
+from collections.abc import Mapping
 from datetime import date
 
 from pydantic import BaseModel, model_validator
@@ -10,6 +11,36 @@ from lmux.types import Cost, Usage
 def per_million_tokens(price: float) -> float:
     """Convert a per-million-token price to a per-token price."""
     return price / 1_000_000
+
+
+def build_pricing_index(pricing: Mapping[str, "ModelPricing"]) -> list[tuple[str, "ModelPricing"]]:
+    """Build a case-folded, longest-first prefix index for ``resolve_pricing``.
+
+    Keys are lowercased so lookup is case-insensitive — provider ``model`` fields vary in
+    capitalization (e.g. Azure returns ``Cohere-command-a`` and ``Phi-4`` but ``deepseek-r1``
+    and ``grok-4``). Entries are sorted by lowercased-key length descending so the longest
+    prefix wins; an exact match is just the longest possible prefix (a key as long as the id).
+    Two keys that lowercase to the same string must carry the same pricing.
+    """
+    return sorted(
+        ((key.lower(), value) for key, value in pricing.items()),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    )
+
+
+def resolve_pricing(model: str, index: list[tuple[str, "ModelPricing"]]) -> "ModelPricing | None":
+    """Resolve a model id to its pricing via case-insensitive longest-prefix matching.
+
+    ``index`` comes from ``build_pricing_index``. The id is lowercased and matched against the
+    lowercased keys; the first (longest) prefix hit wins, which yields the exact entry when one
+    exists. Returns ``None`` when nothing matches.
+    """
+    model_lower = model.lower()
+    for prefix, pricing in index:
+        if model_lower.startswith(prefix):
+            return pricing
+    return None
 
 
 class PricingTier(BaseModel):

--- a/packages/lmux/tests/test_cost.py
+++ b/packages/lmux/tests/test_cost.py
@@ -4,7 +4,15 @@ from datetime import date
 
 import pytest
 
-from lmux.cost import ModelPricing, PricingSchedule, PricingTier, calculate_cost, per_million_tokens
+from lmux.cost import (
+    ModelPricing,
+    PricingSchedule,
+    PricingTier,
+    build_pricing_index,
+    calculate_cost,
+    per_million_tokens,
+    resolve_pricing,
+)
 from lmux.types import Usage
 
 
@@ -532,3 +540,38 @@ class TestCalculateCost:
         assert calculate_cost(usage, pricing, as_of=date(2027, 6, 1)).input_cost == pytest.approx(5.00)
         # No as_of -> latest schedule ($5).
         assert calculate_cost(usage, pricing).input_cost == pytest.approx(5.00)
+
+
+class TestBuildPricingIndexAndResolvePricing:
+    @staticmethod
+    def _pricing(rate: float) -> ModelPricing:
+        return ModelPricing(tiers=[PricingTier(input_cost_per_token=rate, output_cost_per_token=0.0)])
+
+    def test_index_sorted_longest_first(self) -> None:
+        p = self._pricing(1.0)
+        index = build_pricing_index({"a": p, "aaa": p, "aa": p})
+        assert [key for key, _ in index] == ["aaa", "aa", "a"]
+
+    def test_index_lowercases_keys(self) -> None:
+        p = self._pricing(1.0)
+        index = build_pricing_index({"Cohere-Command-A": p})
+        assert index == [("cohere-command-a", p)]
+
+    def test_exact_and_prefix_resolution(self) -> None:
+        base = self._pricing(1.0)
+        mini = self._pricing(2.0)
+        index = build_pricing_index({"gpt-4o": base, "gpt-4o-mini": mini})
+        assert resolve_pricing("gpt-4o", index) is base  # exact
+        assert resolve_pricing("gpt-4o-2024-11-20", index) is base  # prefix fallback
+        assert resolve_pricing("gpt-4o-mini-2024-07-18", index) is mini  # longest prefix wins
+
+    def test_case_insensitive_exact_and_prefix(self) -> None:
+        p = self._pricing(1.0)
+        index = build_pricing_index({"Cohere-command-a": p})
+        assert resolve_pricing("cohere-command-a", index) is p
+        assert resolve_pricing("COHERE-COMMAND-A", index) is p
+        assert resolve_pricing("Cohere-Command-A-plus-05-2026", index) is p  # mixed-case prefix
+
+    def test_no_match_returns_none(self) -> None:
+        index = build_pricing_index({"gpt-4o": self._pricing(1.0)})
+        assert resolve_pricing("claude-opus-4-8", index) is None

--- a/uv.lock
+++ b/uv.lock
@@ -663,7 +663,7 @@ wheels = [
 
 [[package]]
 name = "lmux"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "packages/lmux" }
 dependencies = [
     { name = "pydantic" },
@@ -674,7 +674,7 @@ requires-dist = [{ name = "pydantic", specifier = "~=2.10" }]
 
 [[package]]
 name = "lmux-anthropic"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/lmux-anthropic" }
 dependencies = [
     { name = "httpx" },
@@ -720,7 +720,7 @@ provides-extras = ["async"]
 
 [[package]]
 name = "lmux-azure-foundry"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/lmux-azure-foundry" }
 dependencies = [
     { name = "httpx" },
@@ -753,7 +753,7 @@ requires-dist = [{ name = "lmux-google", editable = "packages/lmux-google" }]
 
 [[package]]
 name = "lmux-google"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "packages/lmux-google" }
 dependencies = [
     { name = "google-auth" },
@@ -770,7 +770,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-groq"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/lmux-groq" }
 dependencies = [
     { name = "httpx" },
@@ -796,7 +796,7 @@ requires-dist = [{ name = "lmux", editable = "packages/lmux" }]
 
 [[package]]
 name = "lmux-openai"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/lmux-openai" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Adds a shared case-insensitive, longest-prefix pricing resolver (`build_pricing_index` / `resolve_pricing`) in `lmux.cost` and migrates every provider to it except AWS Bedrock (lowercase-only ids; generated file).

Pricing refresh (no existing per-token rate changed):

- **azure**: o1-pro, gpt-5.2-pro, grok-4-1-fast (was ~30x overpriced via `grok-4`), gpt-5.6 sol/terra/luna, gpt-chat-latest, Cohere-command-a-plus, Mistral-Large-3, mistral-medium-3-5, embed-v-4-0, Kimi-K2.5/K2.6/K2.7-Code; deepseek-v4 cache-read; grok-4-20-* unpriced.
- **openai**: gpt-5.6 alias, gpt-4o-2024-05-13, gpt-4o[-mini]-search-preview (no spurious cache); gpt-5.4-cyber → None.
- **google**: computer-use id rename; GA flash-lite, embedding-2, robotics-er-1.6; image-output models → None (a single output rate underprices image generation 10-20x).
- **groq**: gpt-oss-safeguard-20b cache-read; llama-prompt-guard-2-22m/86m.

Minor version bumps for the six changed packages; provider `lmux` pins raised to `~=0.11`.
