### PR TITLE
fix: Update GPT-5.6 Terra and Luna pricing

### DIFF
--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -37,16 +37,16 @@ _PRICING: dict[str, ModelPricing] = {
     "gpt-5.6-terra": ModelPricing(
         tiers=[
             PricingTier(
-                input_cost_per_token=per_million_tokens(2.50),
-                output_cost_per_token=per_million_tokens(15.00),
-                cache_read_cost_per_token=per_million_tokens(0.25),
-                cache_creation_cost_per_token=per_million_tokens(3.125),
+                input_cost_per_token=per_million_tokens(2.00),
+                output_cost_per_token=per_million_tokens(12.00),
+                cache_read_cost_per_token=per_million_tokens(0.20),
+                cache_creation_cost_per_token=per_million_tokens(2.50),
             ),
             PricingTier(
-                input_cost_per_token=per_million_tokens(5.00),
-                output_cost_per_token=per_million_tokens(22.50),
-                cache_read_cost_per_token=per_million_tokens(0.50),
-                cache_creation_cost_per_token=per_million_tokens(6.25),
+                input_cost_per_token=per_million_tokens(4.00),
+                output_cost_per_token=per_million_tokens(18.00),
+                cache_read_cost_per_token=per_million_tokens(0.40),
+                cache_creation_cost_per_token=per_million_tokens(5.00),
                 min_input_tokens=272_000,
             ),
         ],
@@ -54,16 +54,16 @@ _PRICING: dict[str, ModelPricing] = {
     "gpt-5.6-luna": ModelPricing(
         tiers=[
             PricingTier(
-                input_cost_per_token=per_million_tokens(1.00),
-                output_cost_per_token=per_million_tokens(6.00),
-                cache_read_cost_per_token=per_million_tokens(0.10),
-                cache_creation_cost_per_token=per_million_tokens(1.25),
+                input_cost_per_token=per_million_tokens(0.20),
+                output_cost_per_token=per_million_tokens(1.20),
+                cache_read_cost_per_token=per_million_tokens(0.02),
+                cache_creation_cost_per_token=per_million_tokens(0.25),
             ),
             PricingTier(
-                input_cost_per_token=per_million_tokens(2.00),
-                output_cost_per_token=per_million_tokens(9.00),
-                cache_read_cost_per_token=per_million_tokens(0.20),
-                cache_creation_cost_per_token=per_million_tokens(2.50),
+                input_cost_per_token=per_million_tokens(0.40),
+                output_cost_per_token=per_million_tokens(1.80),
+                cache_read_cost_per_token=per_million_tokens(0.04),
+                cache_creation_cost_per_token=per_million_tokens(0.50),
                 min_input_tokens=272_000,
             ),
         ],

--- a/packages/lmux-openai/tests/test_cost.py
+++ b/packages/lmux-openai/tests/test_cost.py
@@ -109,19 +109,39 @@ class TestCalculateOpenAICost:
         assert cost.cache_creation_cost == pytest.approx(200 * cache_write_rate / 1_000_000)
 
     @pytest.mark.parametrize(
-        ("model", "input_rate", "output_rate"),
+        ("model", "input_rate", "output_rate", "cache_read_rate", "cache_write_rate"),
         [
-            ("gpt-5.6-sol", 10.00, 45.00),
-            ("gpt-5.6-terra", 4.00, 18.00),
-            ("gpt-5.6-luna", 0.40, 1.80),
+            ("gpt-5.6-sol", 10.00, 45.00, 1.00, 12.50),
+            ("gpt-5.6-terra", 4.00, 18.00, 0.40, 5.00),
+            ("gpt-5.6-luna", 0.40, 1.80, 0.04, 0.50),
         ],
     )
-    def test_gpt_5_6_long_context_tier(self, model: str, input_rate: float, output_rate: float) -> None:
-        usage = Usage(input_tokens=300_000, output_tokens=1000)
+    def test_gpt_5_6_long_context_tier(
+        self,
+        model: str,
+        input_rate: float,
+        output_rate: float,
+        cache_read_rate: float,
+        cache_write_rate: float,
+    ) -> None:
+        usage = Usage(
+            input_tokens=300_000,
+            output_tokens=1000,
+            cache_read_tokens=100_000,
+            cache_creation_tokens=50_000,
+        )
         cost = calculate_openai_cost(model, usage)
-        assert cost is not None
-        assert cost.input_cost == pytest.approx(300_000 * input_rate / 1_000_000)
-        assert cost.output_cost == pytest.approx(1000 * output_rate / 1_000_000)
+        input_cost = 150_000 * (input_rate / 1_000_000)
+        output_cost = 1000 * (output_rate / 1_000_000)
+        cache_read_cost = 100_000 * (cache_read_rate / 1_000_000)
+        cache_creation_cost = 50_000 * (cache_write_rate / 1_000_000)
+        assert cost == Cost(
+            input_cost=input_cost,
+            output_cost=output_cost,
+            cache_read_cost=cache_read_cost,
+            cache_creation_cost=cache_creation_cost,
+            total_cost=input_cost + output_cost + cache_read_cost + cache_creation_cost,
+        )
 
     def test_gpt_5_6_bare_alias_matches_sol(self) -> None:
         """The bare gpt-5.6 alias mirrors gpt-5.6-sol, not the cheaper gpt-5 prefix."""

--- a/packages/lmux-openai/tests/test_cost.py
+++ b/packages/lmux-openai/tests/test_cost.py
@@ -86,8 +86,8 @@ class TestCalculateOpenAICost:
         ("model", "input_rate", "output_rate", "cache_read_rate", "cache_write_rate"),
         [
             ("gpt-5.6-sol", 5.00, 30.00, 0.50, 6.25),
-            ("gpt-5.6-terra", 2.50, 15.00, 0.25, 3.125),
-            ("gpt-5.6-luna", 1.00, 6.00, 0.10, 1.25),
+            ("gpt-5.6-terra", 2.00, 12.00, 0.20, 2.50),
+            ("gpt-5.6-luna", 0.20, 1.20, 0.02, 0.25),
         ],
     )
     def test_gpt_5_6_family_base_pricing(
@@ -108,13 +108,20 @@ class TestCalculateOpenAICost:
         assert cost.cache_read_cost == pytest.approx(100 * cache_read_rate / 1_000_000)
         assert cost.cache_creation_cost == pytest.approx(200 * cache_write_rate / 1_000_000)
 
-    def test_gpt_5_6_long_context_tier(self) -> None:
-        # Above 272k input tokens gpt-5.6-sol switches to the long-context tier (10.00 / 45.00).
+    @pytest.mark.parametrize(
+        ("model", "input_rate", "output_rate"),
+        [
+            ("gpt-5.6-sol", 10.00, 45.00),
+            ("gpt-5.6-terra", 4.00, 18.00),
+            ("gpt-5.6-luna", 0.40, 1.80),
+        ],
+    )
+    def test_gpt_5_6_long_context_tier(self, model: str, input_rate: float, output_rate: float) -> None:
         usage = Usage(input_tokens=300_000, output_tokens=1000)
-        cost = calculate_openai_cost("gpt-5.6-sol", usage)
+        cost = calculate_openai_cost(model, usage)
         assert cost is not None
-        assert cost.input_cost == pytest.approx(300_000 * 10.00 / 1_000_000)
-        assert cost.output_cost == pytest.approx(1000 * 45.00 / 1_000_000)
+        assert cost.input_cost == pytest.approx(300_000 * input_rate / 1_000_000)
+        assert cost.output_cost == pytest.approx(1000 * output_rate / 1_000_000)
 
     def test_gpt_5_6_bare_alias_matches_sol(self) -> None:
         """The bare gpt-5.6 alias mirrors gpt-5.6-sol, not the cheaper gpt-5 prefix."""

--- a/tests/integration/cassettes/openai/luna_pricing.json
+++ b/tests/integration/cassettes/openai/luna_pricing.json
@@ -6,29 +6,97 @@
     "stream": false
   },
   "response": {
-    "id": "resp_0d101dbe6b9a8f7b006a6c8850f300819690ecd030f943a2f2",
+    "id": "resp_04b8d3b232b47502006a6c93df86a481968e0c3e775ff0ecac",
+    "object": "response",
+    "created_at": 1785500639,
+    "status": "completed",
+    "background": false,
+    "billing": {
+      "payer": "developer"
+    },
+    "completed_at": 1785500640,
+    "error": null,
+    "frequency_penalty": 0.0,
+    "incomplete_details": null,
+    "instructions": null,
+    "max_output_tokens": null,
+    "max_tool_calls": null,
     "model": "gpt-5.6-luna",
+    "moderation": null,
     "output": [
       {
+        "id": "msg_04b8d3b232b47502006a6c93e0bbd4819699f271373397deaa",
         "type": "message",
+        "status": "completed",
         "content": [
           {
             "type": "output_text",
+            "annotations": [],
+            "logprobs": [],
             "text": "pong"
           }
-        ]
+        ],
+        "phase": "final_answer",
+        "role": "assistant"
       }
     ],
+    "parallel_tool_calls": true,
+    "presence_penalty": 0.0,
+    "previous_response_id": null,
+    "prompt_cache_key": null,
+    "prompt_cache_retention": "24h",
+    "reasoning": {
+      "context": "all_turns",
+      "effort": "medium",
+      "mode": "standard",
+      "summary": null
+    },
+    "safety_identifier": null,
+    "service_tier": "default",
+    "store": true,
+    "temperature": 1.0,
+    "text": {
+      "format": {
+        "type": "text"
+      },
+      "verbosity": "medium"
+    },
+    "tool_choice": "auto",
+    "tool_usage": {
+      "image_gen": {
+        "input_tokens": 0,
+        "input_tokens_details": {
+          "image_tokens": 0,
+          "text_tokens": 0
+        },
+        "output_tokens": 0,
+        "output_tokens_details": {
+          "image_tokens": 0,
+          "text_tokens": 0
+        },
+        "total_tokens": 0
+      },
+      "web_search": {
+        "num_requests": 0
+      }
+    },
+    "tools": [],
+    "top_logprobs": 0,
+    "top_p": 0.98,
+    "truncation": "disabled",
     "usage": {
       "input_tokens": 13,
       "input_tokens_details": {
         "cache_write_tokens": 0,
         "cached_tokens": 0
       },
-      "output_tokens": 16,
+      "output_tokens": 5,
       "output_tokens_details": {
-        "reasoning_tokens": 9
-      }
-    }
+        "reasoning_tokens": 0
+      },
+      "total_tokens": 18
+    },
+    "user": null,
+    "metadata": {}
   }
 }

