### PR TITLE
fix(pricing): refresh provider pricing and repair unreachable Bedrock keys

### DIFF
--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-anthropic"
-version = "0.14.0"
+version = "0.14.1"
 description = "Anthropic provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-anthropic/src/lmux_anthropic/cost.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/cost.py
@@ -56,6 +56,18 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    # Claude Opus 5 family
+    "claude-opus-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(25.00),
+                cache_read_cost_per_token=per_million_tokens(0.50),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(10.00)},
+            ),
+        ],
+    ),
     # Claude Sonnet 5 family — introductory pricing through 2026-08-31, then
     # standard pricing (matching Sonnet 4.6) from 2026-09-01. Full 1M context
     # at standard pricing, so there is no >200K tier.
@@ -299,6 +311,7 @@ _VERTEX_UNIFORM_PRICING_MODELS = (
 _VERTEX_PREMIUM_PRICING_MODELS = (
     "claude-fable-5",
     "claude-mythos-5",
+    "claude-opus-5",
     "claude-sonnet-5",
     "claude-opus-4-8",
     "claude-opus-4-7",

--- a/packages/lmux-anthropic/tests/test_cost.py
+++ b/packages/lmux-anthropic/tests/test_cost.py
@@ -30,10 +30,22 @@ class TestCalculateAnthropicCost:
         )
         cost = calculate_anthropic_cost("claude-opus-5", usage)
         assert cost is not None
-        assert cost.input_cost == pytest.approx((1000 - 200 - 150) * 5.00 / 1_000_000)
-        assert cost.output_cost == pytest.approx(500 * 25.00 / 1_000_000)
-        assert cost.cache_read_cost == pytest.approx(200 * 0.50 / 1_000_000)
-        assert cost.cache_creation_cost == pytest.approx((100 * 6.25 + 50 * 10.00) / 1_000_000)
+        input_cost = (1000 - 200 - 150) * 5.00 / 1_000_000
+        output_cost = 500 * 25.00 / 1_000_000
+        cache_read_cost = 200 * 0.50 / 1_000_000
+        cache_creation_cost = (100 * 6.25 + 50 * 10.00) / 1_000_000
+        # Compared as a dict so the whole object is checked while tolerating float drift;
+        # pytest.approx cannot be nested inside a Cost constructor.
+        assert cost.model_dump() == pytest.approx(
+            {
+                "input_cost": input_cost,
+                "output_cost": output_cost,
+                "total_cost": input_cost + output_cost + cache_read_cost + cache_creation_cost,
+                "cache_read_cost": cache_read_cost,
+                "cache_creation_cost": cache_creation_cost,
+                "currency": "USD",
+            }
+        )
 
     def test_date_suffixed_model_matches_prefix(self) -> None:
         usage = Usage(input_tokens=1000, output_tokens=500)

--- a/packages/lmux-anthropic/tests/test_cost.py
+++ b/packages/lmux-anthropic/tests/test_cost.py
@@ -21,6 +21,20 @@ class TestCalculateAnthropicCost:
         usage = Usage(input_tokens=10, output_tokens=5)
         assert calculate_anthropic_cost("totally-unknown-model", usage) is None
 
+    def test_opus_5_pricing(self) -> None:
+        usage = Usage(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_read_tokens=200,
+            cache_creation_tokens_by_ttl={"5m": 100, "1h": 50},
+        )
+        cost = calculate_anthropic_cost("claude-opus-5", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx((1000 - 200 - 150) * 5.00 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 25.00 / 1_000_000)
+        assert cost.cache_read_cost == pytest.approx(200 * 0.50 / 1_000_000)
+        assert cost.cache_creation_cost == pytest.approx((100 * 6.25 + 50 * 10.00) / 1_000_000)
+
     def test_date_suffixed_model_matches_prefix(self) -> None:
         usage = Usage(input_tokens=1000, output_tokens=500)
         cost = calculate_anthropic_cost("claude-sonnet-4-6-20260214", usage)
@@ -185,6 +199,10 @@ class TestHasVertexRegionalPremium:
 
     def test_unknown_future_models_default_to_premium(self) -> None:
         assert has_vertex_regional_premium("claude-sonnet-6") is True
+
+    def test_opus_5_is_premium(self) -> None:
+        """claude-opus-5 must not be shadowed by the claude-opus-4 (uniform) prefix."""
+        assert has_vertex_regional_premium("claude-opus-5") is True
 
     def test_case_insensitive(self) -> None:
         """Premium classification folds case, like the pricing lookup."""

--- a/packages/lmux-aws-bedrock/pyproject.toml
+++ b/packages/lmux-aws-bedrock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-aws-bedrock"
-version = "0.12.0"
+version = "0.12.1"
 description = "AWS Bedrock provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
@@ -5535,6 +5535,30 @@ _BEDROCK_REGIONAL: dict[str, dict[str, ModelPricing]] = {
                 ),
             ],
         ),
