### PR TITLE
fix(pricing): correct and complete Bedrock regional pricing

### DIFF
--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-anthropic"
-version = "0.13.0"
+version = "0.14.0"
 description = "Anthropic provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"
@@ -20,7 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 vertex = ["google-auth~=2.0"]
-bedrock = ["boto3>=1.42.31,<2", "lmux-bedrock-shared~=0.1"]
+bedrock = ["boto3>=1.42.31,<2", "lmux-bedrock-shared~=0.2"]
 
 [project.urls]
 Homepage = "https://github.com/cluebbehusen/lmux"

--- a/packages/lmux-anthropic/src/lmux_anthropic/provider.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/provider.py
@@ -923,7 +923,9 @@ class AnthropicBedrockProvider(AnthropicProvider):
         pricing = self._custom_pricing.get(model)
         if pricing is not None:
             return calculate_cost(usage, pricing, as_of)
-        return calculate_bedrock_anthropic_cost(model, usage, as_of=as_of)
+        # Bedrock bills by the Region called, and ``region`` is often left unset and resolved from
+        # the session, so price against the resolved auth context rather than the constructor arg.
+        return calculate_bedrock_anthropic_cost(model, usage, region=self._resolve_auth().region, as_of=as_of)
 
     @override
     def _cost_model(self, request_model: str, response_model: str) -> str:

--- a/packages/lmux-anthropic/tests/test_bedrock_provider.py
+++ b/packages/lmux-anthropic/tests/test_bedrock_provider.py
@@ -14,7 +14,7 @@ import respx
 if TYPE_CHECKING:
     import boto3
 
-from lmux.cost import ModelPricing, PricingTier
+from lmux.cost import ModelPricing, PricingTier, per_million_tokens
 from lmux.exceptions import AuthenticationError, InvalidRequestError, ProviderError, RateLimitError
 from lmux.types import Cost, UserMessage
 from lmux_anthropic import AnthropicBedrockProvider
@@ -354,6 +354,33 @@ class TestCost:
         )
         assert intro.cost is not None
         assert intro.cost.input_cost == 2.2  # us-east-1 intro rate (2.0 list x1.1)