--- a/tests/integration/cassettes/openai/luna_pricing.json
+++ b/tests/integration/cassettes/openai/luna_pricing.json
@@ -1,0 +1,34 @@
+{
+  "endpoint": "https://api.openai.com/v1/responses",
+  "request": {
+    "model": "gpt-5.6-luna",
+    "input": "Reply with exactly the word: pong",
+    "stream": false
+  },
+  "response": {
+    "id": "resp_0d101dbe6b9a8f7b006a6c8850f300819690ecd030f943a2f2",
+    "model": "gpt-5.6-luna",
+    "output": [
+      {
+        "type": "message",
+        "content": [
+          {
+            "type": "output_text",
+            "text": "pong"
+          }
+        ]
+      }
+    ],
+    "usage": {
+      "input_tokens": 13,
+      "input_tokens_details": {
+        "cache_write_tokens": 0,
+        "cached_tokens": 0
+      },
+      "output_tokens": 16,
+      "output_tokens_details": {
+        "reasoning_tokens": 9
+      }
+    }
+  }
+}

--- a/tests/integration/openai/test_chat_caching.py
+++ b/tests/integration/openai/test_chat_caching.py
@@ -20,10 +20,10 @@ _READ_CASSETTE = _CASSETTES / "chat_cache_read.json"
 
 # gpt-5.6-terra tier-1 published rates ($/token).
 _RATES = {
-    "input_rate": 2.50 / 1_000_000,
-    "output_rate": 15.00 / 1_000_000,
-    "cache_read_rate": 0.25 / 1_000_000,
-    "cache_write_rate": 3.125 / 1_000_000,
+    "input_rate": 2.00 / 1_000_000,
+    "output_rate": 12.00 / 1_000_000,
+    "cache_read_rate": 0.20 / 1_000_000,
+    "cache_write_rate": 2.50 / 1_000_000,
 }
 
 