+        "google.gemma-4-26b-a4b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.156),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "google.gemma-4-31b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.168),
+                    output_cost_per_token=per_million_tokens(0.48),
+                ),
+            ],
+        ),
+        "google.gemma-4-e2b": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(0.048),
+                    output_cost_per_token=per_million_tokens(0.096),
+                ),
+            ],
+        ),
         "nvidia.nemotron-nano-12b-v2": ModelPricing(
             tiers=[
                 PricingTier(
@@ -5584,6 +5608,24 @@ _BEDROCK_REGIONAL: dict[str, dict[str, ModelPricing]] = {
                 ),
             ],
         ),
+        "openai.gpt-5.6-luna": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.32),
+                    output_cost_per_token=per_million_tokens(7.92),
+                    cache_read_cost_per_token=per_million_tokens(0.132),
+                ),
+            ],
+        ),
+        "openai.gpt-5.6-terra": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(3.3),
+                    output_cost_per_token=per_million_tokens(19.8),
+                    cache_read_cost_per_token=per_million_tokens(0.33),
+                ),
+            ],
+        ),
         "openai.gpt-oss-120b-1": ModelPricing(
             tiers=[
                 PricingTier(
@@ -5597,6 +5639,15 @@ _BEDROCK_REGIONAL: dict[str, dict[str, ModelPricing]] = {
                 PricingTier(
                     input_cost_per_token=per_million_tokens(0.084),
                     output_cost_per_token=per_million_tokens(0.36),
+                ),
+            ],
+        ),
+        "xai.grok-4.3": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(1.5),
+                    output_cost_per_token=per_million_tokens(3.0),
+                    cache_read_cost_per_token=per_million_tokens(0.24),
                 ),
             ],
         ),

--- a/packages/lmux-aws-bedrock/tests/test_cost.py
+++ b/packages/lmux-aws-bedrock/tests/test_cost.py
@@ -395,3 +395,34 @@ class TestCalculateBedrockCost:
         assert cost is not None
         assert cost_default is not None
         assert cost.total_cost == pytest.approx(cost_default.total_cost)