+
+    def test_prices_by_resolved_region(self, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Cost follows the Region the request was sent to, not the constructor argument.
+
+        ``region`` is usually left unset and resolved from the session, and Bedrock bills by the
+        Region called — so a provider pointed at eu-west-1 must bill eu-west-1's rates.
+        """
+        regional = {
+            "eu-west-1": {
+                MODEL: ModelPricing(
+                    tiers=[
+                        PricingTier(
+                            input_cost_per_token=per_million_tokens(9.0),
+                            output_cost_per_token=per_million_tokens(9.0),
+                        )
+                    ],
+                ),
+            },
+        }
+        monkeypatch.setattr("lmux_bedrock_shared.pricing.ANTHROPIC_REGIONAL_PRICING", regional)
+        respx_mock.post(_url(MODEL, "invoke", base="https://bedrock-runtime.eu-west-1.amazonaws.com")).mock(
+            return_value=httpx.Response(200, json=_message(input_tokens=1_000_000, output_tokens=0))
+        )
+        provider = AnthropicBedrockProvider(auth=FakeAuth(_Session(region_name="eu-west-1")))
+        response = provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert response.cost is not None
+        assert response.cost.input_cost == pytest.approx(9.0)
 
     def test_unknown_model_has_no_cost(
         self, sync_provider: AnthropicBedrockProvider, respx_mock: respx.MockRouter

--- a/packages/lmux-aws-bedrock/pyproject.toml
+++ b/packages/lmux-aws-bedrock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-aws-bedrock"
-version = "0.11.0"
+version = "0.12.0"
 description = "AWS Bedrock provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
   "lmux~=0.10",
-  "lmux-bedrock-shared~=0.1",
+  "lmux-bedrock-shared~=0.2",
   "httpx~=0.28",
   "boto3>=1.42.31,<2",
 ]

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
@@ -1,7 +1,7 @@
 """AWS Bedrock pricing data and cost calculation.
 
 Prices are for the us-east-1 region (on-demand, cross-region global inference).
-Use register_pricing() on BedrockProvider for overrides or other regions.
+Regional pricing overrides are included for regions where prices differ.
 
 Anthropic Claude pricing lives in lmux_bedrock_shared.pricing (shared with the
 native lmux-anthropic Bedrock provider) and is merged into _PRICING below.
@@ -15,7 +15,15 @@ from datetime import date
 
 from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
 from lmux.types import Cost, Usage
-from lmux_bedrock_shared.pricing import ANTHROPIC_PRICING
+from lmux_bedrock_shared.pricing import (
+    ANTHROPIC_PRICING,
+    ANTHROPIC_REGIONAL_PRICING,
+    DEFAULT_PRICING_REGION,
+    INFERENCE_PROFILE_PREFIXES,
+    cost_or_none,
+    lookup_pricing,
+    lookup_regional_pricing,
+)
 
 _PRICING: dict[str, ModelPricing] = {
     # -- Amazon Nova / Titan -------------------------------------
@@ -1033,35 +1041,4636 @@ _PRICING: dict[str, ModelPricing] = {
     **ANTHROPIC_PRICING,
 }
 
-_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {}
+# Regional pricing overrides (only models that differ from us-east-1)
+_BEDROCK_REGIONAL: dict[str, dict[str, ModelPricing]] = {
+    "ap-east-2": {
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(3.01),
+                    cache_read_cost_per_token=per_million_tokens(0.09),
+                ),
+            ],
+        ),
+    },
+    "ap-northeast-1": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.396),
+                    output_cost_per_token=per_million_tokens(3.311),
+                    cache_read_cost_per_token=per_million_tokens(0.099),
+                ),
+            ],
+        ),
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.288),
+                    cache_read_cost_per_token=per_million_tokens(0.018),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.042),
+                    output_cost_per_token=per_million_tokens(0.168),
+                    cache_read_cost_per_token=per_million_tokens(0.0105),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.96),
+                    output_cost_per_token=per_million_tokens(3.84),
+                    cache_read_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.029),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.275),
+                    output_cost_per_token=per_million_tokens(0.825),
+                ),
+            ],
+        ),
+        "deepseek.v3.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.701666),
+                    output_cost_per_token=per_million_tokens(2.032411),
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.74),
+                    output_cost_per_token=per_million_tokens(2.22),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(3.01),
+                    cache_read_cost_per_token=per_million_tokens(0.09),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=per_million_tokens(0.35),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.28),
+                    output_cost_per_token=per_million_tokens(0.46),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.1),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.45),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.48),
+                    output_cost_per_token=per_million_tokens(2.4),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.61),
+                    output_cost_per_token=per_million_tokens(1.82),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.12),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.18),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.61),
+                    output_cost_per_token=per_million_tokens(1.82),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.05),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.73),
+                    output_cost_per_token=per_million_tokens(3.03),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.6),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2-vl": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.29),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.28),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "qwen.qwen3-235b-a22b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.27),
+                    output_cost_per_token=per_million_tokens(1.06),
+                ),
+            ],
+        ),
+        "qwen.qwen3-32b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-30b-a3b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-480b-a35b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.54),
+                    output_cost_per_token=per_million_tokens(2.18),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.64),
+                    output_cost_per_token=per_million_tokens(3.22),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(2.64),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.2),
+                    output_cost_per_token=per_million_tokens(3.84),
+                ),
+            ],
+        ),
+    },
+    "ap-northeast-2": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.071),
+                    output_cost_per_token=per_million_tokens(0.284),
+                    cache_read_cost_per_token=per_million_tokens(0.01775),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.041),
+                    output_cost_per_token=per_million_tokens(0.164),
+                    cache_read_cost_per_token=per_million_tokens(0.01025),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.95),
+                    output_cost_per_token=per_million_tokens(3.8),
+                    cache_read_cost_per_token=per_million_tokens(0.2375),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.024592),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(2.96),
+                    cache_read_cost_per_token=per_million_tokens(0.09),
+                ),
+            ],
+        ),
+    },
+    "ap-northeast-3": {
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.027),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+    },
+    "ap-south-1": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.071),
+                    output_cost_per_token=per_million_tokens(0.284),
+                    cache_read_cost_per_token=per_million_tokens(0.01775),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.041),
+                    output_cost_per_token=per_million_tokens(0.164),
+                    cache_read_cost_per_token=per_million_tokens(0.01025),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.94),
+                    output_cost_per_token=per_million_tokens(3.76),
+                    cache_read_cost_per_token=per_million_tokens(0.235),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-image-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.0),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.024),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.0),
+                    output_cost_per_token=per_million_tokens(1.9),
+                ),
+            ],
+        ),
+        "amazon.titan-text-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.4),
+                    output_cost_per_token=per_million_tokens(0.5),
+                ),
+            ],
+        ),
+        "deepseek.v3.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.682424),
+                    output_cost_per_token=per_million_tokens(1.976678),
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.74),
+                    output_cost_per_token=per_million_tokens(2.22),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.35),
+                    output_cost_per_token=per_million_tokens(2.95),
+                    cache_read_cost_per_token=per_million_tokens(0.0875),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=per_million_tokens(0.34),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.27),
+                    output_cost_per_token=per_million_tokens(0.45),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.09),
+                ),
+            ],
+        ),
+        "meta.llama3-70b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.18),
+                    output_cost_per_token=per_million_tokens(4.2),
+                ),
+            ],
+        ),
+        "meta.llama3-8b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.35),
+                    output_cost_per_token=per_million_tokens(1.41),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.48),
+                    output_cost_per_token=per_million_tokens(2.4),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.59),
+                    output_cost_per_token=per_million_tokens(1.76),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.12),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.18),
+                ),
+            ],
+        ),
+        "mistral.mistral-7b-instruct-v0:2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-2402-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(4.8),
+                    output_cost_per_token=per_million_tokens(14.4),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.59),
+                    output_cost_per_token=per_million_tokens(1.76),
+                ),
+            ],
+        ),
+        "mistral.mixtral-8x7b-instruct-v0:1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.54),
+                    output_cost_per_token=per_million_tokens(0.84),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.05),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.35),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.71),
+                    output_cost_per_token=per_million_tokens(2.94),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.6),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.71),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2-vl": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.71),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.28),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.27),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.71),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.35),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.71),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "qwen.qwen3-235b-a22b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.26),
+                    output_cost_per_token=per_million_tokens(1.04),
+                ),
+            ],
+        ),
+        "qwen.qwen3-32b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.71),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-30b-a3b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.71),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-480b-a35b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.53),
+                    output_cost_per_token=per_million_tokens(2.12),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.62),
+                    output_cost_per_token=per_million_tokens(3.13),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "xai.grok-4.3": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.5),
+                    output_cost_per_token=per_million_tokens(3.0),
+                    cache_read_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(2.64),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.2),
+                    output_cost_per_token=per_million_tokens(3.84),
+                ),
+            ],
+        ),
+    },
+    "ap-south-2": {
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.027),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+    },
+    "ap-southeast-1": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.081),
+                    output_cost_per_token=per_million_tokens(0.324),
+                    cache_read_cost_per_token=per_million_tokens(0.02025),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.047),
+                    output_cost_per_token=per_million_tokens(0.188),
+                    cache_read_cost_per_token=per_million_tokens(0.01175),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.08),
+                    output_cost_per_token=per_million_tokens(4.32),
+                    cache_read_cost_per_token=per_million_tokens(0.27),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.028),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.41),
+                    output_cost_per_token=per_million_tokens(3.39),
+                    cache_read_cost_per_token=per_million_tokens(0.1025),
+                ),
+            ],
+        ),
+    },
+    "ap-southeast-2": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.063),
+                    output_cost_per_token=per_million_tokens(0.252),
+                    cache_read_cost_per_token=per_million_tokens(0.01575),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.037),
+                    output_cost_per_token=per_million_tokens(0.148),
+                    cache_read_cost_per_token=per_million_tokens(0.00925),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.84),
+                    output_cost_per_token=per_million_tokens(3.36),
+                    cache_read_cost_per_token=per_million_tokens(0.21),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-image-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.0),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.026004),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.25),
+                    output_cost_per_token=per_million_tokens(0.788),
+                ),
+            ],
+        ),
+        "amazon.titan-text-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.25),
+                ),
+            ],
+        ),
+        "deepseek.v3.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.5974),
+                    output_cost_per_token=per_million_tokens(1.7304),
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.64),
+                    output_cost_per_token=per_million_tokens(1.91),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.32),
+                    output_cost_per_token=per_million_tokens(2.63),
+                    cache_read_cost_per_token=per_million_tokens(0.08),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.0927),
+                    output_cost_per_token=per_million_tokens(0.2987),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2369),
+                    output_cost_per_token=per_million_tokens(0.3914),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.0412),
+                    output_cost_per_token=per_million_tokens(0.0824),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.309),
+                    output_cost_per_token=per_million_tokens(1.236),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.31),
+                    output_cost_per_token=per_million_tokens(1.24),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.31),
+                    output_cost_per_token=per_million_tokens(1.24),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.41),
+                    output_cost_per_token=per_million_tokens(2.06),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.515),
+                    output_cost_per_token=per_million_tokens(1.545),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.206),
+                    output_cost_per_token=per_million_tokens(0.206),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.103),
+                    output_cost_per_token=per_million_tokens(0.103),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.1545),
+                    output_cost_per_token=per_million_tokens(0.1545),
+                ),
+            ],
+        ),
+        "mistral.mistral-7b-instruct-v0:2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.26),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-2402-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(5.2),
+                    output_cost_per_token=per_million_tokens(15.6),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.515),
+                    output_cost_per_token=per_million_tokens(1.545),
+                ),
+            ],
+        ),
+        "mistral.mixtral-8x7b-instruct-v0:1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.59),
+                    output_cost_per_token=per_million_tokens(0.91),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.0412),
+                    output_cost_per_token=per_million_tokens(0.0412),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.103),
+                    output_cost_per_token=per_million_tokens(0.309),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.618),
+                    output_cost_per_token=per_million_tokens(2.575),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.62),
+                    output_cost_per_token=per_million_tokens(3.09),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.206),
+                    output_cost_per_token=per_million_tokens(0.618),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.0618),
+                    output_cost_per_token=per_million_tokens(0.2472),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.0618),
+                    output_cost_per_token=per_million_tokens(0.2369),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.15),
+                    output_cost_per_token=per_million_tokens(0.67),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.1545),
+                    output_cost_per_token=per_million_tokens(0.618),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.0721),
+                    output_cost_per_token=per_million_tokens(0.309),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.1545),
+                    output_cost_per_token=per_million_tokens(0.618),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.0721),
+                    output_cost_per_token=per_million_tokens(0.206),
+                ),
+            ],
+        ),
+        "qwen.qwen3-235b-a22b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2266),
+                    output_cost_per_token=per_million_tokens(0.9064),
+                ),
+            ],
+        ),
+        "qwen.qwen3-32b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.1545),
+                    output_cost_per_token=per_million_tokens(0.618),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-30b-a3b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.1545),
+                    output_cost_per_token=per_million_tokens(0.618),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-480b-a35b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.4635),
+                    output_cost_per_token=per_million_tokens(1.854),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.52),
+                    output_cost_per_token=per_million_tokens(1.24),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.1442),
+                    output_cost_per_token=per_million_tokens(1.236),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.5459),
+                    output_cost_per_token=per_million_tokens(2.7398),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.15),
+                    output_cost_per_token=per_million_tokens(0.62),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.62),
+                    output_cost_per_token=per_million_tokens(2.27),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.41),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.03),
+                    output_cost_per_token=per_million_tokens(3.3),
+                ),
+            ],
+        ),
+    },
+    "ap-southeast-3": {
+        "deepseek.v3.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.74),
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.74),
+                    output_cost_per_token=per_million_tokens(2.22),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.32),
+                    output_cost_per_token=per_million_tokens(2.64),
+                    cache_read_cost_per_token=per_million_tokens(0.08),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.108),
+                    output_cost_per_token=per_million_tokens(0.348),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.276),
+                    output_cost_per_token=per_million_tokens(0.456),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.048),
+                    output_cost_per_token=per_million_tokens(0.096),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.48),
+                    output_cost_per_token=per_million_tokens(2.4),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.8),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.12),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.18),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.8),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.048),
+                    output_cost_per_token=per_million_tokens(0.048),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.0),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.6),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.288),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.276),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.16),
+                    output_cost_per_token=per_million_tokens(0.62),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.31),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.084),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "qwen.qwen3-235b-a22b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.91),
+                ),
+            ],
+        ),
+        "qwen.qwen3-32b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.16),
+                    output_cost_per_token=per_million_tokens(0.62),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-30b-a3b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.16),
+                    output_cost_per_token=per_million_tokens(0.62),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-480b-a35b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.47),
+                    output_cost_per_token=per_million_tokens(1.87),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.636),
+                    output_cost_per_token=per_million_tokens(3.192),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(2.64),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.2),
+                    output_cost_per_token=per_million_tokens(3.84),
+                ),
+            ],
+        ),
+    },
+    "ap-southeast-4": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.065),
+                    output_cost_per_token=per_million_tokens(0.26),
+                    cache_read_cost_per_token=per_million_tokens(0.01625),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.87),
+                    output_cost_per_token=per_million_tokens(3.48),
+                    cache_read_cost_per_token=per_million_tokens(0.2175),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.33),
+                    output_cost_per_token=per_million_tokens(2.71),
+                    cache_read_cost_per_token=per_million_tokens(0.0825),
+                ),
+            ],
+        ),
+    },
+    "ap-southeast-5": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.288),
+                    cache_read_cost_per_token=per_million_tokens(0.018),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.41),
+                    output_cost_per_token=per_million_tokens(3.39),
+                    cache_read_cost_per_token=per_million_tokens(0.1025),
+                ),
+            ],
+        ),
+    },
+    "ap-southeast-6": {
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.32),
+                    output_cost_per_token=per_million_tokens(2.63),
+                    cache_read_cost_per_token=per_million_tokens(0.08),
+                ),
+            ],
+        ),
+    },
+    "ap-southeast-7": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.288),
+                    cache_read_cost_per_token=per_million_tokens(0.018),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.41),
+                    output_cost_per_token=per_million_tokens(3.39),
+                    cache_read_cost_per_token=per_million_tokens(0.1025),
+                ),
+            ],
+        ),
+    },
+    "ca-central-1": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.352),
+                    output_cost_per_token=per_million_tokens(2.97),
+                    cache_read_cost_per_token=per_million_tokens(0.088),
+                ),
+            ],
+        ),
+        "amazon.nova-2-omni-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.4),
+                    output_cost_per_token=per_million_tokens(2.9),
+                ),
+            ],
+        ),
+        "amazon.nova-2-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.463),
+                    output_cost_per_token=per_million_tokens(11.726),
+                ),
+            ],
+        ),
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.064),
+                    output_cost_per_token=per_million_tokens(0.256),
+                    cache_read_cost_per_token=per_million_tokens(0.016),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-image-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.9),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.1),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.3),
+                    output_cost_per_token=per_million_tokens(0.8),
+                ),
+            ],
+        ),
+        "amazon.titan-text-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.3),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.32),
+                    output_cost_per_token=per_million_tokens(2.67),
+                    cache_read_cost_per_token=per_million_tokens(0.08),
+                ),
+            ],
+        ),
+        "meta.llama3-70b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.05),
+                    output_cost_per_token=per_million_tokens(4.03),
+                ),
+            ],
+        ),
+        "meta.llama3-8b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.35),
+                    output_cost_per_token=per_million_tokens(0.69),
+                ),
+            ],
+        ),
+        "mistral.mistral-7b-instruct-v0:2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.17),
+                    output_cost_per_token=per_million_tokens(0.23),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-2402-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(4.6),
+                    output_cost_per_token=per_million_tokens(13.8),
+                ),
+            ],
+        ),
+        "mistral.mixtral-8x7b-instruct-v0:1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.52),
+                    output_cost_per_token=per_million_tokens(0.81),
+                ),
+            ],
+        ),
+    },
+    "ca-west-1": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.374),
+                    output_cost_per_token=per_million_tokens(3.091),
+                    cache_read_cost_per_token=per_million_tokens(0.0935),
+                ),
+            ],
+        ),
+        "amazon.nova-2-omni-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.4),
+                    output_cost_per_token=per_million_tokens(3.1),
+                ),
+            ],
+        ),
+        "amazon.nova-2-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.551),
+                    output_cost_per_token=per_million_tokens(12.386),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.34),
+                    output_cost_per_token=per_million_tokens(2.81),
+                    cache_read_cost_per_token=per_million_tokens(0.85),
+                ),
+            ],
+        ),
+    },
+    "eu-central-1": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.429),
+                    output_cost_per_token=per_million_tokens(3.597),
+                    cache_read_cost_per_token=per_million_tokens(0.10725),
+                ),
+            ],
+        ),
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.078),
+                    output_cost_per_token=per_million_tokens(0.312),
+                    cache_read_cost_per_token=per_million_tokens(0.0195),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.046),
+                    output_cost_per_token=per_million_tokens(0.184),
+                    cache_read_cost_per_token=per_million_tokens(0.0115),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.05),
+                    output_cost_per_token=per_million_tokens(4.2),
+                    cache_read_cost_per_token=per_million_tokens(0.2625),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-image-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.0),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.3),
+                    output_cost_per_token=per_million_tokens(0.863),
+                ),
+            ],
+        ),
+        "deepseek.v3.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.696),
+                    output_cost_per_token=per_million_tokens(2.016),
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.74),
+                    output_cost_per_token=per_million_tokens(2.22),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.39),
+                    output_cost_per_token=per_million_tokens(3.27),
+                    cache_read_cost_per_token=per_million_tokens(0.0975),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.108),
+                    output_cost_per_token=per_million_tokens(0.348),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.276),
+                    output_cost_per_token=per_million_tokens(0.456),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.048),
+                    output_cost_per_token=per_million_tokens(0.096),
+                ),
+            ],
+        ),
+        "google.gemma-4-26b-a4b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.156),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "google.gemma-4-31b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "google.gemma-4-e2b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.048),
+                    output_cost_per_token=per_million_tokens(0.096),
+                ),
+            ],
+        ),
+        "meta.llama3-2-1b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.13),
+                    output_cost_per_token=per_million_tokens(0.13),
+                ),
+            ],
+        ),
+        "meta.llama3-2-3b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.19),
+                    output_cost_per_token=per_million_tokens(0.19),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.48),
+                    output_cost_per_token=per_million_tokens(2.4),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.8),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.12),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.18),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.8),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.048),
+                    output_cost_per_token=per_million_tokens(0.048),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.0),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.6),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.288),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.276),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.79),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.09),
+                    output_cost_per_token=per_million_tokens(0.4),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.084),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "qwen.qwen3-235b-a22b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.29),
+                    output_cost_per_token=per_million_tokens(1.16),
+                ),
+            ],
+        ),
+        "qwen.qwen3-32b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.79),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-30b-a3b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.79),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-480b-a35b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.54),
+                    output_cost_per_token=per_million_tokens(2.16),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.636),
+                    output_cost_per_token=per_million_tokens(3.192),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(2.64),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.2),
+                    output_cost_per_token=per_million_tokens(3.84),
+                ),
+            ],
+        ),
+    },
+    "eu-central-2": {
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.027),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+    },
+    "eu-north-1": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.363),
+                    output_cost_per_token=per_million_tokens(2.992),
+                    cache_read_cost_per_token=per_million_tokens(0.09075),
+                ),
+            ],
+        ),
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.065),
+                    output_cost_per_token=per_million_tokens(0.26),
+                    cache_read_cost_per_token=per_million_tokens(0.01625),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.038),
+                    output_cost_per_token=per_million_tokens(0.152),
+                    cache_read_cost_per_token=per_million_tokens(0.0095),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.87),
+                    output_cost_per_token=per_million_tokens(3.48),
+                    cache_read_cost_per_token=per_million_tokens(0.2175),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.021),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.74),
+                    output_cost_per_token=per_million_tokens(2.22),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.33),
+                    output_cost_per_token=per_million_tokens(2.72),
+                    cache_read_cost_per_token=per_million_tokens(0.0825),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.108),
+                    output_cost_per_token=per_million_tokens(0.348),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.276),
+                    output_cost_per_token=per_million_tokens(0.456),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.048),
+                    output_cost_per_token=per_million_tokens(0.096),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.48),
+                    output_cost_per_token=per_million_tokens(2.4),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.8),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.12),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.18),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.8),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.048),
+                    output_cost_per_token=per_million_tokens(0.048),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.0),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.6),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.288),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.276),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.084),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.636),
+                    output_cost_per_token=per_million_tokens(3.192),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(2.64),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.2),
+                    output_cost_per_token=per_million_tokens(3.84),
+                ),
+            ],
+        ),
+    },
+    "eu-south-1": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.528),
+                    output_cost_per_token=per_million_tokens(4.411),
+                    cache_read_cost_per_token=per_million_tokens(0.132),
+                ),
+            ],
+        ),
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.096),
+                    output_cost_per_token=per_million_tokens(0.384),
+                    cache_read_cost_per_token=per_million_tokens(0.024),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.056),
+                    output_cost_per_token=per_million_tokens(0.224),
+                    cache_read_cost_per_token=per_million_tokens(0.014),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.28),
+                    output_cost_per_token=per_million_tokens(5.21),
+                    cache_read_cost_per_token=per_million_tokens(0.32),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.023),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "deepseek.v3.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.696),
+                    output_cost_per_token=per_million_tokens(2.016),
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.74),
+                    output_cost_per_token=per_million_tokens(2.22),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.481),
+                    output_cost_per_token=per_million_tokens(4.1),
+                    cache_read_cost_per_token=per_million_tokens(0.0825),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=per_million_tokens(0.34),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.27),
+                    output_cost_per_token=per_million_tokens(0.45),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.09),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.35),
+                    output_cost_per_token=per_million_tokens(1.41),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.48),
+                    output_cost_per_token=per_million_tokens(2.4),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.59),
+                    output_cost_per_token=per_million_tokens(1.76),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.23),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.12),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.18),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.8),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.05),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.35),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.0),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.6),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.7),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2-vl": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.7),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.28),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.27),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.79),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.09),
+                    output_cost_per_token=per_million_tokens(0.4),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.7),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.23),
+                ),
+            ],
+        ),
+        "qwen.qwen3-235b-a22b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.29),
+                    output_cost_per_token=per_million_tokens(1.16),
+                ),
+            ],
+        ),
+        "qwen.qwen3-32b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.79),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-30b-a3b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.79),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-480b-a35b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.54),
+                    output_cost_per_token=per_million_tokens(2.16),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.62),
+                    output_cost_per_token=per_million_tokens(3.12),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(2.64),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.2),
+                    output_cost_per_token=per_million_tokens(3.84),
+                ),
+            ],
+        ),
+    },
+    "eu-south-2": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.363),
+                    output_cost_per_token=per_million_tokens(3.205),
+                    cache_read_cost_per_token=per_million_tokens(0.09075),
+                ),
+            ],
+        ),
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.066),
+                    output_cost_per_token=per_million_tokens(0.264),
+                    cache_read_cost_per_token=per_million_tokens(0.0165),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.039),
+                    output_cost_per_token=per_million_tokens(0.156),
+                    cache_read_cost_per_token=per_million_tokens(0.00975),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.88),
+                    output_cost_per_token=per_million_tokens(3.52),
+                    cache_read_cost_per_token=per_million_tokens(0.22),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.021),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.33),
+                    output_cost_per_token=per_million_tokens(2.75),
+                    cache_read_cost_per_token=per_million_tokens(0.0825),
+                ),
+            ],
+        ),
+    },
+    "eu-west-1": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.374),
+                    output_cost_per_token=per_million_tokens(3.157),
+                    cache_read_cost_per_token=per_million_tokens(0.0935),
+                ),
+            ],
+        ),
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.069),
+                    output_cost_per_token=per_million_tokens(0.276),
+                    cache_read_cost_per_token=per_million_tokens(0.01725),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.04),
+                    output_cost_per_token=per_million_tokens(0.16),
+                    cache_read_cost_per_token=per_million_tokens(0.01),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.92),
+                    output_cost_per_token=per_million_tokens(3.68),
+                    cache_read_cost_per_token=per_million_tokens(0.23),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-image-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.0),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.026004),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.0),
+                    output_cost_per_token=per_million_tokens(1.7),
+                ),
+            ],
+        ),
+        "amazon.titan-text-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.3),
+                    output_cost_per_token=per_million_tokens(0.4),
+                ),
+            ],
+        ),
+        "deepseek.v3.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.696),
+                    output_cost_per_token=per_million_tokens(2.016),
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.74),
+                    output_cost_per_token=per_million_tokens(2.22),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.34),
+                    output_cost_per_token=per_million_tokens(2.87),
+                    cache_read_cost_per_token=per_million_tokens(0.085),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=per_million_tokens(0.34),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.27),
+                    output_cost_per_token=per_million_tokens(0.45),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.09),
+                ),
+            ],
+        ),
+        "meta.llama3-2-1b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=per_million_tokens(0.11),
+                ),
+            ],
+        ),
+        "meta.llama3-2-3b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.17),
+                    output_cost_per_token=per_million_tokens(0.17),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.35),
+                    output_cost_per_token=per_million_tokens(1.41),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.48),
+                    output_cost_per_token=per_million_tokens(2.4),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.59),
+                    output_cost_per_token=per_million_tokens(1.76),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.23),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.12),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.18),
+                ),
+            ],
+        ),
+        "mistral.mistral-7b-instruct-v0:2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.16),
+                    output_cost_per_token=per_million_tokens(0.22),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-2402-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(4.3),
+                    output_cost_per_token=per_million_tokens(13.0),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.8),
+                ),
+            ],
+        ),
+        "mistral.mixtral-8x7b-instruct-v0:1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.49),
+                    output_cost_per_token=per_million_tokens(0.76),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.05),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.35),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.0),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.6),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.7),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2-vl": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.7),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.28),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.27),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.7),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.35),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.7),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.23),
+                ),
+            ],
+        ),
+        "qwen.qwen3-235b-a22b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.264),
+                    output_cost_per_token=per_million_tokens(1.056),
+                ),
+            ],
+        ),
+        "qwen.qwen3-32b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.7),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-30b-a3b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.7),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-480b-a35b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.54),
+                    output_cost_per_token=per_million_tokens(2.16),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.62),
+                    output_cost_per_token=per_million_tokens(3.12),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(2.64),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.2),
+                    output_cost_per_token=per_million_tokens(3.84),
+                ),
+            ],
+        ),
+    },
+    "eu-west-2": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.084),
+                    output_cost_per_token=per_million_tokens(0.336),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.049),
+                    output_cost_per_token=per_million_tokens(0.196),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.13),
+                    output_cost_per_token=per_million_tokens(4.52),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-image-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.0),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.1),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.3),
+                    output_cost_per_token=per_million_tokens(0.9),
+                ),
+            ],
+        ),
+        "amazon.titan-text-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.3),
+                ),
+            ],
+        ),
+        "deepseek.v3.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.899985),
+                    output_cost_per_token=per_million_tokens(2.606853),
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.961),
+                    output_cost_per_token=per_million_tokens(2.8675),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.42),
+                    output_cost_per_token=per_million_tokens(3.52),
+                    cache_read_cost_per_token=per_million_tokens(0.105),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.14),
+                    output_cost_per_token=per_million_tokens(0.45),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(0.59),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.06),
+                    output_cost_per_token=per_million_tokens(0.12),
+                ),
+            ],
+        ),
+        "meta.llama3-70b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.45),
+                    output_cost_per_token=per_million_tokens(4.55),
+                ),
+            ],
+        ),
+        "meta.llama3-8b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.39),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.47),
+                    output_cost_per_token=per_million_tokens(1.86),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.47),
+                    output_cost_per_token=per_million_tokens(1.86),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.47),
+                    output_cost_per_token=per_million_tokens(1.86),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.62),
+                    output_cost_per_token=per_million_tokens(3.1),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.78),
+                    output_cost_per_token=per_million_tokens(2.33),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.31),
+                    output_cost_per_token=per_million_tokens(0.31),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.16),
+                    output_cost_per_token=per_million_tokens(0.16),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.23),
+                ),
+            ],
+        ),
+        "mistral.mistral-7b-instruct-v0:2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.26),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-2402-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(5.2),
+                    output_cost_per_token=per_million_tokens(15.6),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.775),
+                    output_cost_per_token=per_million_tokens(2.325),
+                ),
+            ],
+        ),
+        "mistral.mixtral-8x7b-instruct-v0:1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.59),
+                    output_cost_per_token=per_million_tokens(0.91),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.06),
+                    output_cost_per_token=per_million_tokens(0.06),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.16),
+                    output_cost_per_token=per_million_tokens(0.47),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.93),
+                    output_cost_per_token=per_million_tokens(3.875),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.93),
+                    output_cost_per_token=per_million_tokens(4.65),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.31),
+                    output_cost_per_token=per_million_tokens(0.93),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2-vl": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.31),
+                    output_cost_per_token=per_million_tokens(0.93),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.09),
+                    output_cost_per_token=per_million_tokens(0.37),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.09),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(1.01),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.93),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=per_million_tokens(0.47),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.93),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=per_million_tokens(0.31),
+                ),
+            ],
+        ),
+        "qwen.qwen3-235b-a22b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.34),
+                    output_cost_per_token=per_million_tokens(1.37),
+                ),
+            ],
+        ),
+        "qwen.qwen3-32b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.93),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-30b-a3b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.93),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-480b-a35b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.7),
+                    output_cost_per_token=per_million_tokens(2.79),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.78),
+                    output_cost_per_token=per_million_tokens(1.86),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.217),
+                    output_cost_per_token=per_million_tokens(1.86),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.82),
+                    output_cost_per_token=per_million_tokens(4.12),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.23),
+                    output_cost_per_token=per_million_tokens(0.93),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.93),
+                    output_cost_per_token=per_million_tokens(3.41),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=per_million_tokens(0.62),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.55),
+                    output_cost_per_token=per_million_tokens(4.96),
+                ),
+            ],
+        ),
+    },
+    "eu-west-3": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.484),
+                    output_cost_per_token=per_million_tokens(4.059),
+                    cache_read_cost_per_token=per_million_tokens(0.121),
+                ),
+            ],
+        ),
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.088),
+                    output_cost_per_token=per_million_tokens(0.352),
+                    cache_read_cost_per_token=per_million_tokens(0.022),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.052),
+                    output_cost_per_token=per_million_tokens(0.208),
+                    cache_read_cost_per_token=per_million_tokens(0.013),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.18),
+                    output_cost_per_token=per_million_tokens(4.72),
+                    cache_read_cost_per_token=per_million_tokens(0.295),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-image-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.0),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.03),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.25),
+                    output_cost_per_token=per_million_tokens(0.788),
+                ),
+            ],
+        ),
+        "amazon.titan-text-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.25),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.44),
+                    output_cost_per_token=per_million_tokens(3.69),
+                    cache_read_cost_per_token=per_million_tokens(0.11),
+                ),
+            ],
+        ),
+        "meta.llama3-2-1b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.13),
+                    output_cost_per_token=per_million_tokens(0.13),
+                ),
+            ],
+        ),
+        "meta.llama3-2-3b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.2),
+                ),
+            ],
+        ),
+        "mistral.mistral-7b-instruct-v0:2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=per_million_tokens(0.26),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-2402-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(5.2),
+                    output_cost_per_token=per_million_tokens(15.6),
+                ),
+            ],
+        ),
+        "mistral.mixtral-8x7b-instruct-v0:1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.59),
+                    output_cost_per_token=per_million_tokens(0.91),
+                ),
+            ],
+        ),
+    },
+    "il-central-1": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.075),
+                    output_cost_per_token=per_million_tokens(0.3),
+                    cache_read_cost_per_token=per_million_tokens(0.01875),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.044),
+                    output_cost_per_token=per_million_tokens(0.176),
+                    cache_read_cost_per_token=per_million_tokens(0.011),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.0),
+                    output_cost_per_token=per_million_tokens(4.0),
+                    cache_read_cost_per_token=per_million_tokens(0.25),
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.38),
+                    output_cost_per_token=per_million_tokens(3.13),
+                    cache_read_cost_per_token=per_million_tokens(0.095),
+                ),
+            ],
+        ),
+    },
+    "me-central-1": {
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.3),
+                    output_cost_per_token=per_million_tokens(2.5),
+                    cache_read_cost_per_token=per_million_tokens(0.08),
+                ),
+            ],
+        ),
+    },
+    "sa-east-1": {
+        "amazon.titan-embed-image-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.2),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.2),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.4),
+                    output_cost_per_token=per_million_tokens(1.1),
+                ),
+            ],
+        ),
+        "amazon.titan-text-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.3),
+                    output_cost_per_token=per_million_tokens(0.4),
+                ),
+            ],
+        ),
+        "deepseek.v3.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.696),
+                    output_cost_per_token=per_million_tokens(2.016),
+                ),
+            ],
+        ),
+        "deepseek.v3.2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.74),
+                    output_cost_per_token=per_million_tokens(2.22),
+                ),
+            ],
+        ),
+        "google.gemma-3-12b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=per_million_tokens(0.35),
+                ),
+            ],
+        ),
+        "google.gemma-3-27b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.28),
+                    output_cost_per_token=per_million_tokens(0.46),
+                ),
+            ],
+        ),
+        "google.gemma-3-4b-it": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.1),
+                ),
+            ],
+        ),
+        "meta.llama3-70b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(4.45),
+                    output_cost_per_token=per_million_tokens(5.88),
+                ),
+            ],
+        ),
+        "meta.llama3-8b-instruct-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.5),
+                    output_cost_per_token=per_million_tokens(1.01),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.45),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "minimax.minimax-m2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.36),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "mistral.devstral-2-123b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.48),
+                    output_cost_per_token=per_million_tokens(2.4),
+                ),
+            ],
+        ),
+        "mistral.magistral-small-2509": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.61),
+                    output_cost_per_token=per_million_tokens(1.82),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-14b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-3b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.12),
+                ),
+            ],
+        ),
+        "mistral.ministral-3-8b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.18),
+                ),
+            ],
+        ),
+        "mistral.mistral-7b-instruct-v0:2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.25),
+                    output_cost_per_token=per_million_tokens(0.34),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-2402-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(6.7),
+                    output_cost_per_token=per_million_tokens(20.2),
+                ),
+            ],
+        ),
+        "mistral.mistral-large-3-675b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.61),
+                    output_cost_per_token=per_million_tokens(1.82),
+                ),
+            ],
+        ),
+        "mistral.mixtral-8x7b-instruct-v0:1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.76),
+                    output_cost_per_token=per_million_tokens(1.18),
+                ),
+            ],
+        ),
+        "mistral.voxtral-mini-3b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.05),
+                    output_cost_per_token=per_million_tokens(0.05),
+                ),
+            ],
+        ),
+        "mistral.voxtral-small-24b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.12),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2-thinking": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.73),
+                    output_cost_per_token=per_million_tokens(3.03),
+                ),
+            ],
+        ),
+        "moonshotai.kimi-k2.5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(3.6),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2-vl": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.29),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.07),
+                    output_cost_per_token=per_million_tokens(0.28),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-safeguard-20b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "qwen.qwen3-235b-a22b-2507": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.264),
+                    output_cost_per_token=per_million_tokens(1.056),
+                ),
+            ],
+        ),
+        "qwen.qwen3-32b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-30b-a3b-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.73),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-480b-a35b-instruct": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.54),
+                    output_cost_per_token=per_million_tokens(2.16),
+                ),
+            ],
+        ),
+        "qwen.qwen3-coder-next": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.6),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-next-80b-a3b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(1.44),
+                ),
+            ],
+        ),
+        "qwen.qwen3-vl-235b-a22b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.64),
+                    output_cost_per_token=per_million_tokens(3.22),
+                ),
+            ],
+        ),
+        "writer.palmyra-vision-7b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "zai.glm-4.7": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.72),
+                    output_cost_per_token=per_million_tokens(2.64),
+                ),
+            ],
+        ),
+        "zai.glm-4.7-flash": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.08),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "zai.glm5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.2),
+                    output_cost_per_token=per_million_tokens(3.84),
+                ),
+            ],
+        ),
+    },
+    "us-gov-east-1": {
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.03),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2-vl": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.288),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.276),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-5.4": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.3),
+                    output_cost_per_token=per_million_tokens(19.8),
+                    cache_read_cost_per_token=per_million_tokens(0.33),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.084),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+    },
+    "us-gov-west-1": {
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.288),
+                    cache_read_cost_per_token=per_million_tokens(0.018),
+                ),
+            ],
+        ),
+        "amazon.nova-micro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.042),
+                    output_cost_per_token=per_million_tokens(0.168),
+                    cache_read_cost_per_token=per_million_tokens(0.0105),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.96),
+                    output_cost_per_token=per_million_tokens(3.84),
+                    cache_read_cost_per_token=per_million_tokens(0.24),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.11),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "amazon.titan-text-express-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.8),
+                    output_cost_per_token=per_million_tokens(1.6),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-12b-v2-vl": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.24),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-3-30b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.288),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-nano-9b-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.072),
+                    output_cost_per_token=per_million_tokens(0.276),
+                ),
+            ],
+        ),
+        "nvidia.nemotron-super-3-120b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.78),
+                ),
+            ],
+        ),
+        "openai.gpt-5.4": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.3),
+                    output_cost_per_token=per_million_tokens(19.8),
+                    cache_read_cost_per_token=per_million_tokens(0.33),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-120b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.18),
+                    output_cost_per_token=per_million_tokens(0.72),
+                ),
+            ],
+        ),
+        "openai.gpt-oss-20b-1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.084),
+                    output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+    },
+    "us-west-1": {
+        "amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.429),
+                    output_cost_per_token=per_million_tokens(3.351),
+                    cache_read_cost_per_token=per_million_tokens(0.10725),
+                ),
+            ],
+        ),
+        "amazon.nova-2-omni-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.4),
+                    output_cost_per_token=per_million_tokens(3.5),
+                ),
+            ],
+        ),
+        "amazon.nova-2-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.771),
+                    output_cost_per_token=per_million_tokens(14.124),
+                ),
+            ],
+        ),
+        "amazon.nova-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.077),
+                    output_cost_per_token=per_million_tokens(0.308),
+                ),
+            ],
+        ),
+        "amazon.nova-pro-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.03),
+                    output_cost_per_token=per_million_tokens(4.12),
+                ),
+            ],
+        ),
+        "amazon.titan-embed-text-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.024),
+                    output_cost_per_token=0.0,
+                ),
+            ],
+        ),
+        "global.amazon.nova-2-lite-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.39),
+                    output_cost_per_token=per_million_tokens(3.21),
+                    cache_read_cost_per_token=per_million_tokens(0.0975),
+                ),
+            ],
+        ),
+    },
+}
+
+# Claude's overrides come from the shared table, so both Bedrock providers price it identically.
+_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
+    region: {**_BEDROCK_REGIONAL.get(region, {}), **ANTHROPIC_REGIONAL_PRICING.get(region, {})}
+    for region in _BEDROCK_REGIONAL.keys() | ANTHROPIC_REGIONAL_PRICING.keys()
+}
 
 # Pre-sorted by key length descending for longest-prefix matching
 _PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
