### PR TITLE
fix: Validate Claude thinking requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Streaming returns reasoning in `chunk.reasoning_delta`. Each provider maps the e
 | OpenAI / Azure Foundry | `reasoning_effort`                                                                                                                       |
 | Anthropic              | adaptive `thinking` + `output_config.effort` on Claude 4.6+; `thinking` with budget tokens (capped to `max_tokens - 1`) on 4.5 and older |
 | Google                 | `thinking_config` with `thinking_budget` and `include_thoughts`                                                                          |
-| AWS Bedrock            | `additionalModelRequestFields.thinking` — adaptive + `output_config.effort` on Claude 4.6+, budget tokens on 4.5 and older               |
+| AWS Bedrock            | `additionalModelRequestFields.thinking` — adaptive + `output_config.effort` on Claude 4.6+, capped budget tokens on 4.5 and older        |
 | Groq                   | `reasoning_effort` + `include_reasoning`                                                                                                 |
 
 For fine-grained control, use provider-specific params instead (e.g., `AnthropicParams(thinking=...)`). Provider params always take precedence over the top-level `reasoning_effort`.

--- a/packages/lmux-anthropic/README.md
+++ b/packages/lmux-anthropic/README.md
@@ -148,6 +148,20 @@ print(response.cost)
 
 `resource` and the mutually exclusive `base_url` fall back to the `ANTHROPIC_FOUNDRY_RESOURCE` and `ANTHROPIC_FOUNDRY_BASE_URL` environment variables. Model IDs are Foundry deployment names, which default to the plain model IDs (`claude-sonnet-4-6`, ...). Foundry bills Anthropic's standard API pricing through the Microsoft Marketplace, so costs come from the same pricing table with no multiplier.
 
+`reasoning_effort` can select the correct thinking mode only when the deployment name contains a recognizable Claude model ID. For an opaque custom deployment name, configure the thinking mode explicitly for the deployed model:
+
+```python
+from lmux_anthropic import AnthropicParams
+
+response = provider.chat(
+    "claude-prod",
+    [UserMessage(content="Hello")],
+    provider_params=AnthropicParams(thinking={"type": "enabled", "budget_tokens": 8192}),
+)
+```
+
+Use `{"type": "adaptive"}` instead when the deployment targets a model that requires adaptive thinking.
+
 ### Foundry Auth
 
 The default `AnthropicFoundryEnvAuthProvider` reads an API key from `ANTHROPIC_FOUNDRY_API_KEY`. For Microsoft Entra ID, wrap a bearer-token provider:

--- a/packages/lmux-anthropic/README.md
+++ b/packages/lmux-anthropic/README.md
@@ -74,6 +74,8 @@ response = provider.chat(
 | `cache_control` | `dict`                      | Top-level prompt-cache control — auto-places a breakpoint on the last cacheable block (e.g. `{"type": "ephemeral"}`) |
 | `pricing_as_of` | `datetime.date`             | Override the date used for dated pricing (e.g. a model's introductory-rate window); defaults to the current date     |
 
+For manual thinking, an integer `budget_tokens` raises the default `max_tokens` when needed. An explicit `max_tokens` is preserved instead, along with the provider-specific thinking configuration. Ensure those explicit values are compatible with the deployed model; manual thinking normally requires `budget_tokens < max_tokens`, except when interleaved thinking applies.
+
 ## Prompt Caching
 
 Two ways to opt in:

--- a/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
@@ -4,7 +4,7 @@ import copy
 import json
 import re
 from collections.abc import Callable, Sequence
-from typing import Any
+from typing import Any, Literal
 
 from lmux.exceptions import UnsupportedFeatureError
 from lmux.schema import add_additional_properties_false
@@ -249,22 +249,32 @@ def map_tool_choice(tc: ToolChoice) -> dict[str, str]:
 
 
 _ADAPTIVE_MIN = (4, 6)
-_MODEL_GEN_RE = re.compile(r"claude-(?:opus|sonnet|haiku|fable)-(\d+)(?:-(\d{1,2})(?=$|[-:@]))?")
+_FAMILY_FIRST_GEN_RE = re.compile(
+    r"claude-[a-z][a-z0-9]*-(\d{1,2})(?:-(\d{1,2}))?(?=$|[-:@.])",
+    re.IGNORECASE,
+)
+_GENERATION_FIRST_GEN_RE = re.compile(
+    r"claude-(\d{1,2})(?:-(\d{1,2}))?-[a-z]",
+    re.IGNORECASE,
+)
+_ADAPTIVE_PREVIEW_RE = re.compile(r"claude-(?:mythos|fable)-preview(?=$|[-:@.])", re.IGNORECASE)
 
 
-def model_uses_adaptive_thinking(model: str) -> bool:
-    """Return True for Claude generations >= 4.6 (adaptive thinking + effort).
+def model_thinking_mode(model: str) -> Literal["adaptive", "enabled"] | None:
+    """Return the thinking mode required by a recognizable Claude model id.
 
-    Returns False for <= 4.5 (legacy manual ``budget_tokens`` thinking) and for
-    any unparseable string (the legacy path is the safe default: pre-4.6 models
-    accept ``budget_tokens``, newer ones require adaptive).
+    Claude generations 4.6 and newer use adaptive thinking. Older generations
+    use manual ``budget_tokens`` thinking. Opaque deployment names return None
+    because neither mode is a safe default across Claude generations.
     """
-    match = _MODEL_GEN_RE.search(model)
+    if _ADAPTIVE_PREVIEW_RE.search(model) is not None:
+        return "adaptive"
+    match = _FAMILY_FIRST_GEN_RE.search(model) or _GENERATION_FIRST_GEN_RE.search(model)
     if match is None:
-        return False
+        return None
     major = int(match.group(1))
     minor = int(match.group(2)) if match.group(2) is not None else 0
-    return (major, minor) >= _ADAPTIVE_MIN
+    return "adaptive" if (major, minor) >= _ADAPTIVE_MIN else "enabled"
 
 
 def map_response_format(rf: ResponseFormat) -> Json | None:

--- a/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
@@ -249,12 +249,13 @@ def map_tool_choice(tc: ToolChoice) -> dict[str, str]:
 
 
 _ADAPTIVE_MIN = (4, 6)
+_MODEL_FAMILY = r"(?:fable|haiku|mythos|opus|sonnet)"
 _FAMILY_FIRST_GEN_RE = re.compile(
-    r"claude-[a-z][a-z0-9]*-(\d{1,2})(?:-(\d{1,2}))?(?=$|[-:@.])",
+    rf"claude-{_MODEL_FAMILY}-(\d{{1,2}})(?:-(\d{{1,2}}))?(?=$|[-:@.])",
     re.IGNORECASE,
 )
 _GENERATION_FIRST_GEN_RE = re.compile(
-    r"claude-(\d{1,2})(?:-(\d{1,2}))?-[a-z]",
+    rf"claude-(\d{{1,2}})(?:-(\d{{1,2}}))?-{_MODEL_FAMILY}(?=$|[-:@.])",
     re.IGNORECASE,
 )
 _ADAPTIVE_PREVIEW_RE = re.compile(r"claude-(?:mythos|fable)-preview(?=$|[-:@.])", re.IGNORECASE)

--- a/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/_mappers.py
@@ -258,7 +258,7 @@ _GENERATION_FIRST_GEN_RE = re.compile(
     rf"claude-(\d{{1,2}})(?:-(\d{{1,2}}))?-{_MODEL_FAMILY}(?=$|[-:@.])",
     re.IGNORECASE,
 )
-_ADAPTIVE_PREVIEW_RE = re.compile(r"claude-(?:mythos|fable)-preview(?=$|[-:@.])", re.IGNORECASE)
+_ADAPTIVE_PREVIEW_RE = re.compile(r"claude-mythos-preview(?=$|[-:@.])", re.IGNORECASE)
 
 
 def model_thinking_mode(model: str) -> Literal["adaptive", "enabled"] | None:

--- a/packages/lmux-anthropic/src/lmux_anthropic/provider.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/provider.py
@@ -19,7 +19,7 @@ from urllib.parse import quote
 
 from lmux._http import aiter_sse, iter_sse
 from lmux.cost import ModelPricing, calculate_cost
-from lmux.exceptions import LmuxError, ProviderError
+from lmux.exceptions import InvalidRequestError, LmuxError, ProviderError
 from lmux.protocols import AuthProvider, CompletionProvider, PricingProvider
 from lmux.types import ChatChunk, ChatResponse, Cost, Message, ResponseFormat, Tool, ToolChoice, Usage
 from lmux_anthropic._exceptions import (
@@ -53,7 +53,7 @@ from lmux_anthropic._mappers import (
     map_response_format,
     map_tool_choice,
     map_tools,
-    model_uses_adaptive_thinking,
+    model_thinking_mode,
 )
 from lmux_anthropic._wire import (
     WireContentBlockDeltaEvent,
@@ -82,6 +82,8 @@ VERTEX_PROVIDER_NAME = "anthropic-vertex"
 FOUNDRY_PROVIDER_NAME = "anthropic-foundry"
 BEDROCK_PROVIDER_NAME = "anthropic-bedrock"
 DEFAULT_MAX_TOKENS = 4096
+_MIN_THINKING_BUDGET = 1024
+_THINKING_BUDGETS = {"low": 1024, "medium": 8192, "high": 32768}
 _MESSAGES_PATH = "v1/messages"
 _HTTP_ERROR = 400
 
@@ -92,6 +94,36 @@ _INVOKE_STREAM = "invoke-with-response-stream"
 _JSON_CONTENT_TYPE = "application/json"
 _EXCEPTION_MESSAGE_TYPE = "exception"
 _ERROR_MESSAGE_TYPE = "error"
+
+
+def _enabled_thinking_budget(thinking: object) -> int | None:
+    if not isinstance(thinking, Mapping) or thinking.get("type") != "enabled":
+        return None
+    budget = thinking.get("budget_tokens")
+    return budget if type(budget) is int else None
+
+
+def _thinking_for_effort(
+    model: str,
+    reasoning_effort: Literal["low", "medium", "high"],
+    max_tokens: int,
+    provider: str,
+) -> tuple[dict[str, object], dict[str, str] | None]:
+    thinking_mode = model_thinking_mode(model)
+    if thinking_mode is None:
+        msg = (
+            f"Cannot map reasoning_effort for unrecognized Claude model {model!r}; "
+            "set provider_params.thinking explicitly"
+        )
+        raise InvalidRequestError(msg, provider=provider)
+    if thinking_mode == "adaptive":
+        return {"type": "adaptive"}, {"effort": reasoning_effort}
+    budget = min(_THINKING_BUDGETS[reasoning_effort], max_tokens - 1)
+    if budget < _MIN_THINKING_BUDGET:
+        msg = f"max_tokens must be greater than {_MIN_THINKING_BUDGET} when reasoning_effort is set"
+        raise InvalidRequestError(msg, provider=provider)
+    return {"type": "enabled", "budget_tokens": budget}, None
+
 
 # Vertex auth providers may return bare credentials, or credentials together
 # with the project ID they resolved (e.g. from ADC or a service account file).
@@ -445,10 +477,15 @@ class AnthropicProvider(
         stream: bool,
     ) -> dict[str, Any]:
         system, mapped_messages = map_messages(messages)
+        provider_thinking = provider_params.thinking if provider_params is not None else None
+        raw_budget = _enabled_thinking_budget(provider_thinking)
+        effective_max_tokens = max_tokens if max_tokens is not None else self._default_max_tokens
+        if max_tokens is None and raw_budget is not None:
+            effective_max_tokens = max(effective_max_tokens, raw_budget + 1)
         body: dict[str, Any] = {
             "model": model,
             "messages": mapped_messages,
-            "max_tokens": max_tokens if max_tokens is not None else self._default_max_tokens,
+            "max_tokens": effective_max_tokens,
             "stream": stream,
         }
         if system is not None:
@@ -470,15 +507,14 @@ class AnthropicProvider(
         # provider_params.thinking takes precedence over reasoning_effort, so skip the
         # reasoning_effort mapping entirely when it is set (otherwise a stray
         # output_config.effort would linger after the provider_params update below).
-        provider_sets_thinking = provider_params is not None and provider_params.thinking is not None
+        provider_sets_thinking = provider_thinking is not None
         if reasoning_effort is not None and not provider_sets_thinking:
-            if model_uses_adaptive_thinking(model):
-                body["thinking"] = {"type": "adaptive"}
-                body["output_config"] = {**body.get("output_config", {}), "effort": reasoning_effort}
-            else:
-                budget = {"low": 1024, "medium": 8192, "high": 32768}[reasoning_effort]
-                budget = min(budget, body["max_tokens"] - 1)
-                body["thinking"] = {"type": "enabled", "budget_tokens": budget}
+            thinking, output_config = _thinking_for_effort(
+                model, reasoning_effort, body["max_tokens"], self._provider_name
+            )
+            body["thinking"] = thinking
+            if output_config is not None:
+                body["output_config"] = {**body.get("output_config", {}), **output_config}
         if provider_params is not None:
             body.update(self._provider_params_kwargs(provider_params))
         return body

--- a/packages/lmux-anthropic/tests/test_mappers.py
+++ b/packages/lmux-anthropic/tests/test_mappers.py
@@ -866,7 +866,6 @@ class TestModelThinkingMode:
             "claude-sonnet-5",
             "claude-fable-5",
             "claude-mythos-5",
-            "claude-orchid-5",
             "Claude-Sonnet-4-6",
             "CLAUDE-OPUS-4-8",
             "claude-mythos-preview",
@@ -900,6 +899,17 @@ class TestModelThinkingMode:
     def test_legacy_generations(self, model: str) -> None:
         assert model_thinking_mode(model) == "enabled"
 
-    @pytest.mark.parametrize("model", ["not-a-model", "", "claude-custom-deployment", "claude-deployment-2026"])
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "not-a-model",
+            "",
+            "claude-custom-deployment",
+            "claude-deployment-2026",
+            "claude-prod-4-5",
+            "claude-4-5-prod",
+            "claude-orchid-5",
+        ],
+    )
     def test_unparseable_generations(self, model: str) -> None:
         assert model_thinking_mode(model) is None

--- a/packages/lmux-anthropic/tests/test_mappers.py
+++ b/packages/lmux-anthropic/tests/test_mappers.py
@@ -42,7 +42,7 @@ from lmux_anthropic._mappers import (
     map_response_format,
     map_tool_choice,
     map_tools,
-    model_uses_adaptive_thinking,
+    model_thinking_mode,
 )
 from lmux_anthropic._wire import (
     WireContentBlockDeltaEvent,
@@ -855,7 +855,7 @@ class TestMapToolChoice:
         assert map_tool_choice(ToolChoiceFunction(name="get_weather")) == {"type": "tool", "name": "get_weather"}
 
 
-class TestModelUsesAdaptiveThinking:
+class TestModelThinkingMode:
     @pytest.mark.parametrize(
         "model",
         [
@@ -865,6 +865,11 @@ class TestModelUsesAdaptiveThinking:
             "claude-sonnet-4-6",
             "claude-sonnet-5",
             "claude-fable-5",
+            "claude-mythos-5",
+            "claude-orchid-5",
+            "Claude-Sonnet-4-6",
+            "CLAUDE-OPUS-4-8",
+            "claude-mythos-preview",
             "global.anthropic.claude-opus-4-8",
             "global.anthropic.claude-sonnet-5",
             "us.anthropic.claude-opus-4-6-v1",
@@ -873,7 +878,7 @@ class TestModelUsesAdaptiveThinking:
         ],
     )
     def test_adaptive_generations(self, model: str) -> None:
-        assert model_uses_adaptive_thinking(model) is True
+        assert model_thinking_mode(model) == "adaptive"
 
     @pytest.mark.parametrize(
         "model",
@@ -890,9 +895,11 @@ class TestModelUsesAdaptiveThinking:
             "claude-3-7-sonnet",
             "claude-3-5-sonnet",
             "claude-3-opus",
-            "not-a-model",
-            "",
         ],
     )
-    def test_legacy_and_unparseable_generations(self, model: str) -> None:
-        assert model_uses_adaptive_thinking(model) is False
+    def test_legacy_generations(self, model: str) -> None:
+        assert model_thinking_mode(model) == "enabled"
+
+    @pytest.mark.parametrize("model", ["not-a-model", "", "claude-custom-deployment", "claude-deployment-2026"])
+    def test_unparseable_generations(self, model: str) -> None:
+        assert model_thinking_mode(model) is None

--- a/packages/lmux-anthropic/tests/test_mappers.py
+++ b/packages/lmux-anthropic/tests/test_mappers.py
@@ -909,6 +909,7 @@ class TestModelThinkingMode:
             "claude-prod-4-5",
             "claude-4-5-prod",
             "claude-orchid-5",
+            "claude-fable-preview",
         ],
     )
     def test_unparseable_generations(self, model: str) -> None:

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -463,6 +463,20 @@ class TestChat:
         assert body["thinking"] == {"type": "enabled", "budget_tokens": "provider-defined"}
         assert body["max_tokens"] == 4096
 
+    def test_provider_params_thinking_preserves_explicit_max_tokens(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(
+            "claude-sonnet-4-5",
+            [UserMessage(content="Hi")],
+            max_tokens=4096,
+            provider_params=AnthropicParams(thinking={"type": "enabled", "budget_tokens": 32768}),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["max_tokens"] == 4096
+        assert body["thinking"] == {"type": "enabled", "budget_tokens": 32768}
+
     def test_empty_provider_params(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
         route = _ok(respx_mock)
         sync_provider.chat(MODEL, [UserMessage(content="Hi")], provider_params=AnthropicParams())

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -1144,6 +1144,28 @@ class TestFoundryChat:
         assert request.headers["api-key"] == "foundry-key"
         assert json.loads(request.content)["model"] == MODEL
 
+    def test_reasoning_effort_rejects_opaque_deployment(
+        self, foundry_sync_provider: AnthropicFoundryProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
+        with pytest.raises(InvalidRequestError, match="unrecognized Claude model"):
+            foundry_sync_provider.chat("claude-prod-4-5", [UserMessage(content="Hi")], reasoning_effort="low")
+        assert not route.called
+
+    def test_opaque_deployment_accepts_explicit_thinking(
+        self, foundry_sync_provider: AnthropicFoundryProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
+        foundry_sync_provider.chat(
+            "claude-prod-4-5",
+            [UserMessage(content="Hi")],
+            provider_params=AnthropicParams(thinking={"type": "enabled", "budget_tokens": 2048}),
+        )
+        assert json.loads(route.calls.last.request.content)["thinking"] == {
+            "type": "enabled",
+            "budget_tokens": 2048,
+        }
+
     async def test_basic_achat(self, respx_mock: respx.MockRouter) -> None:
         respx_mock.post(_foundry_url()).mock(return_value=httpx.Response(200, json=_message()))
         provider = AnthropicFoundryProvider(auth=FakeFoundryAuth(), resource="my-resource")

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -371,6 +371,24 @@ class TestChat:
         )
         assert json.loads(route.calls.last.request.content)["thinking"] == {"type": "enabled", "budget_tokens": 8192}
 
+    def test_reasoning_effort_rejects_too_small_max_tokens(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock)
+        with pytest.raises(InvalidRequestError, match="max_tokens must be greater than 1024"):
+            sync_provider.chat(
+                "claude-sonnet-4-5", [UserMessage(content="Hi")], max_tokens=1024, reasoning_effort="low"
+            )
+        assert not route.called
+
+    def test_reasoning_effort_rejects_unrecognized_model(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock)
+        with pytest.raises(InvalidRequestError, match="unrecognized Claude model"):
+            sync_provider.chat("custom-deployment", [UserMessage(content="Hi")], reasoning_effort="low")
+        assert not route.called
+
     def test_reasoning_effort_adaptive_model(
         self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
     ) -> None:
@@ -406,6 +424,7 @@ class TestChat:
         )
         body = json.loads(route.calls.last.request.content)
         assert body["thinking"] == {"type": "enabled", "budget_tokens": 2048}
+        assert body["max_tokens"] == 4096
         assert "output_config" not in body
 
     def test_provider_params(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
@@ -424,11 +443,25 @@ class TestChat:
         )
         body = json.loads(route.calls.last.request.content)
         assert body["thinking"] == {"type": "enabled", "budget_tokens": 5000}
+        assert body["max_tokens"] == 5001
         assert body["metadata"] == {"user_id": "u1"}
         assert body["top_k"] == 40
         assert body["service_tier"] == "auto"
         assert body["inference_geo"] == "us"
         assert body["cache_control"] == {"type": "ephemeral"}
+
+    def test_provider_params_non_integer_thinking_budget_is_untouched(
+        self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok(respx_mock)
+        sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            provider_params=AnthropicParams(thinking={"type": "enabled", "budget_tokens": "provider-defined"}),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["thinking"] == {"type": "enabled", "budget_tokens": "provider-defined"}
+        assert body["max_tokens"] == 4096
 
     def test_empty_provider_params(self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter) -> None:
         route = _ok(respx_mock)

--- a/packages/lmux-aws-bedrock/README.md
+++ b/packages/lmux-aws-bedrock/README.md
@@ -103,6 +103,10 @@ response = provider.chat(
 | `additional_model_response_field_paths` | `list[str]`       | Extra response fields to return                                        |
 | `pricing_as_of`                         | `datetime.date`   | Override the date used for dated pricing; defaults to the current date |
 
+For Claude 4.5 and older, `reasoning_effort` maps to a manual thinking budget capped below `maxTokens`. When `max_tokens` is omitted, lmux sends `maxTokens: 4096`, so medium and high effort both use a 4095-token thinking budget. Pass a larger `max_tokens` to use their full mapped budgets.
+
+An integer manual-thinking budget in `additional_model_request_fields` raises the default `maxTokens` when needed. An explicit `max_tokens` is preserved instead, along with the provider-specific fields. Ensure those explicit values are compatible with the deployed model; manual thinking normally requires `budget_tokens < maxTokens`, except when interleaved thinking applies.
+
 ## Prompt Caching
 
 Place `CachePointContent` parts in `UserMessage` content to emit Converse `cachePoint` blocks marking the end of a stable prompt prefix. A cache point with no preceding block in its message is placed after whatever came before it (the prior message, or the system blocks). Markers with nothing cacheable before them are dropped, and adjacent duplicates are coalesced — the first marker wins.

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
@@ -248,7 +248,7 @@ _GENERATION_FIRST_GEN_RE = re.compile(
     rf"claude-(\d{{1,2}})(?:-(\d{{1,2}}))?-{_MODEL_FAMILY}(?=$|[-:@.])",
     re.IGNORECASE,
 )
-_ADAPTIVE_PREVIEW_RE = re.compile(r"claude-(?:mythos|fable)-preview(?=$|[-:@.])", re.IGNORECASE)
+_ADAPTIVE_PREVIEW_RE = re.compile(r"claude-mythos-preview(?=$|[-:@.])", re.IGNORECASE)
 
 
 def model_thinking_mode(model: str) -> Literal["adaptive", "enabled"] | None:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
@@ -4,7 +4,7 @@ import copy
 import json
 import re
 from collections.abc import Callable, Sequence
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
     from mypy_boto3_bedrock_runtime.literals import CacheTTLType, ImageFormatType
@@ -239,22 +239,32 @@ def map_tool_choice(tc: ToolChoice) -> dict[str, object]:
 
 
 _ADAPTIVE_MIN = (4, 6)
-_MODEL_GEN_RE = re.compile(r"claude-(?:opus|sonnet|haiku|fable)-(\d+)(?:-(\d{1,2})(?=$|[-:@]))?")
+_FAMILY_FIRST_GEN_RE = re.compile(
+    r"claude-[a-z][a-z0-9]*-(\d{1,2})(?:-(\d{1,2}))?(?=$|[-:@.])",
+    re.IGNORECASE,
+)
+_GENERATION_FIRST_GEN_RE = re.compile(
+    r"claude-(\d{1,2})(?:-(\d{1,2}))?-[a-z]",
+    re.IGNORECASE,
+)
+_ADAPTIVE_PREVIEW_RE = re.compile(r"claude-(?:mythos|fable)-preview(?=$|[-:@.])", re.IGNORECASE)
 
 
-def model_uses_adaptive_thinking(model: str) -> bool:
-    """Return True for Claude generations >= 4.6 (adaptive thinking + effort).
+def model_thinking_mode(model: str) -> Literal["adaptive", "enabled"] | None:
+    """Return the thinking mode required by a recognizable Claude model id.
 
-    Returns False for <= 4.5 (legacy manual ``budget_tokens`` thinking) and for
-    any unparseable string (the legacy path is the safe default: pre-4.6 models
-    accept ``budget_tokens``, newer ones require adaptive).
+    Claude generations 4.6 and newer use adaptive thinking. Older generations
+    use manual ``budget_tokens`` thinking. Opaque deployment names return None
+    because neither mode is a safe default across Claude generations.
     """
-    match = _MODEL_GEN_RE.search(model)
+    if _ADAPTIVE_PREVIEW_RE.search(model) is not None:
+        return "adaptive"
+    match = _FAMILY_FIRST_GEN_RE.search(model) or _GENERATION_FIRST_GEN_RE.search(model)
     if match is None:
-        return False
+        return None
     major = int(match.group(1))
     minor = int(match.group(2)) if match.group(2) is not None else 0
-    return (major, minor) >= _ADAPTIVE_MIN
+    return "adaptive" if (major, minor) >= _ADAPTIVE_MIN else "enabled"
 
 
 def map_response_format(rf: ResponseFormat) -> dict[str, object] | None:

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/_mappers.py
@@ -239,12 +239,13 @@ def map_tool_choice(tc: ToolChoice) -> dict[str, object]:
 
 
 _ADAPTIVE_MIN = (4, 6)
+_MODEL_FAMILY = r"(?:fable|haiku|mythos|opus|sonnet)"
 _FAMILY_FIRST_GEN_RE = re.compile(
-    r"claude-[a-z][a-z0-9]*-(\d{1,2})(?:-(\d{1,2}))?(?=$|[-:@.])",
+    rf"claude-{_MODEL_FAMILY}-(\d{{1,2}})(?:-(\d{{1,2}}))?(?=$|[-:@.])",
     re.IGNORECASE,
 )
 _GENERATION_FIRST_GEN_RE = re.compile(
-    r"claude-(\d{1,2})(?:-(\d{1,2}))?-[a-z]",
+    rf"claude-(\d{{1,2}})(?:-(\d{{1,2}}))?-{_MODEL_FAMILY}(?=$|[-:@.])",
     re.IGNORECASE,
 )
 _ADAPTIVE_PREVIEW_RE = re.compile(r"claude-(?:mythos|fable)-preview(?=$|[-:@.])", re.IGNORECASE)

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/provider.py
@@ -15,7 +15,7 @@ this step.
 
 import asyncio
 import json
-from collections.abc import AsyncIterator, Iterator, Sequence
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
 from datetime import date
 from typing import TYPE_CHECKING, Any, Literal, override
 from urllib.parse import quote
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from aiobotocore.session import AioSession
 
 from lmux.cost import ModelPricing, calculate_cost
-from lmux.exceptions import LmuxError
+from lmux.exceptions import InvalidRequestError, LmuxError
 from lmux.protocols import AuthProvider, CompletionProvider, EmbeddingProvider, PricingProvider
 from lmux.types import (
     ChatChunk,
@@ -55,7 +55,7 @@ from lmux_aws_bedrock._mappers import (
     map_stream_event,
     map_tool_choice,
     map_tools,
-    model_uses_adaptive_thinking,
+    model_thinking_mode,
 )
 from lmux_aws_bedrock._wire import (
     WireConverseResponse,
@@ -70,6 +70,9 @@ from lmux_bedrock_shared.auth import BedrockAuthContext, resolve_auth_context
 
 PROVIDER_NAME = PROVIDER
 _JSON_CONTENT_TYPE = "application/json"
+_DEFAULT_MAX_TOKENS = 4096
+_MIN_THINKING_BUDGET = 1024
+_THINKING_BUDGETS = {"low": 1024, "medium": 8192, "high": 32768}
 
 _CONVERSE = "converse"
 _CONVERSE_STREAM = "converse-stream"
@@ -77,6 +80,34 @@ _INVOKE = "invoke"
 
 _EXCEPTION_MESSAGE_TYPE = "exception"
 _ERROR_MESSAGE_TYPE = "error"
+
+
+def _enabled_thinking_budget(thinking: object) -> int | None:
+    if not isinstance(thinking, Mapping) or thinking.get("type") != "enabled":
+        return None
+    budget = thinking.get("budget_tokens")
+    return budget if type(budget) is int else None
+
+
+def _thinking_for_effort(
+    model: str,
+    reasoning_effort: Literal["low", "medium", "high"],
+    max_tokens: int,
+) -> tuple[dict[str, object], dict[str, str] | None]:
+    thinking_mode = model_thinking_mode(model)
+    if thinking_mode is None:
+        msg = (
+            f"Cannot map reasoning_effort for unrecognized Claude model {model!r}; "
+            "set provider_params.additional_model_request_fields['thinking'] explicitly"
+        )
+        raise InvalidRequestError(msg, provider=PROVIDER_NAME)
+    if thinking_mode == "adaptive":
+        return {"type": "adaptive"}, {"effort": reasoning_effort}
+    budget = min(_THINKING_BUDGETS[reasoning_effort], max_tokens - 1)
+    if budget < _MIN_THINKING_BUDGET:
+        msg = f"max_tokens must be greater than {_MIN_THINKING_BUDGET} when reasoning_effort is set"
+        raise InvalidRequestError(msg, provider=PROVIDER_NAME)
+    return {"type": "enabled", "budget_tokens": budget}, None
 
 
 def _today() -> date:
@@ -516,13 +547,20 @@ class BedrockProvider(
         if reasoning_effort is not None:
             existing = {**kwargs.get("additionalModelRequestFields", {})}
             if "thinking" not in existing:
-                if model_uses_adaptive_thinking(model):
-                    existing["thinking"] = {"type": "adaptive"}
-                    existing["output_config"] = {**existing.get("output_config", {}), "effort": reasoning_effort}
-                else:
-                    budget = {"low": 1024, "medium": 8192, "high": 32768}[reasoning_effort]
-                    existing["thinking"] = {"type": "enabled", "budget_tokens": budget}
+                effective_max_tokens = max_tokens if max_tokens is not None else _DEFAULT_MAX_TOKENS
+                thinking, output_config = _thinking_for_effort(model, reasoning_effort, effective_max_tokens)
+                existing["thinking"] = thinking
+                if output_config is not None:
+                    existing["output_config"] = {**existing.get("output_config", {}), **output_config}
             kwargs["additionalModelRequestFields"] = existing
+
+        additional = kwargs.get("additionalModelRequestFields")
+        thinking = additional.get("thinking") if isinstance(additional, Mapping) else None
+        raw_budget = _enabled_thinking_budget(thinking)
+        if max_tokens is None and raw_budget is not None:
+            inference_config = {**kwargs.get("inferenceConfig", {})}
+            inference_config["maxTokens"] = max(_DEFAULT_MAX_TOKENS, raw_budget + 1)
+            kwargs["inferenceConfig"] = inference_config
 
         return kwargs
 

--- a/packages/lmux-aws-bedrock/tests/test_mappers.py
+++ b/packages/lmux-aws-bedrock/tests/test_mappers.py
@@ -44,7 +44,7 @@ from lmux_aws_bedrock._mappers import (
     map_stream_event,
     map_tool_choice,
     map_tools,
-    model_uses_adaptive_thinking,
+    model_thinking_mode,
 )
 from lmux_aws_bedrock._wire import (
     WireConverseResponse,
@@ -841,7 +841,7 @@ class TestMapToolChoice:
         assert map_tool_choice(ToolChoiceFunction(name="get_weather")) == {"tool": {"name": "get_weather"}}
 
 
-class TestModelUsesAdaptiveThinking:
+class TestModelThinkingMode:
     @pytest.mark.parametrize(
         "model",
         [
@@ -851,6 +851,11 @@ class TestModelUsesAdaptiveThinking:
             "claude-sonnet-4-6",
             "claude-sonnet-5",
             "claude-fable-5",
+            "claude-mythos-5",
+            "claude-orchid-5",
+            "Claude-Sonnet-4-6",
+            "CLAUDE-OPUS-4-8",
+            "claude-mythos-preview",
             "global.anthropic.claude-opus-4-8",
             "global.anthropic.claude-sonnet-5",
             "us.anthropic.claude-opus-4-6-v1",
@@ -859,7 +864,7 @@ class TestModelUsesAdaptiveThinking:
         ],
     )
     def test_adaptive_generations(self, model: str) -> None:
-        assert model_uses_adaptive_thinking(model) is True
+        assert model_thinking_mode(model) == "adaptive"
 
     @pytest.mark.parametrize(
         "model",
@@ -876,9 +881,11 @@ class TestModelUsesAdaptiveThinking:
             "claude-3-7-sonnet",
             "claude-3-5-sonnet",
             "claude-3-opus",
-            "not-a-model",
-            "",
         ],
     )
-    def test_legacy_and_unparseable_generations(self, model: str) -> None:
-        assert model_uses_adaptive_thinking(model) is False
+    def test_legacy_generations(self, model: str) -> None:
+        assert model_thinking_mode(model) == "enabled"
+
+    @pytest.mark.parametrize("model", ["not-a-model", "", "claude-custom-deployment", "claude-deployment-2026"])
+    def test_unparseable_generations(self, model: str) -> None:
+        assert model_thinking_mode(model) is None

--- a/packages/lmux-aws-bedrock/tests/test_mappers.py
+++ b/packages/lmux-aws-bedrock/tests/test_mappers.py
@@ -852,7 +852,6 @@ class TestModelThinkingMode:
             "claude-sonnet-5",
             "claude-fable-5",
             "claude-mythos-5",
-            "claude-orchid-5",
             "Claude-Sonnet-4-6",
             "CLAUDE-OPUS-4-8",
             "claude-mythos-preview",
@@ -886,6 +885,17 @@ class TestModelThinkingMode:
     def test_legacy_generations(self, model: str) -> None:
         assert model_thinking_mode(model) == "enabled"
 
-    @pytest.mark.parametrize("model", ["not-a-model", "", "claude-custom-deployment", "claude-deployment-2026"])
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "not-a-model",
+            "",
+            "claude-custom-deployment",
+            "claude-deployment-2026",
+            "claude-prod-4-5",
+            "claude-4-5-prod",
+            "claude-orchid-5",
+        ],
+    )
     def test_unparseable_generations(self, model: str) -> None:
         assert model_thinking_mode(model) is None

--- a/packages/lmux-aws-bedrock/tests/test_mappers.py
+++ b/packages/lmux-aws-bedrock/tests/test_mappers.py
@@ -895,6 +895,7 @@ class TestModelThinkingMode:
             "claude-prod-4-5",
             "claude-4-5-prod",
             "claude-orchid-5",
+            "claude-fable-preview",
         ],
     )
     def test_unparseable_generations(self, model: str) -> None:

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -408,7 +408,33 @@ class TestChat:
         route = _ok_converse(converse_response, respx_mock)
         sync_provider.chat(MODEL, [UserMessage(content="Hi")], reasoning_effort="medium")
         body = json.loads(route.calls.last.request.content)
+        assert body["additionalModelRequestFields"]["thinking"] == {"type": "enabled", "budget_tokens": 4095}
+        assert body["inferenceConfig"]["maxTokens"] == 4096
+
+    def test_reasoning_effort_honors_high_max_tokens(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(MODEL, [UserMessage(content="Hi")], max_tokens=100000, reasoning_effort="medium")
+        body = json.loads(route.calls.last.request.content)
         assert body["additionalModelRequestFields"]["thinking"] == {"type": "enabled", "budget_tokens": 8192}
+        assert body["inferenceConfig"]["maxTokens"] == 100000
+
+    def test_reasoning_effort_rejects_too_small_max_tokens(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock)
+        with pytest.raises(InvalidRequestError, match="max_tokens must be greater than 1024"):
+            sync_provider.chat(MODEL, [UserMessage(content="Hi")], max_tokens=1024, reasoning_effort="low")
+        assert not route.called
+
+    def test_reasoning_effort_rejects_unrecognized_model(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock, model="custom-deployment")
+        with pytest.raises(InvalidRequestError, match="unrecognized Claude model"):
+            sync_provider.chat("custom-deployment", [UserMessage(content="Hi")], reasoning_effort="low")
+        assert not route.called
 
     def test_reasoning_effort_deep_merges_with_provider_params(
         self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
@@ -420,9 +446,11 @@ class TestChat:
             reasoning_effort="high",
             provider_params=BedrockParams(additional_model_request_fields={"some_field": "value"}),
         )
-        additional = json.loads(route.calls.last.request.content)["additionalModelRequestFields"]
-        assert additional["thinking"] == {"type": "enabled", "budget_tokens": 32768}
+        body = json.loads(route.calls.last.request.content)
+        additional = body["additionalModelRequestFields"]
+        assert additional["thinking"] == {"type": "enabled", "budget_tokens": 4095}
         assert additional["some_field"] == "value"
+        assert body["inferenceConfig"]["maxTokens"] == 4096
 
     def test_provider_params_thinking_overrides_reasoning_effort(
         self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
@@ -436,8 +464,28 @@ class TestChat:
                 additional_model_request_fields={"thinking": {"type": "enabled", "budget_tokens": 99999}}
             ),
         )
-        additional = json.loads(route.calls.last.request.content)["additionalModelRequestFields"]
+        body = json.loads(route.calls.last.request.content)
+        additional = body["additionalModelRequestFields"]
         assert additional["thinking"] == {"type": "enabled", "budget_tokens": 99999}
+        assert body["inferenceConfig"]["maxTokens"] == 100000
+
+    def test_provider_params_non_integer_thinking_budget_is_untouched(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            provider_params=BedrockParams(
+                additional_model_request_fields={"thinking": {"type": "enabled", "budget_tokens": "provider-defined"}}
+            ),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["additionalModelRequestFields"]["thinking"] == {
+            "type": "enabled",
+            "budget_tokens": "provider-defined",
+        }
+        assert "inferenceConfig" not in body
 
     def test_reasoning_effort_does_not_mutate_provider_params(
         self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter

--- a/packages/lmux-aws-bedrock/tests/test_provider.py
+++ b/packages/lmux-aws-bedrock/tests/test_provider.py
@@ -487,6 +487,22 @@ class TestChat:
         }
         assert "inferenceConfig" not in body
 
+    def test_provider_params_thinking_preserves_explicit_max_tokens(
+        self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        route = _ok_converse(converse_response, respx_mock)
+        sync_provider.chat(
+            MODEL,
+            [UserMessage(content="Hi")],
+            max_tokens=1024,
+            provider_params=BedrockParams(
+                additional_model_request_fields={"thinking": {"type": "enabled", "budget_tokens": 99999}}
+            ),
+        )
+        body = json.loads(route.calls.last.request.content)
+        assert body["inferenceConfig"] == {"maxTokens": 1024}
+        assert body["additionalModelRequestFields"] == {"thinking": {"type": "enabled", "budget_tokens": 99999}}
+
     def test_reasoning_effort_does_not_mutate_provider_params(
         self, sync_provider: BedrockProvider, converse_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:


### PR DESCRIPTION
Claude thinking requests could select the legacy mode for newer model IDs and emit invalid token budgets. Opaque deployment names cannot be classified safely because older and newer Claude generations require different modes. This PR recognizes current model families case-insensitively, rejects ambiguous reasoning_effort mappings with guidance to configure provider thinking explicitly, and keeps lmux-generated budgets within valid limits across Anthropic and Bedrock. Closes #121.