+
+
+class TestRetiredModelIdsResolveViaConverse:
+    """The Converse table merges the shared Anthropic subset, so it must price the same retired
+    IDs. Asserting the IDs a caller presents, not the table's own keys, is what catches a key
+    that has silently become unreachable.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "anthropic.claude-3-7-sonnet-20250219-v1:0",
+            "anthropic.claude-3-opus-20240229-v1:0",
+            "anthropic.claude-opus-4-20250514-v1:0",
+        ],
+    )
+    def test_retired_dated_id_prices(self, model: str) -> None:
+        cost = calculate_bedrock_cost(model, Usage(input_tokens=1_000_000, output_tokens=1_000_000))
+        assert cost is not None, f"{model} is unreachable — the table key is not a prefix of it"
+        assert cost.total_cost > 0
+
+    def test_opus_5_profiles_price(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        standard = calculate_bedrock_cost("us.anthropic.claude-opus-5", usage)
+        glob = calculate_bedrock_cost("global.anthropic.claude-opus-5", usage)
+        assert standard is not None
+        assert glob is not None
+        assert standard.total_cost == pytest.approx(5.5 + 27.5)
+        assert glob.total_cost == pytest.approx(5.0 + 25.0)

--- a/packages/lmux-azure-foundry/pyproject.toml
+++ b/packages/lmux-azure-foundry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-azure-foundry"
-version = "0.9.0"
+version = "0.9.1"
 description = "Azure AI Foundry provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
@@ -73,22 +73,29 @@ _PRICING: dict[str, ModelPricing] = {
         ],
     ),
     # --- OpenAI: GPT-5.6 family (sol/terra/luna) ---
-    # Azure had not published gpt-5.6 retail meters at the time of writing (GA on Azure but
-    # unpriced), so these mirror OpenAI's Global Standard rates, which Azure AOAI meters match
-    # for every other GPT-5.x model. Cache-write is intentionally omitted: Azure does not meter
-    # cache writes for any AOAI model (unlike OpenAI, which bills gpt-5.6+ cache writes). Replace
-    # with the -glbl meters once Azure publishes them. The bare "gpt-5.6" alias routes to Sol.
+    # Rates come from the Azure "5.6 {sol,terra,luna} {ShortCo,LongCo} ... Std Gl 1M Tokens"
+    # meters. gpt-5.6 is the only AOAI family Azure meters cache writes for ("Cd Wr"), at 1.25x
+    # the input rate; every other family exposes cached input only. Azure labels the second tier
+    # LongCo without publishing the boundary, so the 272K threshold comes from OpenAI's rule.
+    # The bare "gpt-5.6" alias routes to Sol.
+    #
+    # Azure bills cache writes but does not report them: the usage object carries only
+    # cached_tokens, a read counter. So the cache-write rate below applies only when a caller
+    # passes cache_creation_tokens to calculate_azure_foundry_cost directly. In a cost derived
+    # from an Azure response those tokens stay inside input_tokens and bill at 1.0x, not 1.25x.
     "gpt-5.6": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(5.00),
                 output_cost_per_token=per_million_tokens(30.00),
                 cache_read_cost_per_token=per_million_tokens(0.50),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
             ),
             PricingTier(
                 input_cost_per_token=per_million_tokens(10.00),
                 output_cost_per_token=per_million_tokens(45.00),
                 cache_read_cost_per_token=per_million_tokens(1.00),
+                cache_creation_cost_per_token=per_million_tokens(12.50),
                 min_input_tokens=272_000,
             ),
         ],
@@ -99,11 +106,13 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(5.00),
                 output_cost_per_token=per_million_tokens(30.00),
                 cache_read_cost_per_token=per_million_tokens(0.50),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
             ),
             PricingTier(
                 input_cost_per_token=per_million_tokens(10.00),
                 output_cost_per_token=per_million_tokens(45.00),
                 cache_read_cost_per_token=per_million_tokens(1.00),
+                cache_creation_cost_per_token=per_million_tokens(12.50),
                 min_input_tokens=272_000,
             ),
         ],
@@ -114,11 +123,13 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(2.50),
                 output_cost_per_token=per_million_tokens(15.00),
                 cache_read_cost_per_token=per_million_tokens(0.25),
+                cache_creation_cost_per_token=per_million_tokens(3.125),
             ),
             PricingTier(
                 input_cost_per_token=per_million_tokens(5.00),
                 output_cost_per_token=per_million_tokens(22.50),
                 cache_read_cost_per_token=per_million_tokens(0.50),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
                 min_input_tokens=272_000,
             ),
         ],
@@ -129,11 +140,13 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(1.00),
                 output_cost_per_token=per_million_tokens(6.00),
                 cache_read_cost_per_token=per_million_tokens(0.10),
+                cache_creation_cost_per_token=per_million_tokens(1.25),
             ),
             PricingTier(
                 input_cost_per_token=per_million_tokens(2.00),
                 output_cost_per_token=per_million_tokens(9.00),
                 cache_read_cost_per_token=per_million_tokens(0.20),
+                cache_creation_cost_per_token=per_million_tokens(2.50),
                 min_input_tokens=272_000,
             ),
         ],
@@ -565,12 +578,21 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    # Azure publishes the long-context band as "4.3 ... Glbl L" meters without stating the
+    # boundary; xAI documents it as 200K prompt tokens, where the rate exactly doubles.
     "grok-4.3": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(1.25),
                 output_cost_per_token=per_million_tokens(2.50),
-            )
+                cache_read_cost_per_token=per_million_tokens(0.20),
+            ),
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.50),
+                output_cost_per_token=per_million_tokens(5.00),
+                cache_read_cost_per_token=per_million_tokens(0.40),
+                min_input_tokens=200_000,
+            ),
         ],
     ),
     "grok-4-fast": ModelPricing(
@@ -625,6 +647,10 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    # Scout is a partner/community (Marketplace) model, not sold by Azure, so it has no Foundry
+    # Models meter and does not appear on the Llama pricing page. Its rate comes from the retail
+    # catalog under serviceName='Azure Machine Learning', productName='Managed Model Hosting
+    # Service', meters "Llama-4-Scout-17B-16E-In/Out Tokens".
     "llama-4-scout": ModelPricing(
         tiers=[
             PricingTier(
@@ -711,10 +737,9 @@ _PRICING: dict[str, ModelPricing] = {
     ),
     # --- MoonshotAI Kimi. Runtime `model` ids per the Azure model catalog are Kimi-K2.5 /
     # Kimi-K2.6 / Kimi-K2.7-Code (the "FW-"/"FW Kimi" form is only the Fireworks billing meter,
-    # not the deployable id). Azure offers these only as Data Zone deployments; the base rates below
-    # are the DZ meter / 1.1, keeping the base-is-global convention used by every other model. Pass
-    # deployment_type="data_zone" to bill the exact DZ rate — the default, unqualified call
-    # deliberately under-reports ~9% (there is no global tier to fall back to). ---
+    # not the deployable id). The rates below are the Azure "K2.x ... glbl" meters, matching the
+    # base-is-global convention used by every other model. Note that Kimi-K2-Thinking still has a
+    # live retail meter but was retired 2026-03-29, so it is deliberately absent. ---
     "Kimi-K2.5": ModelPricing(
         tiers=[
             PricingTier(

--- a/packages/lmux-azure-foundry/tests/test_cost.py
+++ b/packages/lmux-azure-foundry/tests/test_cost.py
@@ -134,7 +134,7 @@ class TestCalculateAzureFoundryCost:
     @pytest.mark.parametrize(
         ("model", "input_rate", "output_rate", "cache_rate"),
         [
-            # Base is DZ meter / 1.1 (base-is-global convention); DZ deployments reconstruct the DZ rate.
+            # Base is the Azure "K2.x ... glbl" meter; DZ deployments apply the multiplier on top.
             ("Kimi-K2.5", 0.60, 3.00, 0.10),
             ("Kimi-K2.6", 0.95, 4.00, 0.16),
             ("Kimi-K2.7-Code", 0.95, 4.00, 0.19),
@@ -209,20 +209,20 @@ class TestCalculateAzureFoundryCost:
     @pytest.mark.parametrize(
         ("model", "base_rates", "hi_rates"),
         [
-            ("gpt-5.6-sol", (5.00, 30.00, 0.50), (10.00, 45.00, 1.00)),
-            ("gpt-5.6-terra", (2.50, 15.00, 0.25), (5.00, 22.50, 0.50)),
-            ("gpt-5.6-luna", (1.00, 6.00, 0.10), (2.00, 9.00, 0.20)),
+            ("gpt-5.6-sol", (5.00, 30.00, 0.50, 6.25), (10.00, 45.00, 1.00, 12.50)),
+            ("gpt-5.6-terra", (2.50, 15.00, 0.25, 3.125), (5.00, 22.50, 0.50, 6.25)),
+            ("gpt-5.6-luna", (1.00, 6.00, 0.10, 1.25), (2.00, 9.00, 0.20, 2.50)),
         ],
     )
-    def test_gpt_5_6_family_mirrors_openai_without_cache_write(
+    def test_gpt_5_6_family_rates_including_cache_write(
         self,
         model: str,
-        base_rates: tuple[float, float, float],
-        hi_rates: tuple[float, float, float],
+        base_rates: tuple[float, float, float, float],
+        hi_rates: tuple[float, float, float, float],
     ) -> None:
-        """Azure gpt-5.6-* mirror OpenAI input/output/cache-read on both tiers but bill no cache write."""
-        in_base, out_base, cr_base = base_rates
-        in_hi, out_hi, cr_hi = hi_rates
+        """gpt-5.6-* bill input/output/cache-read/cache-write on both tiers, cache write at 1.25x input."""
+        in_base, out_base, cr_base, cw_base = base_rates
+        in_hi, out_hi, cr_hi, cw_hi = hi_rates
         base = calculate_azure_foundry_cost(
             model, Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=100, cache_creation_tokens=200)
         )
@@ -230,16 +230,18 @@ class TestCalculateAzureFoundryCost:
         assert base.input_cost == pytest.approx((1000 - 100 - 200) * in_base / 1_000_000)
         assert base.output_cost == pytest.approx(500 * out_base / 1_000_000)
         assert base.cache_read_cost == pytest.approx(100 * cr_base / 1_000_000)
-        assert base.cache_creation_cost == pytest.approx(0.0)  # Azure meters no cache write for AOAI
+        assert base.cache_creation_cost == pytest.approx(200 * cw_base / 1_000_000)
         hi = calculate_azure_foundry_cost(model, Usage(input_tokens=300_000, output_tokens=1000))
         assert hi is not None
         assert hi.input_cost == pytest.approx(300_000 * in_hi / 1_000_000)
         assert hi.output_cost == pytest.approx(1000 * out_hi / 1_000_000)
         cache_hi = calculate_azure_foundry_cost(
-            model, Usage(input_tokens=300_000, output_tokens=0, cache_read_tokens=300_000)
+            model,
+            Usage(input_tokens=300_000, output_tokens=0, cache_read_tokens=200_000, cache_creation_tokens=100_000),
         )
         assert cache_hi is not None
-        assert cache_hi.cache_read_cost == pytest.approx(300_000 * cr_hi / 1_000_000)
+        assert cache_hi.cache_read_cost == pytest.approx(200_000 * cr_hi / 1_000_000)
+        assert cache_hi.cache_creation_cost == pytest.approx(100_000 * cw_hi / 1_000_000)
 
     def test_gpt_5_6_bare_alias_matches_sol(self) -> None:
         """The bare gpt-5.6 alias resolves to Sol rates, not the gpt-5 prefix (1.25/10)."""
@@ -259,11 +261,21 @@ class TestCalculateAzureFoundryCost:
         assert cost.output_cost == pytest.approx(2.50)
 
     def test_grok_4_3_model(self) -> None:
-        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
+        usage = Usage(input_tokens=100_000, output_tokens=100_000, cache_read_tokens=10_000)
         cost = calculate_azure_foundry_cost("grok-4.3", usage)
         assert cost is not None
-        assert cost.input_cost == pytest.approx(1.25)
-        assert cost.output_cost == pytest.approx(2.50)
+        assert cost.input_cost == pytest.approx((100_000 - 10_000) * 1.25 / 1_000_000)
+        assert cost.output_cost == pytest.approx(100_000 * 2.50 / 1_000_000)
+        assert cost.cache_read_cost == pytest.approx(10_000 * 0.20 / 1_000_000)
+
+    def test_grok_4_3_long_context_tier(self) -> None:
+        """Every grok-4.3 rate doubles above 200K prompt tokens."""
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000, cache_read_tokens=100_000)
+        cost = calculate_azure_foundry_cost("grok-4.3", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx((1_000_000 - 100_000) * 2.50 / 1_000_000)
+        assert cost.output_cost == pytest.approx(1_000_000 * 5.00 / 1_000_000)
+        assert cost.cache_read_cost == pytest.approx(100_000 * 0.40 / 1_000_000)
 
     def test_deepseek_v4_models(self) -> None:
         usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)

--- a/packages/lmux-bedrock-shared/pyproject.toml
+++ b/packages/lmux-bedrock-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-bedrock-shared"
-version = "0.2.0"
+version = "0.2.1"
 description = "Shared AWS Bedrock internals (SigV4 signing, event-stream decoding, Anthropic pricing) for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-bedrock-shared/src/lmux_bedrock_shared/pricing.py
+++ b/packages/lmux-bedrock-shared/src/lmux_bedrock_shared/pricing.py
@@ -26,7 +26,7 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    "anthropic.claude-3-5-sonnet-v1": ModelPricing(
+    "anthropic.claude-3-5-sonnet-20240620-v1": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(3.0),
@@ -34,7 +34,7 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+    "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(3.0),
@@ -44,7 +44,7 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    "anthropic.claude-3-7-sonnet-v1": ModelPricing(
+    "anthropic.claude-3-7-sonnet-20250219-v1": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(3.0),
@@ -62,7 +62,7 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    "anthropic.claude-3-opus-v1": ModelPricing(
+    "anthropic.claude-3-opus-20240229-v1": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(15.0),
@@ -129,6 +129,16 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "anthropic.claude-opus-4-20250514-v1": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(15.0),
+                output_cost_per_token=per_million_tokens(75.0),
+                cache_read_cost_per_token=per_million_tokens(1.5),
+                cache_creation_cost_per_token=per_million_tokens(18.75),
+            ),
+        ],
+    ),
     "anthropic.claude-opus-4-5-20251101-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -173,13 +183,14 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    "anthropic.claude-opus-4-v1": ModelPricing(
+    "anthropic.claude-opus-5": ModelPricing(
         tiers=[
             PricingTier(
-                input_cost_per_token=per_million_tokens(15.0),
-                output_cost_per_token=per_million_tokens(75.0),
-                cache_read_cost_per_token=per_million_tokens(1.5),
-                cache_creation_cost_per_token=per_million_tokens(18.75),
+                input_cost_per_token=per_million_tokens(5.5),
+                output_cost_per_token=per_million_tokens(27.5),
+                cache_read_cost_per_token=per_million_tokens(0.55),
+                cache_creation_cost_per_token=per_million_tokens(6.875),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(11.0)},
             ),
         ],
     ),
@@ -248,6 +259,24 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "apac.anthropic.claude-3-5-sonnet-20240620-v1": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(3.0),
+                output_cost_per_token=per_million_tokens(15.0),
+            ),
+        ],
+    ),
+    "apac.anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(3.0),
+                output_cost_per_token=per_million_tokens(15.0),
+                cache_read_cost_per_token=per_million_tokens(0.3),
+                cache_creation_cost_per_token=per_million_tokens(3.75),
+            ),
+        ],
+    ),
     "apac.anthropic.claude-3-haiku-20240307-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -308,6 +337,17 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
         ],
     ),
     "au.anthropic.claude-opus-4-8": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.5),
+                output_cost_per_token=per_million_tokens(27.5),
+                cache_read_cost_per_token=per_million_tokens(0.55),
+                cache_creation_cost_per_token=per_million_tokens(6.875),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(11.0)},
+            ),
+        ],
+    ),
+    "au.anthropic.claude-opus-5": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(5.5),
@@ -436,6 +476,17 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "eu.anthropic.claude-opus-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.5),
+                output_cost_per_token=per_million_tokens(27.5),
+                cache_read_cost_per_token=per_million_tokens(0.55),
+                cache_creation_cost_per_token=per_million_tokens(6.875),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(11.0)},
+            ),
+        ],
+    ),
     "eu.anthropic.claude-sonnet-4-20250514-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -549,6 +600,17 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
         ],
     ),
     "global.anthropic.claude-opus-4-8": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.0),
+                output_cost_per_token=per_million_tokens(25.0),
+                cache_read_cost_per_token=per_million_tokens(0.5),
+                cache_creation_cost_per_token=per_million_tokens(6.25),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(10.0)},
+            ),
+        ],
+    ),
+    "global.anthropic.claude-opus-5": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(5.0),
@@ -763,6 +825,17 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    "us.anthropic.claude-opus-5": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.5),
+                output_cost_per_token=per_million_tokens(27.5),
+                cache_read_cost_per_token=per_million_tokens(0.55),
+                cache_creation_cost_per_token=per_million_tokens(6.875),
+                cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(11.0)},
+            ),
+        ],
+    ),
     "us.anthropic.claude-sonnet-4-20250514-v1": ModelPricing(
         tiers=[
             PricingTier(
@@ -825,7 +898,7 @@ ANTHROPIC_PRICING: dict[str, ModelPricing] = {
 # Regional overrides for Claude (only Regions whose prices differ from us-east-1)
 ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
     "ap-northeast-1": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -835,7 +908,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "ap-northeast-2": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -845,7 +918,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "ap-northeast-3": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -855,7 +928,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "ap-south-1": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -865,7 +938,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "ap-south-2": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -875,7 +948,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "ap-southeast-1": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -885,7 +958,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "ap-southeast-2": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -895,7 +968,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "eu-north-1": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -905,7 +978,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "eu-south-1": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -915,7 +988,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "eu-south-2": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -925,7 +998,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "eu-west-1": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -935,7 +1008,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "eu-west-3": {
-        "anthropic.claude-3-5-sonnet-v2": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20241022-v2": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.0),
@@ -945,7 +1018,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "us-gov-east-1": {
-        "anthropic.claude-3-5-sonnet-v1": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20240620-v1": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.6),
@@ -953,7 +1026,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
                 ),
             ],
         ),
-        "anthropic.claude-3-7-sonnet-v1": ModelPricing(
+        "anthropic.claude-3-7-sonnet-20250219-v1": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.6),
@@ -995,7 +1068,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
         ),
     },
     "us-gov-west-1": {
-        "anthropic.claude-3-5-sonnet-v1": ModelPricing(
+        "anthropic.claude-3-5-sonnet-20240620-v1": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.6),
@@ -1003,7 +1076,7 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
                 ),
             ],
         ),
-        "anthropic.claude-3-7-sonnet-v1": ModelPricing(
+        "anthropic.claude-3-7-sonnet-20250219-v1": ModelPricing(
             tiers=[
                 PricingTier(
                     input_cost_per_token=per_million_tokens(3.6),

--- a/packages/lmux-bedrock-shared/tests/test_pricing.py
+++ b/packages/lmux-bedrock-shared/tests/test_pricing.py
@@ -134,3 +134,36 @@ class TestCalculateBedrockAnthropicCost:
         assert latest is not None
         assert intro.input_cost < standard.input_cost
         assert latest == standard
+
+
+_RETIRED_MODEL_IDS = [
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "anthropic.claude-3-5-haiku-20241022-v1:0",
+    "anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "anthropic.claude-3-opus-20240229-v1:0",
+    "anthropic.claude-opus-4-20250514-v1:0",
+    "anthropic.claude-3-haiku-20240307-v1:0",
+    "anthropic.claude-3-sonnet-20240229-v1:0",
+]
+
+
+class TestRetiredModelIdsResolve:
+    """Retired Claude models are retained for historical cost lookups, so the IDs that were
+    actually callable must still price. A dateless table key is unreachable: prefix matching
+    cannot bridge ``...sonnet-20241022-v2:0`` to ``...sonnet-v2``, so the entry looks present
+    in the table while pricing nothing.
+    """
+
+    @pytest.mark.parametrize("model", _RETIRED_MODEL_IDS)
+    def test_dated_model_id_prices(self, model: str) -> None:
+        cost = calculate_bedrock_anthropic_cost(model, Usage(input_tokens=1_000_000, output_tokens=1_000_000))
+        assert cost is not None, f"{model} is unreachable — the table key is not a prefix of it"
+        assert cost.total_cost > 0
+
+    @pytest.mark.parametrize("model", _RETIRED_MODEL_IDS)
+    def test_dated_inference_profile_id_prices(self, model: str) -> None:
+        """The cross-Region profile form strips to the bare dated ID, which must also resolve."""
+        cost = calculate_bedrock_anthropic_cost(f"us.{model}", Usage(input_tokens=1_000_000, output_tokens=0))
+        assert cost is not None
+        assert cost.total_cost > 0

--- a/packages/lmux-google/pyproject.toml
+++ b/packages/lmux-google/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-google"
-version = "0.10.0"
+version = "0.10.1"
 description = "Google (Gemini) provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-google/src/lmux_google/cost.py
+++ b/packages/lmux-google/src/lmux_google/cost.py
@@ -1,7 +1,9 @@
 """Google model pricing data and cost calculation.
 