-
-
-# Cross-region inference profile prefixes. A profile call (e.g. "us.anthropic...")
-# with no dedicated regional entry falls back to the base model's pricing.
-_INFERENCE_PROFILE_PREFIXES = ("global.", "us.", "eu.", "apac.", "au.", "jp.", "ca.")
-
-
-def _strip_profile_prefix(model: str) -> str:
-    for prefix in _INFERENCE_PROFILE_PREFIXES:
-        if model.startswith(prefix):
-            return model[len(prefix) :]
-    return model
-
-
-def _lookup_default_pricing(model: str) -> ModelPricing | None:
-    pricing = _PRICING.get(model)
-    if pricing is not None:
-        return pricing
-    for prefix, p in _PRICING_BY_PREFIX:
-        if model.startswith(prefix):
-            return p
-    bare = _strip_profile_prefix(model)
-    if bare != model:
-        return _lookup_default_pricing(bare)
-    return None
 
 
 def calculate_bedrock_cost(
@@ -1069,24 +5678,21 @@ def calculate_bedrock_cost(
 ) -> Cost | None:
     """Calculate cost for a Bedrock API call. Returns None if model pricing is unknown.
 
-    ``as_of`` selects dated pricing for models with scheduled rate changes
+    ``region`` is the Region the request is sent to, which is the Region Bedrock bills against --
+    a cross-Region inference profile is priced by the Region it is called from, not by wherever the
+    request is routed. ``as_of`` selects dated pricing for models with scheduled rate changes
     (e.g. Claude Sonnet 5's introductory period); it defaults to the latest
     schedule. See ``lmux.cost.calculate_cost``.
-    """
-    # Try regional pricing first if region specified
-    if region is not None and region != "us-east-1":
-        regional = _REGIONAL_PRICING.get(region, {})
-        pricing = regional.get(model)
-        if pricing is None:
-            for prefix, p in sorted(regional.items(), key=lambda item: len(item[0]), reverse=True):
-                if model.startswith(prefix):
-                    pricing = p
-                    break
-        if pricing is not None:
-            return calculate_cost(usage, pricing, as_of)
 
-    # Fall back to default (us-east-1) pricing
-    pricing = _lookup_default_pricing(model)
+    Matching is shared with the native Anthropic Bedrock provider (see
+    ``lmux_bedrock_shared.pricing``) so Claude resolves identically through either.
+    """
+    if region is not None and region != DEFAULT_PRICING_REGION:
+        pricing = lookup_regional_pricing(_REGIONAL_PRICING, region, model)
+        if pricing is not None:
+            return cost_or_none(pricing, usage, as_of)
+
+    pricing = lookup_pricing(_PRICING, _PRICING_BY_PREFIX, model, INFERENCE_PROFILE_PREFIXES)
     if pricing is None:
         return None
     return calculate_cost(usage, pricing, as_of)

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -134,7 +134,10 @@ class BedrockProvider(
         pricing = self._custom_pricing.get(model)
         if pricing is not None:
             return calculate_cost(usage, pricing, as_of)
-        return calculate_bedrock_cost(model, usage, region=self._region, as_of=as_of)
+        # Price against the Region the request was actually sent to, not the constructor argument:
+        # ``region`` is usually left unset and resolved from the session (AWS_DEFAULT_REGION, a
+        # profile), and Bedrock bills by the Region called.
+        return calculate_bedrock_cost(model, usage, region=self._resolve_auth().region, as_of=as_of)
 
     # MARK: Client & Auth Management
 

--- a/packages/lmux-aws-bedrock/tests/test_cost.py
+++ b/packages/lmux-aws-bedrock/tests/test_cost.py
@@ -4,12 +4,13 @@ from datetime import date
 
 import pytest
 
-from lmux.cost import ModelPricing, PricingTier, per_million_tokens
+from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
 from lmux.types import Usage
 from lmux_aws_bedrock.cost import (
     _REGIONAL_PRICING,
     calculate_bedrock_cost,
 )
+from lmux_bedrock_shared.pricing import ANTHROPIC_REGIONAL_PRICING, calculate_bedrock_anthropic_cost
 
 
 class TestCalculateBedrockCost:
@@ -130,15 +131,48 @@ class TestCalculateBedrockCost:
         assert cost_default is not None
         assert cost.total_cost == pytest.approx(cost_default.total_cost)
 
-    def test_regional_pricing_empty_dict(self) -> None:
-        """With empty _REGIONAL_PRICING, all regions fall back to default."""
-        assert _REGIONAL_PRICING == {}
+    def test_regional_override_matches_versioned_request_id(self) -> None:
+        """A Region's override applies to the ID a request actually carries.
+
+        Table keys omit the ``:0`` version suffix that real Bedrock model IDs end with, so the
+        override has to survive prefix matching — the case that silently fell through to
+        us-east-1 pricing. Driven off the shipped table rather than a hardcoded rate, so a
+        pricing refresh doesn't churn the test.
+        """
+        region = next(r for r, models in _REGIONAL_PRICING.items() if models)
+        model, pricing = next(iter(_REGIONAL_PRICING[region].items()))
         usage = Usage(input_tokens=1000, output_tokens=500)
-        cost = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1", usage, region="eu-west-1")
-        cost_default = calculate_bedrock_cost("meta.llama3-1-70b-instruct-v1", usage)
+        cost = calculate_bedrock_cost(f"{model}:0", usage, region=region)
         assert cost is not None
-        assert cost_default is not None
-        assert cost.total_cost == pytest.approx(cost_default.total_cost)
+        assert cost.total_cost == pytest.approx(calculate_cost(usage, pricing, None).total_cost)
+
+    def test_no_regional_override_is_cheaper_than_us_east_1(self) -> None:
+        """Guard against the global-discount artifact re-entering the regional table.
+
+        Genuine Bedrock regional variation is a premium — niche Regions cost more, not less. The
+        only sub-baseline rate is the ~10% Global cross-Region discount, which belongs on the
+        ``global.`` keys, not a regional override. A generator that fills a Region's standard rate
+        from a Global-only meter re-creates that artifact, and it always lands below us-east-1. So
+        every override must be >= the default; a genuinely cheaper Region would trip this and want
+        a human to confirm it is real rather than another leak.
+        """
+        # Input/output only: a partial override omits cache rates and prices a cached call as None,
+        # which is not what this guard is about.
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        for region, models in _REGIONAL_PRICING.items():
+            for model in models:
+                # The premium premise is about standard rates. A per-Region Global rate is a
+                # separate axis that legitimately runs cheaper than us-east-1's Global rate.
+                if model.startswith("global."):
+                    continue
+                override = calculate_bedrock_cost(f"{model}:0", usage, region=region)
+                default = calculate_bedrock_cost(f"{model}:0", usage, region="us-east-1")
+                assert override is not None
+                # Some models are Region-exclusive (e.g. a model offered in GovCloud but not
+                # us-east-1), so there is no baseline to be cheaper than — nothing to check.
+                if default is None:
+                    continue
+                assert override.total_cost >= default.total_cost - 1e-9, f"{region}/{model} priced below us-east-1"
 
     def test_inference_profile_us_prefix(self) -> None:
         """us. prefixed inference profile IDs match and use non-global pricing."""
@@ -227,6 +261,118 @@ class TestCalculateBedrockCost:
         assert cost is not None
         assert cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
         assert cost.output_cost == pytest.approx(500 * 2.0 / 1_000_000)
+
+    def test_claude_prices_identically_to_the_native_bedrock_provider(self) -> None:
+        """The shared Anthropic table exists so the Converse and native Bedrock providers never
+        drift. Assert it holds for every Region that carries a Claude override, including the
+        Regions only the shared table knows about.
+        """
+        # Both a plain call and a cached one: the two providers share one table, so they must agree
+        # on the cost — including agreeing that a cached call against a cache-less override is
+        # unpriced (both return None).
+        for usage in (
+            Usage(input_tokens=1000, output_tokens=500),
+            Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=100),
+        ):
+            for region, models in ANTHROPIC_REGIONAL_PRICING.items():
+                for model in models:
+                    converse = calculate_bedrock_cost(f"{model}:0", usage, region=region)
+                    native = calculate_bedrock_anthropic_cost(f"{model}:0", usage, region=region)
+                    assert converse == native, f"{region}/{model} drifted"
+
+    def test_partial_override_prices_tokens_but_not_uncovered_cache(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A Region that prices input/output but not cache keeps its token premium; a cached call
+        against the missing rate is unpriced (None) rather than billed for free."""
+        regional = {
+            "eu-west-1": {
+                "amazon.nova-pro-v1": ModelPricing(
+                    tiers=[
+                        PricingTier(
+                            input_cost_per_token=per_million_tokens(1.13),
+                            output_cost_per_token=per_million_tokens(4.52),
+                        )  # no cache rate
+                    ],
+                ),
+            },
+        }
+        monkeypatch.setattr("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional)
+        plain = calculate_bedrock_cost(
+            "amazon.nova-pro-v1:0", Usage(input_tokens=1_000_000, output_tokens=0), region="eu-west-1"
+        )
+        assert plain is not None
+        assert plain.input_cost == pytest.approx(1.13)
+        cached = calculate_bedrock_cost(
+            "amazon.nova-pro-v1:0",
+            Usage(input_tokens=1_000_000, output_tokens=0, cache_read_tokens=1000),
+            region="eu-west-1",
+        )
+        assert cached is None
+
+    def test_regional_global_profile_uses_the_regions_global_rate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A global. call is billed by its source Region, and AWS publishes a per-Region global rate.
+        The regional global. override must win over the us-east-1 global key."""
+        regional = {
+            "ap-northeast-1": {
+                "global.amazon.nova-2-lite-v1": ModelPricing(
+                    tiers=[
+                        PricingTier(
+                            input_cost_per_token=per_million_tokens(0.36),
+                            output_cost_per_token=per_million_tokens(3.01),
+                        )
+                    ],
+                ),
+            },
+        }
+        monkeypatch.setattr("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional)
+        usage = Usage(input_tokens=1_000_000, output_tokens=0)
+        cost = calculate_bedrock_cost("global.amazon.nova-2-lite-v1:0", usage, region="ap-northeast-1")
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(0.36)
+
+    def test_geo_profile_uses_the_regions_standard_rate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bedrock bills a geo profile at the standard rate of the Region it is called from, so it
+        resolves to that Region's base-model override."""
+        regional = {
+            "eu-west-1": {
+                "meta.llama3-1-70b-instruct-v1": ModelPricing(
+                    tiers=[
+                        PricingTier(
+                            input_cost_per_token=per_million_tokens(3.0),
+                            output_cost_per_token=per_million_tokens(3.0),
+                        )
+                    ],
+                ),
+            },
+        }
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        monkeypatch.setattr("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional)
+        cost = calculate_bedrock_cost("eu.meta.llama3-1-70b-instruct-v1", usage, region="eu-west-1")
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(1000 * 3.0 / 1_000_000)
+
+    def test_global_profile_never_takes_a_regional_standard_rate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``global.`` is priced separately (~10% below standard), so a Region carrying only a
+        standard override must not capture a global call — that would bill the discounted profile
+        at the Region's standard rate. Absent regionally means it matches the default table."""
+        regional = {
+            "eu-west-1": {
+                "meta.llama3-1-70b-instruct-v1": ModelPricing(
+                    tiers=[
+                        PricingTier(
+                            input_cost_per_token=per_million_tokens(50.0),
+                            output_cost_per_token=per_million_tokens(50.0),
+                        )
+                    ],
+                ),
+            },
+        }
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        monkeypatch.setattr("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional)
+        cost = calculate_bedrock_cost("global.meta.llama3-1-70b-instruct-v1", usage, region="eu-west-1")
+        default = calculate_bedrock_cost("global.meta.llama3-1-70b-instruct-v1", usage)
+        assert cost is not None
+        assert default is not None
+        assert cost.total_cost == pytest.approx(default.total_cost)
 
     def test_regional_pricing_falls_back_to_default_for_unlisted_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A model not in regional overrides falls back to us-east-1 default."""

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     import boto3
     from aiobotocore.session import AioSession
 
-from lmux.cost import ModelPricing, PricingTier
+from lmux.cost import ModelPricing, PricingTier, per_million_tokens
 from lmux.exceptions import (
     AuthenticationError,
     InvalidRequestError,
@@ -824,6 +824,37 @@ class TestClientManagement:
         provider = BedrockProvider(auth=FakeAuth(_Session(region_name="ap-south-1")))
         provider.chat(MODEL, [UserMessage(content="Hi")])
         assert route.called
+
+    def test_session_region_prices_regionally(
+        self, converse_response: dict[str, Any], respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cost follows the Region the request was sent to even when no ``region=`` was passed.
+
+        Leaving it unset and letting the session resolve it (AWS_DEFAULT_REGION, a profile) is the
+        common configuration, so pricing must read the resolved Region rather than the constructor
+        argument, which is None here.
+        """
+        regional = {
+            "ap-south-1": {
+                MODEL: ModelPricing(
+                    tiers=[
+                        PricingTier(
+                            input_cost_per_token=per_million_tokens(9.0),
+                            output_cost_per_token=per_million_tokens(9.0),
+                        )
+                    ],
+                ),
+            },
+        }
+        monkeypatch.setattr("lmux_aws_bedrock.cost._REGIONAL_PRICING", regional)
+        base = "https://bedrock-runtime.ap-south-1.amazonaws.com"
+        respx_mock.post(_url(MODEL, "converse", base=base)).mock(
+            return_value=httpx.Response(200, json=converse_response)
+        )
+        provider = BedrockProvider(auth=FakeAuth(_Session(region_name="ap-south-1")))
+        response = provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert response.cost is not None
+        assert response.cost.input_cost == pytest.approx(10 * 9.0 / 1_000_000)
 
     def test_endpoint_url_override(
         self, fake_auth: FakeAuth, converse_response: dict[str, Any], respx_mock: respx.MockRouter

--- a/packages/lmux-bedrock-shared/pyproject.toml
+++ b/packages/lmux-bedrock-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-bedrock-shared"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared AWS Bedrock internals (SigV4 signing, event-stream decoding, Anthropic pricing) for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-bedrock-shared/src/lmux_bedrock_shared/pricing.py
+++ b/packages/lmux-bedrock-shared/src/lmux_bedrock_shared/pricing.py
@@ -340,6 +340,31 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "au.anthropic.claude-sonnet-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.2),
+                output_cost_per_token=per_million_tokens(11.0),
+                cache_read_cost_per_token=per_million_tokens(0.22),
+                cache_creation_cost_per_token=per_million_tokens(2.75),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(4.4)},
+            ),
+        ],
+        schedules=[
+            PricingSchedule(
+                valid_from=date(2026, 9, 1),
+                tiers=[
+                    PricingTier(
+                        input_cost_per_token=per_million_tokens(3.3),
+                        output_cost_per_token=per_million_tokens(16.5),
+                        cache_read_cost_per_token=per_million_tokens(0.33),
+                        cache_creation_cost_per_token=per_million_tokens(4.125),
+                        cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(6.6)},
+                    ),
+                ],
+            ),
+        ],
+    ),
     "eu.anthropic.claude-3-haiku-20240307-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -797,43 +822,321 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
     ),
 }
 