--- a/tests/integration/openai/test_explicit_cache.py
+++ b/tests/integration/openai/test_explicit_cache.py
@@ -19,10 +19,10 @@ _CASSETTE = Path(__file__).parent.parent / "cassettes" / "openai" / "explicit_ca
 
 # gpt-5.6-terra published rates ($/token).
 _RATES = {
-    "input_rate": 2.50 / 1_000_000,
-    "output_rate": 15.00 / 1_000_000,
-    "cache_read_rate": 0.25 / 1_000_000,
-    "cache_write_rate": 3.125 / 1_000_000,
+    "input_rate": 2.00 / 1_000_000,
+    "output_rate": 12.00 / 1_000_000,
+    "cache_read_rate": 0.20 / 1_000_000,
+    "cache_write_rate": 2.50 / 1_000_000,
 }
 
 # A >1024-token prompt with a unique prefix, so a live/record call is a cold cache write.

--- a/tests/integration/openai/test_luna_pricing.py
+++ b/tests/integration/openai/test_luna_pricing.py
@@ -1,0 +1,27 @@
+"""OpenAI GPT-5.6 Luna Responses cost matches the published rate."""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from lmux.types import ResponseResponse
+from lmux_openai.provider import OpenAIProvider
+
+_MODEL = "gpt-5.6-luna"
+_PROMPT = "Reply with exactly the word: pong"
+_CASSETTE = Path(__file__).parent.parent / "cassettes" / "openai" / "luna_pricing.json"
+_RATES = {"input_rate": 0.20 / 1_000_000, "output_rate": 1.20 / 1_000_000}
+
+
+def _respond(auth: Any, transport: Any) -> ResponseResponse:  # noqa: ANN401
+    return OpenAIProvider(auth=auth, transport=transport).create_response(_MODEL, _PROMPT)
+
+
+@pytest.mark.verified
+def test_luna_pricing(scenario: Callable[..., Any], assert_cost: Callable[..., None]) -> None:
+    response = scenario(_CASSETTE, _respond, requires="OPENAI_API_KEY")
+    assert response.provider == "openai"
+    assert "pong" in response.output_text.lower()
+    assert_cost(response, **_RATES)

--- a/tests/integration/openai/test_reasoning.py
+++ b/tests/integration/openai/test_reasoning.py
@@ -18,10 +18,10 @@ _CASSETTE = Path(__file__).parent.parent / "cassettes" / "openai" / "reasoning.j
 
 # gpt-5.6-terra published rates ($/token).
 _RATES = {
-    "input_rate": 2.50 / 1_000_000,
-    "output_rate": 15.00 / 1_000_000,
-    "cache_read_rate": 0.25 / 1_000_000,
-    "cache_write_rate": 3.125 / 1_000_000,
+    "input_rate": 2.00 / 1_000_000,
+    "output_rate": 12.00 / 1_000_000,
+    "cache_read_rate": 0.20 / 1_000_000,
+    "cache_write_rate": 2.50 / 1_000_000,
 }
 
 


### PR DESCRIPTION
OpenAI reduced GPT-5.6 Terra and Luna pricing, but lmux still reported their launch rates. This PR updates the short- and long-context input, cached-input, cache-write, and output rates while leaving GPT-5.6 Sol and the bare GPT-5.6 alias unchanged.