-Prices are for standard on-demand (global endpoint) Vertex AI pricing;
-the Gemini Developer API paid tier uses the same per-token rates.
+Prices are for standard on-demand (global endpoint) Vertex AI pricing. The
+Gemini Developer API paid tier matches these rates for Gemini 2.5 and later,
+but diverges on Gemini 2.0: the Developer API bills 2.0 Flash at 0.10/0.40
+against Vertex's 0.15/0.60. The Vertex rates are the ones stored here.
 Pricing source: https://cloud.google.com/vertex-ai/generative-ai/pricing
 """
 
@@ -17,12 +19,32 @@ from lmux.types import Cost, Usage
 
 _PRICING: dict[str, ModelPricing] = {
     # ── Google Gemini 3 ────────────────────────────────────────
+    "gemini-3.6-flash": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.5),
+                output_cost_per_token=per_million_tokens(7.5),
+                cache_read_cost_per_token=per_million_tokens(0.15),
+            ),
+        ],
+    ),
     "gemini-3.5-flash": ModelPricing(
         tiers=[
             PricingTier(
                 input_cost_per_token=per_million_tokens(1.5),
                 output_cost_per_token=per_million_tokens(9.0),
                 cache_read_cost_per_token=per_million_tokens(0.15),
+            ),
+        ],
+    ),
+    # Flash-Lite must keep its own key: without it the id prefix-matches
+    # gemini-3.5-flash and bills 5x the correct input rate.
+    "gemini-3.5-flash-lite": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.30),
+                output_cost_per_token=per_million_tokens(2.50),
+                cache_read_cost_per_token=per_million_tokens(0.03),
             ),
         ],
     ),
@@ -131,6 +153,7 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.15),
                 output_cost_per_token=per_million_tokens(0.6),
+                cache_read_cost_per_token=per_million_tokens(0.0375),
             ),
         ],
     ),
@@ -139,6 +162,7 @@ _PRICING: dict[str, ModelPricing] = {
             PricingTier(
                 input_cost_per_token=per_million_tokens(0.075),
                 output_cost_per_token=per_million_tokens(0.3),
+                cache_read_cost_per_token=per_million_tokens(0.01875),
             ),
         ],
     ),

--- a/packages/lmux-google/tests/test_cost.py
+++ b/packages/lmux-google/tests/test_cost.py
@@ -176,3 +176,36 @@ class TestCalculateGoogleCost:
         cost = calculate_google_cost("gemini-3.1-flash-lite", usage)
         assert cost is not None
         assert cost.cache_read_cost == pytest.approx(500 * 0.025 / 1_000_000)
+
+    @pytest.mark.parametrize(
+        "model",
+        ["gemini-3.5-flash-lite", "gemini-3.5-flash-lite-preview-06-2026", "GEMINI-3.5-Flash-Lite"],
+    )
+    def test_gemini_3_5_flash_lite_does_not_fall_through_to_flash(self, model: str) -> None:
+        """Flash-Lite must not prefix-match gemini-3.5-flash, which bills 5x its input rate."""
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000, cache_read_tokens=1_000_000)
+        cost = calculate_google_cost(model, usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx(0.0)  # every input token is a cache read
+        assert cost.output_cost == pytest.approx(2.50)
+        assert cost.cache_read_cost == pytest.approx(0.03)
+
+    def test_gemini_3_6_flash(self) -> None:
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000, cache_read_tokens=100_000)
+        cost = calculate_google_cost("gemini-3.6-flash", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx((1_000_000 - 100_000) * 1.50 / 1_000_000)
+        assert cost.output_cost == pytest.approx(7.50)
+        assert cost.cache_read_cost == pytest.approx(100_000 * 0.15 / 1_000_000)
+
+    @pytest.mark.parametrize(
+        ("model", "rate"),
+        [("gemini-2.0-flash", 0.0375), ("gemini-2.0-flash-lite", 0.01875)],
+    )
+    def test_gemini_2_0_cache_reads_are_billed(self, model: str, rate: float) -> None:
+        """An unset cache-read rate would bill these tokens at zero rather than the published rate."""
+        usage = Usage(input_tokens=100_000, output_tokens=0, cache_read_tokens=100_000)
+        cost = calculate_google_cost(model, usage)
+        assert cost is not None
+        assert cost.cache_read_cost == pytest.approx(100_000 * rate / 1_000_000)
+        assert cost.total_cost > 0.0

--- a/scripts/update_bedrock_pricing.py
+++ b/scripts/update_bedrock_pricing.py
@@ -57,9 +57,13 @@ LCTX_THRESHOLD = 200_000
 
 # Foundation Models API: servicename (after stripping " (Amazon Bedrock Edition)") -> Bedrock model ID
 FM_SERVICENAME_MAP: dict[str, str] = {
-    # Anthropic Claude
+    # Anthropic Claude. Retired models must be keyed by their real dated model ID. AWS drops a
+    # model from list_foundation_models when it retires, so the catalog resolver can no longer
+    # turn a dateless key into the ID a caller presents, and the dateless key would be written
+    # out as an entry nothing can ever look up. See KNOWN_UNRESOLVED_IDS.
     "Claude Fable 5": "anthropic.claude-fable-5-v1",
     "Claude Mythos 5": "anthropic.claude-mythos-5-v1",
+    "Claude Opus 5": "anthropic.claude-opus-5-v1",
     "Claude Sonnet 5": "anthropic.claude-sonnet-5-v1",
     "Claude Opus 4.8": "anthropic.claude-opus-4-8-v1",
     "Claude Opus 4.7": "anthropic.claude-opus-4-7-v1",
@@ -69,16 +73,13 @@ FM_SERVICENAME_MAP: dict[str, str] = {
     "Claude Sonnet 4.5": "anthropic.claude-sonnet-4-5-v1",
     "Claude Haiku 4.5": "anthropic.claude-haiku-4-5-v1",
     "Claude Sonnet 4": "anthropic.claude-sonnet-4-v1",
-    "Claude Opus 4": "anthropic.claude-opus-4-v1",
+    "Claude Opus 4": "anthropic.claude-opus-4-20250514-v1",
     "Claude Opus 4.1": "anthropic.claude-opus-4-1-v1",
-    "Claude 3.7 Sonnet": "anthropic.claude-3-7-sonnet-v1",
-    "Claude 3.5 Sonnet v2": "anthropic.claude-3-5-sonnet-v2",
-    "Claude 3.5 Sonnet": "anthropic.claude-3-5-sonnet-v1",
-    # AWS delisted 3.5 Haiku from list_foundation_models, so the catalog resolver
-    # can no longer map a simplified key to the real dated ID. Hardcode the dated
-    # model ID directly so prefix matching still prices existing 3.5 Haiku calls.
+    "Claude 3.7 Sonnet": "anthropic.claude-3-7-sonnet-20250219-v1",
+    "Claude 3.5 Sonnet v2": "anthropic.claude-3-5-sonnet-20241022-v2",
+    "Claude 3.5 Sonnet": "anthropic.claude-3-5-sonnet-20240620-v1",
     "Claude 3.5 Haiku": "anthropic.claude-3-5-haiku-20241022-v1",
-    "Claude 3 Opus": "anthropic.claude-3-opus-v1",
+    "Claude 3 Opus": "anthropic.claude-3-opus-20240229-v1",
     "Claude 3 Sonnet": "anthropic.claude-3-sonnet-v1",
     "Claude 3 Haiku": "anthropic.claude-3-haiku-v1",
     "Claude": "anthropic.claude-v2",
@@ -292,6 +293,57 @@ def _build_resolution_indexes(
     return real_raw, real_clean, dateless_to_real, normalized_to_real, prefix_to_real
 
 
+# Simplified IDs that never resolve, because AWS no longer lists the model. Membership records
+# that someone checked what a caller actually presents -- not that the key is necessarily right.
+# An unresolved ID missing from this set is a newly retired model whose key may have silently
+# become unreachable, so generation stops instead of emitting an entry nothing can look up.
+KNOWN_UNRESOLVED_IDS: frozenset[str] = frozenset(
+    {
+        # The key is itself the real (retired) Bedrock model ID, so its entry is reachable.
+        "ai21.j2-mid-v1",
+        "ai21.j2-ultra-v1",
+        "ai21.jamba-instruct-v1",
+        "amazon.titan-text-express-v1",
+        "amazon.titan-text-lite-v1",
+        "amazon.titan-text-premier-v1",
+        "anthropic.claude-instant-v1",
+        "anthropic.claude-v2",
+        "cohere.command-light-text-v14",
+        "cohere.command-text-v14",
+        "meta.llama2-13b-chat-v1",
+        "meta.llama2-70b-chat-v1",
+        "meta.llama3-2-11b-instruct-v1",
+        "meta.llama3-2-1b-instruct-v1",
+        "meta.llama3-2-3b-instruct-v1",
+        "meta.llama3-2-90b-instruct-v1",
+        # Reachable: the key is a prefix of the real ID, but the model is not offered in
+        # us-east-1 and fetch_bedrock_catalog only lists that Region, so it cannot be confirmed.
+        "qwen.qwen3-235b-a22b-2507",
+        # Dated IDs hardcoded in FM_SERVICENAME_MAP; delisted, so they cannot resolve.
+        "anthropic.claude-3-5-haiku-20241022-v1",
+        "anthropic.claude-3-5-sonnet-20240620-v1",
+        "anthropic.claude-3-5-sonnet-20241022-v2",
+        "anthropic.claude-3-7-sonnet-20250219-v1",
+        "anthropic.claude-3-opus-20240229-v1",
+        "anthropic.claude-opus-4-20250514-v1",
+        # Not confirmed reachable: the real ID may differ, which would price these as None.
+        # These are live models rather than retirements, tracked as a separate known gap.
+        "amazon.nova-2-omni-v1",
+        "amazon.nova-2-pro-v1",
+        "anthropic.claude-mythos-5-v1",
+        "deepseek.v3.1",
+        "google.gemma-4-26b-a4b",
+        "google.gemma-4-31b",
+        "google.gemma-4-e2b",
+        "moonshotai.kimi-k2-thinking",
+        "nvidia.nemotron-nano-12b-v2-vl",
+        "qwen.qwen3-coder-480b-a35b-instruct",
+        "xai.grok-4.3",
+        "zai.glm5",
+    }
+)
+
+
 def build_id_resolution_map(
     simplified_ids: set[str],
     real_model_ids: list[str],
@@ -344,8 +396,16 @@ def build_id_resolution_map(
 
         unresolved.append(sid)
 
+    unexpected = sorted(set(unresolved) - KNOWN_UNRESOLVED_IDS)
+    if unexpected:
+        _die(
+            f"Could not resolve to real Bedrock model IDs: {unexpected}. A model that retires drops "
+            "out of list_foundation_models, so its simplified key stops resolving and would be "
+            "written out as an entry no caller can look up. Point FM_SERVICENAME_MAP at the real "
+            "dated model ID, then record the key in KNOWN_UNRESOLVED_IDS."
+        )
     if unresolved:
-        _warn(f"Could not resolve to real Bedrock model IDs: {sorted(unresolved)}")
+        _info(f"Unresolved but known ({len(unresolved)}): {sorted(unresolved)}")
     if mapping:
         _info(f"Resolved {len(mapping)} simplified IDs to real Bedrock model IDs:")
         for old, new in sorted(mapping.items()):
@@ -673,7 +733,11 @@ def _parse_fm_dimension(usagetype: str) -> tuple[str, bool] | None:
     skip_patterns = [
         "ProvisionedThroughput",
         "Reserved",
+        # Both spellings are required: legacy PascalCase is "_Batch", the snake_case
+        # form used from Claude Opus 5 onward is "_batch". Missing the lowercase one
+        # lets a batch rate overwrite the standard rate under the same dimension key.
         "Batch",
+        "_batch",
         "LatencyOptimized",
         "ModelStorage",
         "Customization",

--- a/uv.lock
+++ b/uv.lock
@@ -675,7 +675,7 @@ requires-dist = [{ name = "pydantic", specifier = "~=2.10" }]
 
 [[package]]
 name = "lmux-anthropic"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "packages/lmux-anthropic" }
 dependencies = [
     { name = "httpx" },
@@ -703,7 +703,7 @@ provides-extras = ["vertex", "bedrock"]
 
 [[package]]
 name = "lmux-aws-bedrock"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "packages/lmux-aws-bedrock" }
 dependencies = [
     { name = "boto3" },
@@ -729,7 +729,7 @@ provides-extras = ["async"]
 
 [[package]]
 name = "lmux-azure-foundry"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "packages/lmux-azure-foundry" }
 dependencies = [
     { name = "httpx" },
@@ -751,7 +751,7 @@ provides-extras = ["identity"]
 
 [[package]]
 name = "lmux-bedrock-shared"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/lmux-bedrock-shared" }
 dependencies = [
     { name = "boto3" },
@@ -777,7 +777,7 @@ requires-dist = [{ name = "lmux-google", editable = "packages/lmux-google" }]
 
 [[package]]
 name = "lmux-google"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "packages/lmux-google" }
 dependencies = [
     { name = "google-auth" },


### PR DESCRIPTION
Routine pricing refresh across six providers. No stored price had gone stale; every
problem was a missing key, field, or tier.

The ones that mattered: `gemini-3.5-flash-lite` had no key of its own and prefix-matched
`gemini-3.5-flash`, billing 5x; Gemini 2.0 had no cache-read rate, which bills cached
tokens at zero; `grok-4.3` was missing its above-200K tier; Claude Opus 5 was absent
everywhere.

Two Bedrock generator bugs behind that last one. The batch filter matched only PascalCase,
so Opus 5's snake_case `input_tokens_batch` meter overwrote its standard rate. And five
retired Claude models were keyed without their date, so the dated IDs callers actually
record priced nothing. Unresolved keys now fail generation rather than warn, since AWS
delists a model when it retires and the dead keys regrow on their own.