-_PRICING_BY_PREFIX = sorted(ANTHROPIC_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
+# Regional overrides for Claude (only Regions whose prices differ from us-east-1)
+ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
+    "ap-northeast-1": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "ap-northeast-2": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "ap-northeast-3": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "ap-south-1": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "ap-south-2": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "ap-southeast-1": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "ap-southeast-2": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "eu-north-1": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "eu-south-1": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "eu-south-2": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "eu-west-1": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "eu-west-3": {
+        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.0),
+                    output_cost_per_token=per_million_tokens(15.0),
+                ),
+            ],
+        ),
+    },
+    "us-gov-east-1": {
+        "anthropic.claude-3-5-sonnet-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.6),
+                    output_cost_per_token=per_million_tokens(18.0),
+                ),
+            ],
+        ),
+        "anthropic.claude-3-7-sonnet-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.6),
+                    output_cost_per_token=per_million_tokens(18.0),
+                    cache_read_cost_per_token=per_million_tokens(0.36),
+                    cache_creation_cost_per_token=per_million_tokens(4.5),
+                ),
+            ],
+        ),
+        "anthropic.claude-3-haiku-20240307-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.3),
+                    output_cost_per_token=per_million_tokens(1.5),
+                ),
+            ],
+        ),
+        "anthropic.claude-opus-4-8": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(6.0),
+                    output_cost_per_token=per_million_tokens(30.0),
+                    cache_read_cost_per_token=per_million_tokens(0.6),
+                    cache_creation_cost_per_token=per_million_tokens(7.5),
+                    cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(12.0)},
+                ),
+            ],
+        ),
+        "anthropic.claude-sonnet-4-5-20250929-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.6),
+                    output_cost_per_token=per_million_tokens(18.0),
+                    cache_read_cost_per_token=per_million_tokens(0.36),
+                    cache_creation_cost_per_token=per_million_tokens(4.5),
+                    cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(7.2)},
+                ),
+            ],
+        ),
+    },
+    "us-gov-west-1": {
+        "anthropic.claude-3-5-sonnet-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.6),
+                    output_cost_per_token=per_million_tokens(18.0),
+                ),
+            ],
+        ),
+        "anthropic.claude-3-7-sonnet-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.6),
+                    output_cost_per_token=per_million_tokens(18.0),
+                    cache_read_cost_per_token=per_million_tokens(0.36),
+                    cache_creation_cost_per_token=per_million_tokens(4.5),
+                ),
+            ],
+        ),
+        "anthropic.claude-3-haiku-20240307-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.3),
+                    output_cost_per_token=per_million_tokens(1.5),
+                ),
+            ],
+        ),
+        "anthropic.claude-opus-4-8": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(6.0),
+                    output_cost_per_token=per_million_tokens(30.0),
+                    cache_read_cost_per_token=per_million_tokens(0.6),
+                    cache_creation_cost_per_token=per_million_tokens(7.5),
+                    cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(12.0)},
+                ),
+            ],
+        ),
+        "anthropic.claude-sonnet-4-5-20250929-v1": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.6),
+                    output_cost_per_token=per_million_tokens(18.0),
+                    cache_read_cost_per_token=per_million_tokens(0.36),
+                    cache_creation_cost_per_token=per_million_tokens(4.5),
+                    cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(7.2)},
+                ),
+            ],
+        ),
+    },
+}
+
+_ANTHROPIC_BY_PREFIX = sorted(ANTHROPIC_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
+
+# The Region the default tables are priced for; every other Region is an override.
+DEFAULT_PRICING_REGION = "us-east-1"
+
+# Cross-region inference profile prefixes. Bedrock bills a profile call at the standard rate of the
+# Region the request is sent to, so a geo profile (e.g. "us.anthropic...") with no dedicated entry
+# resolves to the base model. "global." is priced separately (~10% below standard) and is never
+# resolved to the base model inside a regional table: absent there means it matches the default
+# table, not that it takes the Region's standard rate.
+GEO_PROFILE_PREFIXES = ("us.", "eu.", "apac.", "au.", "jp.", "ca.")
+GLOBAL_PROFILE_PREFIX = "global."
+INFERENCE_PROFILE_PREFIXES = (GLOBAL_PROFILE_PREFIX, *GEO_PROFILE_PREFIXES)
 
 
-# Cross-region inference profile prefixes. A profile call (e.g. "us.anthropic...")
-# with no dedicated regional entry falls back to the base model's pricing.
-_INFERENCE_PROFILE_PREFIXES = ("global.", "us.", "eu.", "apac.", "au.", "jp.", "ca.")
-
-
-def _strip_profile_prefix(model: str) -> str:
-    for prefix in _INFERENCE_PROFILE_PREFIXES:
+def strip_profile_prefix(model: str, prefixes: tuple[str, ...] = INFERENCE_PROFILE_PREFIXES) -> str:
+    """Drop an inference-profile prefix from a model ID, if it carries one."""
+    for prefix in prefixes:
         if model.startswith(prefix):
             return model[len(prefix) :]
     return model
 
 
-def _lookup_pricing(model: str) -> ModelPricing | None:
-    pricing = ANTHROPIC_PRICING.get(model)
+def lookup_pricing(
+    table: dict[str, ModelPricing],
+    by_prefix: list[tuple[str, ModelPricing]],
+    model: str,
+    strip_prefixes: tuple[str, ...],
+) -> ModelPricing | None:
+    """Exact match, then longest-prefix, then one retry against the profile-stripped ID."""
+    pricing = table.get(model)
     if pricing is not None:
         return pricing
-    for prefix, p in _PRICING_BY_PREFIX:
+    for prefix, p in by_prefix:
         if model.startswith(prefix):
             return p
-    bare = _strip_profile_prefix(model)
+    bare = strip_profile_prefix(model, strip_prefixes)
     if bare != model:
-        return _lookup_pricing(bare)
+        return lookup_pricing(table, by_prefix, bare, strip_prefixes)
     return None
 
 
-def calculate_bedrock_anthropic_cost(model: str, usage: Usage, *, as_of: date | None = None) -> Cost | None:
+def lookup_regional_pricing(
+    regional: dict[str, dict[str, ModelPricing]], region: str, model: str
+) -> ModelPricing | None:
+    """A Region's pricing override, or None when it has none and the default table applies.
+
+    Sorted per call rather than precomputed: the prefix order has to come from the same table the
+    exact match reads, or the two can disagree. Only one Region's handful of overrides is sorted,
+    on a request that already carries an HTTP round trip.
+    """
+    table = regional.get(region)
+    if not table:
+        return None
+    by_prefix = sorted(table.items(), key=lambda item: len(item[0]), reverse=True)
+    return lookup_pricing(table, by_prefix, model, GEO_PROFILE_PREFIXES)
+
+
+def calculate_bedrock_anthropic_cost(
+    model: str, usage: Usage, *, region: str | None = None, as_of: date | None = None
+) -> Cost | None:
     """Calculate cost for a native Anthropic-on-Bedrock call. None if pricing is unknown.
 
     Handles both bare model IDs and cross-region inference-profile IDs
-    (e.g. ``us.anthropic.claude-opus-4-8``). ``as_of`` selects dated pricing for
+    (e.g. ``us.anthropic.claude-opus-4-8``). ``region`` is the Region the request is sent to, which
+    is the Region Bedrock bills against -- a cross-Region inference profile is priced by the Region
+    it is called from, not by wherever the request is routed. ``as_of`` selects dated pricing for
     models with scheduled rate changes (e.g. Claude Sonnet 5's introductory
     period); it defaults to the latest schedule. See ``lmux.cost.calculate_cost``.
     """
-    pricing = _lookup_pricing(model)
+    if region is not None and region != DEFAULT_PRICING_REGION:
+        pricing = lookup_regional_pricing(ANTHROPIC_REGIONAL_PRICING, region, model)
+        if pricing is not None:
+            return cost_or_none(pricing, usage, as_of)
+    pricing = lookup_pricing(ANTHROPIC_PRICING, _ANTHROPIC_BY_PREFIX, model, INFERENCE_PROFILE_PREFIXES)
     if pricing is None:
+        return None
+    return calculate_cost(usage, pricing, as_of)
+
+
+def cost_or_none(pricing: ModelPricing, usage: Usage, as_of: date | None = None) -> Cost | None:
+    """Cost from a regional override, or None when it leaves a billed token dimension unpriced.
+
+    A Region may publish input/output but no cache meter; ``calculate_cost`` treats a missing rate
+    as zero, which would bill those cache tokens for free, so the unknown cost is reported as None
+    instead. Regional overrides are single-tier, so the base tier's rates decide.
+    """
+    tier = pricing.tiers[0]
+    creation = max(usage.cache_creation_tokens or 0, sum((usage.cache_creation_tokens_by_ttl or {}).values()))
+    if (usage.cache_read_tokens or 0) and tier.cache_read_cost_per_token is None:
+        return None
+    if creation and tier.cache_creation_cost_per_token is None and not tier.cache_creation_cost_per_token_by_ttl:
         return None
     return calculate_cost(usage, pricing, as_of)

--- a/packages/lmux-bedrock-shared/tests/test_pricing.py
+++ b/packages/lmux-bedrock-shared/tests/test_pricing.py
@@ -2,8 +2,44 @@
 
 from datetime import date
 
+import pytest
+
+from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens
 from lmux.types import Usage
-from lmux_bedrock_shared.pricing import calculate_bedrock_anthropic_cost
+from lmux_bedrock_shared.pricing import ANTHROPIC_REGIONAL_PRICING, calculate_bedrock_anthropic_cost, cost_or_none
+
+_TOKENS_NO_CACHE = ModelPricing(tiers=[PricingTier(input_cost_per_token=1e-6, output_cost_per_token=2e-6)])
+_TOKENS_WITH_CACHE = ModelPricing(
+    tiers=[
+        PricingTier(
+            input_cost_per_token=1e-6,
+            output_cost_per_token=2e-6,
+            cache_read_cost_per_token=1e-7,
+            cache_creation_cost_per_token=1e-6,
+        )
+    ]
+)
+
+
+class TestCostOrNone:
+    def test_no_cache_usage_is_priced(self) -> None:
+        usage = Usage(input_tokens=100, output_tokens=50)
+        assert cost_or_none(_TOKENS_NO_CACHE, usage) == calculate_cost(usage, _TOKENS_NO_CACHE)
+
+    def test_cache_read_without_rate_is_none(self) -> None:
+        assert cost_or_none(_TOKENS_NO_CACHE, Usage(input_tokens=100, output_tokens=50, cache_read_tokens=10)) is None
+
+    def test_cache_creation_without_rate_is_none(self) -> None:
+        usage = Usage(input_tokens=100, output_tokens=50, cache_creation_tokens=10)
+        assert cost_or_none(_TOKENS_NO_CACHE, usage) is None
+
+    def test_cache_creation_by_ttl_without_rate_is_none(self) -> None:
+        usage = Usage(input_tokens=100, output_tokens=50, cache_creation_tokens_by_ttl={"1h": 10})
+        assert cost_or_none(_TOKENS_NO_CACHE, usage) is None
+
+    def test_cache_usage_with_rate_is_priced(self) -> None:
+        usage = Usage(input_tokens=100, output_tokens=50, cache_read_tokens=10, cache_creation_tokens=10)
+        assert cost_or_none(_TOKENS_WITH_CACHE, usage) == calculate_cost(usage, _TOKENS_WITH_CACHE)
 
 
 class TestCalculateBedrockAnthropicCost:
@@ -44,6 +80,49 @@ class TestCalculateBedrockAnthropicCost:
         assert glob is not None
         assert regional is not None
         assert glob.input_cost < regional.input_cost
+
+    def test_regional_override_matches_versioned_request_id(self) -> None:
+        """A Region with published Claude overrides bills those rates, not us-east-1's.
+
+        Table keys omit the ``:0`` suffix real Bedrock model IDs carry, so the override has to
+        survive prefix matching. Driven off the shipped table rather than a hardcoded rate.
+        """
+        region = next(r for r, models in ANTHROPIC_REGIONAL_PRICING.items() if models)
+        model, pricing = next(iter(ANTHROPIC_REGIONAL_PRICING[region].items()))
+        usage = Usage(input_tokens=1000, output_tokens=500)
+        cost = calculate_bedrock_anthropic_cost(f"{model}:0", usage, region=region)
+        assert cost is not None
+        assert cost.total_cost == pytest.approx(calculate_cost(usage, pricing, None).total_cost)
+
+    def test_default_and_unknown_regions_use_the_default_table(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=0)
+        base = calculate_bedrock_anthropic_cost("anthropic.claude-opus-4-8", usage)
+        assert base is not None
+        for region in (None, "us-east-1", "xx-nowhere-99"):
+            assert calculate_bedrock_anthropic_cost("anthropic.claude-opus-4-8", usage, region=region) == base
+
+    def test_global_profile_never_takes_a_regional_standard_rate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``global.`` is priced separately (~10% below standard), so a Region carrying only a
+        standard override must not capture a global call."""
+        regional = {
+            "eu-west-1": {
+                "anthropic.claude-opus-4-8": ModelPricing(
+                    tiers=[
+                        PricingTier(
+                            input_cost_per_token=per_million_tokens(50.0),
+                            output_cost_per_token=per_million_tokens(50.0),
+                        )
+                    ],
+                ),
+            },
+        }
+        monkeypatch.setattr("lmux_bedrock_shared.pricing.ANTHROPIC_REGIONAL_PRICING", regional)
+        usage = Usage(input_tokens=1_000_000, output_tokens=0)
+        cost = calculate_bedrock_anthropic_cost("global.anthropic.claude-opus-4-8", usage, region="eu-west-1")
+        default = calculate_bedrock_anthropic_cost("global.anthropic.claude-opus-4-8", usage)
+        assert cost is not None
+        assert default is not None
+        assert cost.total_cost == pytest.approx(default.total_cost)
 
     def test_dated_schedule(self) -> None:
         usage = Usage(input_tokens=1_000_000, output_tokens=0)

--- a/scripts/update_bedrock_pricing.py
+++ b/scripts/update_bedrock_pricing.py
@@ -9,9 +9,12 @@ Then fetches real model and inference profile IDs from the Bedrock API
 (via boto3's default credential chain) to ensure pricing keys match actual
 Bedrock identifiers.
 
+Regional overrides for every Region are included by default (a handful of Regions -- notably
+GovCloud -- price some models above us-east-1); ``--regions`` narrows this for quick partial runs.
+
 Usage:
-    python3 scripts/update_bedrock_pricing.py --write
-    python3 scripts/update_bedrock_pricing.py               # stdout, us-east-1 only
+    python3 scripts/update_bedrock_pricing.py --write            # all Regions
+    python3 scripts/update_bedrock_pricing.py                    # stdout, all Regions
     python3 scripts/update_bedrock_pricing.py --regions eu-west-1 ap-northeast-1
 """
 
@@ -25,7 +28,7 @@ from dataclasses import dataclass, fields, replace
 from datetime import date
 from decimal import ROUND_HALF_UP, Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError, EndpointConnectionError
@@ -572,11 +575,18 @@ def _set_dimension(mp: ModelPrices, dim_name: str, price: Decimal) -> None:
         mp.cache_write_1h_cost = price
 
 
-def parse_amazon_models(data: dict[str, Any]) -> tuple[dict[str, ModelPrices], dict[str, ModelPrices]]:
+def parse_amazon_models(
+    data: dict[str, Any], *, fallback_to_global: bool = True
+) -> tuple[dict[str, ModelPrices], dict[str, ModelPrices]]:
     """Parse non-mantle entries from AmazonBedrock API for Amazon + legacy models.
 
     Returns (default_pricing, global_pricing) where global_pricing contains only
     models that have cross-region global inference profile pricing.
+
+    ``fallback_to_global`` fills a missing standard rate from the global rate. Correct for the
+    us-east-1 baseline (a global-only model still needs a list price), but wrong for regional diffs:
+    a Region that publishes only the global meter has no genuine standard rate, and emitting the
+    global discount as its standard rate under-reports geo-profile calls (see ``_fetch_regional_diffs``).
     """
     products = data.get("products", {})
     terms = data.get("terms", {}).get("OnDemand", {})
@@ -620,8 +630,7 @@ def parse_amazon_models(data: dict[str, Any]) -> tuple[dict[str, ModelPrices], d
         for dim_name, prices_by_scope in dims.items():
             non_global_price = prices_by_scope.get(False)
             global_price = prices_by_scope.get(True)
-            # Default uses non-global price, falls back to global
-            price = non_global_price if non_global_price is not None else global_price
+            price = non_global_price if non_global_price is not None else (global_price if fallback_to_global else None)
             if price is not None:
                 _set_dimension(default_mp, dim_name, price)
             if global_price is not None:
@@ -724,11 +733,16 @@ def _is_global_fm(usagetype: str) -> bool:
     return legacy_global or snake_global
 
 
-def parse_foundation_models(data: dict[str, Any]) -> tuple[dict[str, ModelPrices], dict[str, ModelPrices]]:
+def parse_foundation_models(
+    data: dict[str, Any], *, fallback_to_global: bool = True
+) -> tuple[dict[str, ModelPrices], dict[str, ModelPrices]]:
     """Parse AmazonBedrockFoundationModels API. Prices are per million tokens.
 
     Returns (default_pricing, global_pricing) where global_pricing contains only
     models that have cross-region global inference profile pricing.
+
+    ``fallback_to_global`` fills a missing standard rate from the global rate -- see
+    :func:`parse_amazon_models`; it is disabled for regional diffs.
     """
     products = data.get("products", {})
     terms = data.get("terms", {}).get("OnDemand", {})
@@ -767,16 +781,19 @@ def parse_foundation_models(data: dict[str, Any]) -> tuple[dict[str, ModelPrices
     if unmapped:
         _warn(f"Unmapped Foundation Models servicenames: {sorted(unmapped)}")
 
-    return _build_fm_result(collected)
+    return _build_fm_result(collected, fallback_to_global=fallback_to_global)
 
 
 def _build_fm_result(
     collected: dict[str, dict[tuple[str, bool, bool], Decimal]],
+    *,
+    fallback_to_global: bool = True,
 ) -> tuple[dict[str, ModelPrices], dict[str, ModelPrices]]:
     """Build ModelPrices from collected Foundation Models data.
 
-    Returns (default_pricing, global_pricing) where default uses non-global prices
-    (falling back to global), and global_pricing contains only models with global pricing.
+    Returns (default_pricing, global_pricing). ``default`` uses non-global (standard) prices;
+    ``fallback_to_global`` fills a missing standard dimension from the global rate (see
+    :func:`parse_amazon_models`). ``global_pricing`` contains only models with global pricing.
     """
     result: dict[str, ModelPrices] = {}
     global_result: dict[str, ModelPrices] = {}
@@ -785,10 +802,9 @@ def _build_fm_result(
         global_mp = ModelPrices()
         has_global = False
         for dim_name in ("input", "output", "cache_read", "cache_write", "cache_write_1h"):
-            # Standard tier: prefer non-global, fall back to global
             non_global_std = prices.get((dim_name, False, False))
             global_std = prices.get((dim_name, False, True))
-            std = non_global_std if non_global_std is not None else global_std
+            std = non_global_std if non_global_std is not None else (global_std if fallback_to_global else None)
             if std is not None:
                 _set_dimension(default_mp, dim_name, std)
             if global_std is not None:
@@ -798,7 +814,7 @@ def _build_fm_result(
             # Long-context tier: same pattern
             non_global_lctx = prices.get((dim_name, True, False))
             global_lctx = prices.get((dim_name, True, True))
-            lctx = non_global_lctx if non_global_lctx is not None else global_lctx
+            lctx = non_global_lctx if non_global_lctx is not None else (global_lctx if fallback_to_global else None)
             _set_fm_lctx(default_mp, dim_name, lctx)
             if global_lctx is not None:
                 _set_fm_lctx(global_mp, dim_name, global_lctx)
@@ -864,6 +880,38 @@ def compute_regional_diffs(default: dict[str, ModelPrices], regional: dict[str, 
         if def_prices is None or _prices_differ(def_prices, reg_prices):
             diffs[model_id] = reg_prices
     return diffs
+
+
+def _tier_is_emittable(input_cost: Decimal | None, output_cost: Decimal | None, *, is_embedding: bool) -> bool:
+    """Whether a tier has the rates ``PricingTier`` requires. Embeddings bill no output tokens."""
+    if input_cost is None:
+        return False
+    return is_embedding or output_cost is not None
+
+
+def drop_unemittable(prices: dict[str, ModelPrices]) -> tuple[dict[str, ModelPrices], list[tuple[str, str]]]:
+    """Split overrides into those safe to emit and the (model ID, reason) pairs that are not.
+
+    Input and output rates are mandatory -- a ``PricingTier`` will not construct without them -- so a
+    Region that omits either (e.g. ap-east-2 lists ``APE2-NovaLite-input-tokens`` with no non-batch
+    ``-output-tokens``) is dropped and falls back to us-east-1. A Region that prices input/output but
+    omits a cache dimension (e.g. eu-west-2 Nova Pro, whose cache reads are priced only on the flex
+    and priority tiers) is kept: its genuine input/output premium is emitted, and a cached call
+    against the missing rate is reported as unpriced at runtime -- see
+    ``lmux.cost.usage_has_unpriced_dimension`` -- rather than billed for free.
+    """
+    keep: dict[str, ModelPrices] = {}
+    dropped: list[tuple[str, str]] = []
+    for model_id, mp in prices.items():
+        is_emb = _is_embedding(model_id)
+        if not _tier_is_emittable(mp.input_cost, mp.output_cost, is_embedding=is_emb):
+            dropped.append((model_id, "no complete on-demand tier"))
+            continue
+        if mp.has_lctx and not _tier_is_emittable(mp.lctx_input_cost, mp.lctx_output_cost, is_embedding=is_emb):
+            dropped.append((model_id, "no complete long-context tier"))
+            continue
+        keep[model_id] = mp
+    return keep, dropped
 
 
 def _prices_differ(a: ModelPrices, b: ModelPrices) -> bool:
@@ -944,12 +992,10 @@ def _emit_import_lines(lines: list[str], *, has_dated: bool) -> None:
     """Emit the datetime + lmux imports common to both generated pricing modules."""
     lines.append("from datetime import date")
     lines.append("")
+    names = ["ModelPricing", "PricingTier", "calculate_cost", "per_million_tokens"]
     if has_dated:
-        lines.append(
-            "from lmux.cost import ModelPricing, PricingSchedule, PricingTier, calculate_cost, per_million_tokens"
-        )
-    else:
-        lines.append("from lmux.cost import ModelPricing, PricingTier, calculate_cost, per_million_tokens")
+        names.insert(1, "PricingSchedule")
+    lines.append("from lmux.cost import " + ", ".join(names))
     lines.append("from lmux.types import Cost, Usage")
 
 
@@ -976,7 +1022,15 @@ def _emit_header(lines: list[str], *, has_regional: bool, has_dated: bool) -> No
     lines.append('"""')
     lines.append("")
     _emit_import_lines(lines, has_dated=has_dated)
-    lines.append("from lmux_bedrock_shared.pricing import ANTHROPIC_PRICING")
+    lines.append("from lmux_bedrock_shared.pricing import (")
+    lines.append("    ANTHROPIC_PRICING,")
+    lines.append("    ANTHROPIC_REGIONAL_PRICING,")
+    lines.append("    DEFAULT_PRICING_REGION,")
+    lines.append("    INFERENCE_PROFILE_PREFIXES,")
+    lines.append("    cost_or_none,")
+    lines.append("    lookup_pricing,")
+    lines.append("    lookup_regional_pricing,")
+    lines.append(")")
     lines.append("")
 
 
@@ -1000,14 +1054,17 @@ def _emit_pricing_dict(lines: list[str], pricing: dict[str, ModelPrices]) -> Non
     lines.append("")
 
 
-def _emit_regional_dict(
+def _emit_nested_pricing_dict(
     lines: list[str],
+    name: str,
     regional: dict[str, dict[str, ModelPrices]] | None,
+    *,
+    comment: str,
 ) -> None:
-    """Emit the _REGIONAL_PRICING dict and prefix list."""
-    if regional:
-        lines.append("# Regional pricing overrides (only models that differ from us-east-1)")
-        lines.append("_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {")
+    """Emit a ``{region: {model_id: ModelPricing}}`` literal under ``name``."""
+    if regional and any(regional.values()):
+        lines.append(f"# {comment}")
+        lines.append(f"{name}: dict[str, dict[str, ModelPricing]] = {{")
         for region in sorted(regional.keys()):
             if not regional[region]:
                 continue
@@ -1016,11 +1073,28 @@ def _emit_regional_dict(
                 _emit_model_pricing(lines, model_id, regional[region][model_id], indent=8)
             lines.append("    },")
         lines.append("}")
-        lines.append("")
     else:
-        lines.append("_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {}")
-        lines.append("")
+        lines.append(f"{name}: dict[str, dict[str, ModelPricing]] = {{}}")
+    lines.append("")
 
+
+def _emit_regional_dict(
+    lines: list[str],
+    regional: dict[str, dict[str, ModelPrices]] | None,
+) -> None:
+    """Emit the non-Anthropic regional overrides merged with the shared Anthropic subset."""
+    _emit_nested_pricing_dict(
+        lines,
+        "_BEDROCK_REGIONAL",
+        regional,
+        comment="Regional pricing overrides (only models that differ from us-east-1)",
+    )
+    lines.append("# Claude's overrides come from the shared table, so both Bedrock providers price it identically.")
+    lines.append("_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {")
+    lines.append("    region: {**_BEDROCK_REGIONAL.get(region, {}), **ANTHROPIC_REGIONAL_PRICING.get(region, {})}")
+    lines.append("    for region in _BEDROCK_REGIONAL.keys() | ANTHROPIC_REGIONAL_PRICING.keys()")
+    lines.append("}")
+    lines.append("")
     lines.append("# Pre-sorted by key length descending for longest-prefix matching")
     lines.append("_PRICING_BY_PREFIX = sorted(_PRICING.items(), key=lambda item: len(item[0]), reverse=True)")
     lines.append("")
@@ -1028,54 +1102,26 @@ def _emit_regional_dict(
 
 
 _FUNCTION_BODY = """\
-# Cross-region inference profile prefixes. A profile call (e.g. "us.anthropic...")
-# with no dedicated regional entry falls back to the base model's pricing.
-_INFERENCE_PROFILE_PREFIXES = ("global.", "us.", "eu.", "apac.", "au.", "jp.", "ca.")
-
-
-def _strip_profile_prefix(model: str) -> str:
-    for prefix in _INFERENCE_PROFILE_PREFIXES:
-        if model.startswith(prefix):
-            return model[len(prefix) :]
-    return model
-
-
-def _lookup_default_pricing(model: str) -> ModelPricing | None:
-    pricing = _PRICING.get(model)
-    if pricing is not None:
-        return pricing
-    for prefix, p in _PRICING_BY_PREFIX:
-        if model.startswith(prefix):
-            return p
-    bare = _strip_profile_prefix(model)
-    if bare != model:
-        return _lookup_default_pricing(bare)
-    return None
-
-
 def calculate_bedrock_cost(
     model: str, usage: Usage, *, region: str | None = None, as_of: date | None = None
 ) -> Cost | None:
     \"\"\"Calculate cost for a Bedrock API call. Returns None if model pricing is unknown.
 
-    ``as_of`` selects dated pricing for models with scheduled rate changes
+    ``region`` is the Region the request is sent to, which is the Region Bedrock bills against --
+    a cross-Region inference profile is priced by the Region it is called from, not by wherever the
+    request is routed. ``as_of`` selects dated pricing for models with scheduled rate changes
     (e.g. Claude Sonnet 5's introductory period); it defaults to the latest
     schedule. See ``lmux.cost.calculate_cost``.
-    \"\"\"
-    # Try regional pricing first if region specified
-    if region is not None and region != "us-east-1":
-        regional = _REGIONAL_PRICING.get(region, {})
-        pricing = regional.get(model)
-        if pricing is None:
-            for prefix, p in sorted(regional.items(), key=lambda item: len(item[0]), reverse=True):
-                if model.startswith(prefix):
-                    pricing = p
-                    break
-        if pricing is not None:
-            return calculate_cost(usage, pricing, as_of)
 
-    # Fall back to default (us-east-1) pricing
-    pricing = _lookup_default_pricing(model)
+    Matching is shared with the native Anthropic Bedrock provider (see
+    ``lmux_bedrock_shared.pricing``) so Claude resolves identically through either.
+    \"\"\"
+    if region is not None and region != DEFAULT_PRICING_REGION:
+        pricing = lookup_regional_pricing(_REGIONAL_PRICING, region, model)
+        if pricing is not None:
+            return cost_or_none(pricing, usage, as_of)
+
+    pricing = lookup_pricing(_PRICING, _PRICING_BY_PREFIX, model, INFERENCE_PROFILE_PREFIXES)
     if pricing is None:
         return None
     return calculate_cost(usage, pricing, as_of)
@@ -1088,50 +1134,118 @@ def _emit_function(lines: list[str]) -> None:
     lines.append("")
 
 
+def _split_regional(
+    regional: dict[str, dict[str, ModelPrices]] | None,
+    *,
+    anthropic: bool,
+) -> dict[str, dict[str, ModelPrices]]:
+    """Take either the Anthropic or the non-Anthropic half of the regional overrides."""
+    split: dict[str, dict[str, ModelPrices]] = {}
+    for region, models in (regional or {}).items():
+        half = {mid: mp for mid, mp in models.items() if _is_anthropic(mid) is anthropic}
+        if half:
+            split[region] = half
+    return split
+
+
 def _is_anthropic(model_id: str) -> bool:
     """Whether a (possibly profile-prefixed) model ID is an Anthropic Claude model."""
     return _strip_profile_prefix(model_id).startswith("anthropic.")
 
 
 _SHARED_ANTHROPIC_FUNCTION_BODY = '''\
-_PRICING_BY_PREFIX = sorted(ANTHROPIC_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
+_ANTHROPIC_BY_PREFIX = sorted(ANTHROPIC_PRICING.items(), key=lambda item: len(item[0]), reverse=True)
+
+# The Region the default tables are priced for; every other Region is an override.
+DEFAULT_PRICING_REGION = "us-east-1"
+
+# Cross-region inference profile prefixes. Bedrock bills a profile call at the standard rate of the
+# Region the request is sent to, so a geo profile (e.g. "us.anthropic...") with no dedicated entry
+# resolves to the base model. "global." is priced separately (~10% below standard) and is never
+# resolved to the base model inside a regional table: absent there means it matches the default
+# table, not that it takes the Region's standard rate.
+GEO_PROFILE_PREFIXES = ("us.", "eu.", "apac.", "au.", "jp.", "ca.")
+GLOBAL_PROFILE_PREFIX = "global."
+INFERENCE_PROFILE_PREFIXES = (GLOBAL_PROFILE_PREFIX, *GEO_PROFILE_PREFIXES)
 
 
-# Cross-region inference profile prefixes. A profile call (e.g. "us.anthropic...")
-# with no dedicated regional entry falls back to the base model's pricing.
-_INFERENCE_PROFILE_PREFIXES = ("global.", "us.", "eu.", "apac.", "au.", "jp.", "ca.")
-
-
-def _strip_profile_prefix(model: str) -> str:
-    for prefix in _INFERENCE_PROFILE_PREFIXES:
+def strip_profile_prefix(model: str, prefixes: tuple[str, ...] = INFERENCE_PROFILE_PREFIXES) -> str:
+    """Drop an inference-profile prefix from a model ID, if it carries one."""
+    for prefix in prefixes:
         if model.startswith(prefix):
             return model[len(prefix) :]
     return model
 
 
-def _lookup_pricing(model: str) -> ModelPricing | None:
-    pricing = ANTHROPIC_PRICING.get(model)
+def lookup_pricing(
+    table: dict[str, ModelPricing],
+    by_prefix: list[tuple[str, ModelPricing]],
+    model: str,
+    strip_prefixes: tuple[str, ...],
+) -> ModelPricing | None:
+    """Exact match, then longest-prefix, then one retry against the profile-stripped ID."""
+    pricing = table.get(model)
     if pricing is not None:
         return pricing
-    for prefix, p in _PRICING_BY_PREFIX:
+    for prefix, p in by_prefix:
         if model.startswith(prefix):
             return p
-    bare = _strip_profile_prefix(model)
+    bare = strip_profile_prefix(model, strip_prefixes)
     if bare != model:
-        return _lookup_pricing(bare)
+        return lookup_pricing(table, by_prefix, bare, strip_prefixes)
     return None
 
 
-def calculate_bedrock_anthropic_cost(model: str, usage: Usage, *, as_of: date | None = None) -> Cost | None:
+def lookup_regional_pricing(
+    regional: dict[str, dict[str, ModelPricing]], region: str, model: str
+) -> ModelPricing | None:
+    """A Region's pricing override, or None when it has none and the default table applies.
+
+    Sorted per call rather than precomputed: the prefix order has to come from the same table the
+    exact match reads, or the two can disagree. Only one Region's handful of overrides is sorted,
+    on a request that already carries an HTTP round trip.
+    """
+    table = regional.get(region)
+    if not table:
+        return None
+    by_prefix = sorted(table.items(), key=lambda item: len(item[0]), reverse=True)
+    return lookup_pricing(table, by_prefix, model, GEO_PROFILE_PREFIXES)
+
+
+def calculate_bedrock_anthropic_cost(
+    model: str, usage: Usage, *, region: str | None = None, as_of: date | None = None
+) -> Cost | None:
     """Calculate cost for a native Anthropic-on-Bedrock call. None if pricing is unknown.
 
     Handles both bare model IDs and cross-region inference-profile IDs
-    (e.g. ``us.anthropic.claude-opus-4-8``). ``as_of`` selects dated pricing for
+    (e.g. ``us.anthropic.claude-opus-4-8``). ``region`` is the Region the request is sent to, which
+    is the Region Bedrock bills against -- a cross-Region inference profile is priced by the Region
+    it is called from, not by wherever the request is routed. ``as_of`` selects dated pricing for
     models with scheduled rate changes (e.g. Claude Sonnet 5's introductory
     period); it defaults to the latest schedule. See ``lmux.cost.calculate_cost``.
     """
-    pricing = _lookup_pricing(model)
+    if region is not None and region != DEFAULT_PRICING_REGION:
+        pricing = lookup_regional_pricing(ANTHROPIC_REGIONAL_PRICING, region, model)
+        if pricing is not None:
+            return cost_or_none(pricing, usage, as_of)
+    pricing = lookup_pricing(ANTHROPIC_PRICING, _ANTHROPIC_BY_PREFIX, model, INFERENCE_PROFILE_PREFIXES)
     if pricing is None:
+        return None
+    return calculate_cost(usage, pricing, as_of)
+
+
+def cost_or_none(pricing: ModelPricing, usage: Usage, as_of: date | None = None) -> Cost | None:
+    """Cost from a regional override, or None when it leaves a billed token dimension unpriced.
+
+    A Region may publish input/output but no cache meter; ``calculate_cost`` treats a missing rate
+    as zero, which would bill those cache tokens for free, so the unknown cost is reported as None
+    instead. Regional overrides are single-tier, so the base tier's rates decide.
+    """
+    tier = pricing.tiers[0]
+    creation = max(usage.cache_creation_tokens or 0, sum((usage.cache_creation_tokens_by_ttl or {}).values()))
+    if (usage.cache_read_tokens or 0) and tier.cache_read_cost_per_token is None:
+        return None
+    if creation and tier.cache_creation_cost_per_token is None and not tier.cache_creation_cost_per_token_by_ttl:
         return None
     return calculate_cost(usage, pricing, as_of)
 '''
@@ -1155,15 +1269,27 @@ def _emit_shared_header(lines: list[str], *, has_dated: bool) -> None:
     lines.append("")
 
 
-def generate_shared_anthropic_py(pricing: dict[str, ModelPrices]) -> str:
+def generate_shared_anthropic_py(
+    pricing: dict[str, ModelPrices],
+    regional: dict[str, dict[str, ModelPrices]] | None = None,
+) -> str:
     """Generate the lmux_bedrock_shared.pricing source (Anthropic-on-Bedrock subset)."""
     lines: list[str] = []
-    _emit_shared_header(lines, has_dated=any(_dated_schedule_for(mid) for mid in pricing))
+    has_dated = any(_dated_schedule_for(mid) for mid in pricing) or any(
+        _dated_schedule_for(mid) for models in (regional or {}).values() for mid in models
+    )
+    _emit_shared_header(lines, has_dated=has_dated)
     lines.append("ANTHROPIC_PRICING: dict[str, ModelPricing] = {")
     for model_id in sorted(pricing):
         _emit_model_pricing(lines, model_id, pricing[model_id])
     lines.append("}")
     lines.append("")
+    _emit_nested_pricing_dict(
+        lines,
+        "ANTHROPIC_REGIONAL_PRICING",
+        regional,
+        comment="Regional overrides for Claude (only Regions whose prices differ from us-east-1)",
+    )
     lines.extend(_SHARED_ANTHROPIC_FUNCTION_BODY.splitlines())
     lines.append("")
     return "\n".join(lines)
@@ -1299,23 +1425,82 @@ def _warn(msg: str) -> None:
     print(f"WARNING: {msg}", file=sys.stderr)  # noqa: T201
 
 
+def _die(msg: str) -> NoReturn:
+    """Print an error to stderr and exit non-zero, leaving any existing generated files untouched."""
+    print(f"ERROR: {msg}", file=sys.stderr)  # noqa: T201
+    raise SystemExit(1)
+
+
+def _region_overrides(  # noqa: PLR0913
+    reg_bedrock: dict[str, Any],
+    reg_fm: dict[str, Any],
+    default_pricing: dict[str, ModelPrices],
+    global_pricing: dict[str, ModelPrices],
+    global_models: set[str],
+    resolution_map: dict[str, str],
+    region: str,
+) -> dict[str, ModelPrices]:
+    """A Region's standard (bare) and Global-profile (``global.``) overrides vs us-east-1.
+
+    Standard overrides use only non-global meters (a Global-only meter is not a genuine standard
+    rate). Global overrides come from the Global meters: a Global-profile call is billed by the
+    Region it is called from, and AWS publishes a per-Region Global rate (uniform for Claude, but
+    not for Nova/Titan), so those must be kept where they differ from the us-east-1 Global rate --
+    keyed ``global.<id>`` -- rather than falling through to the single us-east-1 Global rate.
+
+    ``global_models`` are the resolved model IDs that actually have a Global inference profile (the
+    default table's ``global.`` keys). A Global override is emitted only for those: some models
+    carry a Global *meter* in the price list but no invokable Global profile, so a ``global.`` key
+    for them would price a call that cannot be made.
+    """
+    reg_mantle = parse_mantle_models(reg_bedrock)
+    reg_amazon, reg_amazon_global = parse_amazon_models(reg_bedrock, fallback_to_global=False)
+    reg_foundation, reg_foundation_global = parse_foundation_models(reg_fm, fallback_to_global=False)
+
+    reg_std = resolve_pricing_ids(merge_pricing(reg_mantle, reg_amazon, reg_foundation), resolution_map)
+    std_diffs, std_dropped = drop_unemittable(compute_regional_diffs(default_pricing, reg_std))
+
+    reg_global = resolve_pricing_ids(merge_pricing({}, reg_amazon_global, reg_foundation_global), resolution_map)
+    reg_global = {mid: mp for mid, mp in reg_global.items() if mid in global_models}
+    global_diffs, global_dropped = drop_unemittable(compute_regional_diffs(global_pricing, reg_global))
+
+    for model_id, reason in std_dropped:
+        _warn(f"  {region}: {model_id} — {reason}; falling back to us-east-1 pricing")
+    for model_id, reason in global_dropped:
+        _warn(f"  {region}: global.{model_id} — {reason}; falling back to us-east-1 global pricing")
+
+    return {**std_diffs, **{f"global.{model_id}": mp for model_id, mp in global_diffs.items()}}
+
+
 def _fetch_regional_diffs(
     args: argparse.Namespace,
     default_pricing: dict[str, ModelPrices],
+    global_pricing: dict[str, ModelPrices],
+    global_models: set[str],
+    resolution_map: dict[str, str],
 ) -> dict[str, dict[str, ModelPrices]] | None:
-    """Fetch pricing for requested regions and return diffs from us-east-1."""
-    if not args.regions and not args.all_regions:
-        return None
+    """Fetch pricing for every Region (or those requested) and return overrides vs us-east-1.
 
-    if args.all_regions:
+    ``resolution_map`` must be the one already applied to ``default_pricing``/``global_pricing``:
+    both sides of the comparison have to be keyed by real Bedrock model IDs, or every dated model
+    misses the lookup and is reported as a spurious diff under an ID no request ever carries.
+    ``global_models`` are the resolved IDs with a Global profile (see :func:`_region_overrides`).
+    """
+    if args.regions:
+        # An explicit narrowing for quick partial runs. On a write it yields a partial table --
+        # only the requested Regions keep overrides -- so warn rather than silently drop the rest.
+        if args.write:
+            _warn("--regions with --write emits overrides for only those Regions; omit --regions to refresh all.")
+        regions = [r for r in args.regions if r != DEFAULT_REGION]
+    else:
+        # Default (including the documented bare --write): every Region, so a refresh regenerates
+        # the full regional table instead of wiping it.
         bedrock_index = fetch_region_index("AmazonBedrock")
         fm_index = fetch_region_index("AmazonBedrockFoundationModels")
-        regions = sorted(set(bedrock_index.keys()) | set(fm_index.keys()))
-        regions = [r for r in regions if r != DEFAULT_REGION]
-    else:
-        regions = [r for r in args.regions if r != DEFAULT_REGION]
+        regions = sorted((set(bedrock_index.keys()) | set(fm_index.keys())) - {DEFAULT_REGION})
 
     regional_diffs: dict[str, dict[str, ModelPrices]] = {}
+    failed: list[str] = []
     for region in regions:
         _info(f"Fetching pricing for {region}...")
         try:
@@ -1323,19 +1508,28 @@ def _fetch_regional_diffs(
             reg_fm = fetch_pricing("AmazonBedrockFoundationModels", region)
         except (urllib.error.URLError, json.JSONDecodeError, KeyError) as e:
             _warn(f"Failed to fetch {region}: {e}")
+            failed.append(region)
             continue
 
-        reg_mantle = parse_mantle_models(reg_bedrock)
-        reg_amazon, _ = parse_amazon_models(reg_bedrock)
-        reg_foundation, _ = parse_foundation_models(reg_fm)
-        reg_merged = merge_pricing(reg_mantle, reg_amazon, reg_foundation)
-
-        diffs = compute_regional_diffs(default_pricing, reg_merged)
-        if diffs:
-            regional_diffs[region] = diffs
-            _info(f"  {region}: {len(diffs)} models differ from us-east-1")
+        overrides = _region_overrides(
+            reg_bedrock, reg_fm, default_pricing, global_pricing, global_models, resolution_map, region
+        )
+        if overrides:
+            regional_diffs[region] = overrides
+            _info(f"  {region}: {len(overrides)} overrides differ from us-east-1")
         else:
             _info(f"  {region}: all prices match us-east-1")
+
+    if failed:
+        detail = ", ".join(failed)
+        # A partial fetch must not overwrite a complete committed table: a skipped Region's genuine
+        # overrides would vanish and every call there would silently fall back to us-east-1.
+        if args.write:
+            _die(
+                f"{len(failed)} region(s) failed to fetch ({detail}); refusing to --write a table that would "
+                "drop their overrides. Re-run when the Pricing API is reachable."
+            )
+        _warn(f"{len(failed)} region(s) failed to fetch ({detail}); the printed table omits them.")
 
     return regional_diffs or None
 
@@ -1356,12 +1550,12 @@ def main() -> None:
         "--regions",
         nargs="+",
         metavar="REGION",
-        help="Include regional pricing overrides for these regions",
+        help="Only these regions get overrides (default: all regions)",
     )
     _ = parser.add_argument(
         "--all-regions",
         action="store_true",
-        help="Include all available regions",
+        help="Deprecated no-op: all regions are included by default",
     )
     args = parser.parse_args()
 
@@ -1403,20 +1597,21 @@ def main() -> None:
     expanded_pricing = expand_with_real_profiles(default_pricing, global_pricing, real_profile_ids)
     _info(f"Total entries after inference profile expansion: {len(expanded_pricing)}")
 
-    # Regional pricing (compared against unexpanded default)
-    regional_diffs = _fetch_regional_diffs(args, default_pricing)
+    # Regional pricing (compared against unexpanded default/global, re-keyed the same way). Only
+    # models with a real Global profile (a "global." key in the expanded table) get Global overrides.
+    global_models = {k[len("global.") :] for k in expanded_pricing if k.startswith("global.")}
+    regional_diffs = _fetch_regional_diffs(args, default_pricing, global_pricing, global_models, resolution_map)
 
     # Split off the Anthropic-on-Bedrock subset (shared with the native lmux-anthropic Bedrock
-    # provider). The shared subset carries default and inference-profile pricing only: the native
-    # provider prices by request ID alone, so it has no per-region dimension to hold overrides.
-    # Per-region overrides therefore stay whole in lmux-aws-bedrock's _REGIONAL_PRICING, which its
-    # Converse provider consults with the request's region before falling back to the default table.
+    # provider), default and regional alike, so both consumers price Claude from the same table.
+    # lmux-aws-bedrock merges the Anthropic subset back into its own tables.
     anthropic_pricing = {mid: mp for mid, mp in expanded_pricing.items() if _is_anthropic(mid)}
     bedrock_pricing = {mid: mp for mid, mp in expanded_pricing.items() if not _is_anthropic(mid)}
-    bedrock_regional = regional_diffs or {}
+    anthropic_regional = _split_regional(regional_diffs, anthropic=True)
+    bedrock_regional = _split_regional(regional_diffs, anthropic=False)
 
     # Generate code
-    shared_code = generate_shared_anthropic_py(anthropic_pricing)
+    shared_code = generate_shared_anthropic_py(anthropic_pricing, anthropic_regional)
     bedrock_code = generate_cost_py(bedrock_pricing, bedrock_regional)
 
     if args.write:

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ requires-dist = [{ name = "pydantic", specifier = "~=2.10" }]
 
 [[package]]
 name = "lmux-anthropic"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "packages/lmux-anthropic" }
 dependencies = [
     { name = "httpx" },
@@ -703,7 +703,7 @@ provides-extras = ["vertex", "bedrock"]
 
 [[package]]
 name = "lmux-aws-bedrock"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/lmux-aws-bedrock" }
 dependencies = [
     { name = "boto3" },
@@ -751,7 +751,7 @@ provides-extras = ["identity"]
 
 [[package]]
 name = "lmux-bedrock-shared"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/lmux-bedrock-shared" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
The Bedrock regional pricing in the last release was mostly an artifact: bare-model regional overrides were filled from each Region's Global cross-Region meter, so smaller Regions looked ~10% *cheaper* than us-east-1 — the uniform `0.9091x` global-discount ratio mistaken for a standard regional rate. Genuine regional variation is a premium (GovCloud, and Nova/Titan in smaller Regions), which the table now reflects.

Generator now diffs each Region's standard (non-global) meters against us-east-1 rather than the Global fallback; keeps per-Region `global.<id>` rates separately (a Global call is billed by its source Region — uniform for Claude, not for Nova/Titan) for models that actually have a Global profile; resolves regional IDs so overrides match the versioned IDs real requests carry; keeps a partial override's genuine input/output premium while reporting a cached call as unpriced (`None`) where a Region publishes no cache meter; and defaults `--write` to every Region, aborting on any fetch failure so a refresh never wipes the table.

Both providers now price by the resolved request Region and share the same Region-aware lookup, so Converse and the native Anthropic provider never drift. Minor bumps: `lmux-bedrock-shared` 0.2.0, `lmux-aws-bedrock` 0.12.0, `lmux-anthropic` 0.14.0 (shared pin raised to `~=0.2`); core `lmux` unchanged. The bulk of the diff is regenerated pricing data — the reviewable changes are `scripts/update_bedrock_pricing.py` and the tests.