### PR TITLE
fix: Correct drifted provider pricing and add dated pricing to lmux-google

### DIFF
--- a/packages/lmux-anthropic/README.md
+++ b/packages/lmux-anthropic/README.md
@@ -86,7 +86,7 @@ response = provider.chat(
 | `service_tier`  | `"auto" \| "standard_only"` | Service tier selection                                                                                               |
 | `inference_geo` | `"us"`                      | Inference geography (affects cost)                                                                                   |
 | `cache_control` | `dict`                      | Top-level prompt-cache control — auto-places a breakpoint on the last cacheable block (e.g. `{"type": "ephemeral"}`) |
-| `pricing_as_of` | `datetime.date`             | Override the date used for dated pricing (e.g. a model's introductory-rate window); defaults to the current date     |
+| `pricing_as_of` | `datetime.date`             | Override the date used for dated pricing, e.g. replaying usage from before a scheduled rate change; defaults to today |
 
 For manual thinking, an integer `budget_tokens` raises the default `max_tokens` when needed. An explicit `max_tokens` is preserved instead, along with the provider-specific thinking configuration. Ensure those explicit values are compatible with the deployed model; manual thinking normally requires `budget_tokens < max_tokens`, except when interleaved thinking applies.
 

--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-anthropic"
-version = "0.15.0"
+version = "0.15.1"
 description = "Anthropic provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-anthropic/src/lmux_anthropic/cost.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/cost.py
@@ -332,9 +332,8 @@ def has_vertex_regional_premium(model: str) -> bool:
 def calculate_anthropic_cost(model: str, usage: Usage, as_of: date | None = None) -> Cost | None:
     """Calculate cost for an Anthropic API call. Returns None if model pricing is unknown.
 
-    ``as_of`` selects dated pricing for models with scheduled rate changes
-    (e.g. Claude Sonnet 5's introductory period); it defaults to the latest
-    schedule. See ``lmux.cost.calculate_cost``.
+    ``as_of`` selects dated pricing for models with scheduled rate changes; it
+    defaults to the latest schedule. See ``lmux.cost.calculate_cost``.
     """
     pricing = resolve_pricing(model, _PRICING_BY_PREFIX)
     if pricing is None:

--- a/packages/lmux-anthropic/src/lmux_anthropic/cost.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/cost.py
@@ -20,7 +20,6 @@ from datetime import date
 
 from lmux.cost import (
     ModelPricing,
-    PricingSchedule,
     PricingTier,
     build_pricing_index,
     calculate_cost,
@@ -68,9 +67,9 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
-    # Claude Sonnet 5 family — introductory pricing through 2026-08-31, then
-    # standard pricing (matching Sonnet 4.6) from 2026-09-01. Full 1M context
-    # at standard pricing, so there is no >200K tier.
+    # Claude Sonnet 5 family — the $2/$10 launch rate is the standard price; the
+    # increase once scheduled for 2026-09-01 was cancelled. Full 1M context at
+    # standard pricing, so there is no >200K tier.
     "claude-sonnet-5": ModelPricing(
         tiers=[
             PricingTier(
@@ -79,20 +78,6 @@ _PRICING: dict[str, ModelPricing] = {
                 cache_read_cost_per_token=per_million_tokens(0.20),
                 cache_creation_cost_per_token=per_million_tokens(2.50),
                 cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(4.00)},
-            ),
-        ],
-        schedules=[
-            PricingSchedule(
-                valid_from=date(2026, 9, 1),
-                tiers=[
-                    PricingTier(
-                        input_cost_per_token=per_million_tokens(3.00),
-                        output_cost_per_token=per_million_tokens(15.00),
-                        cache_read_cost_per_token=per_million_tokens(0.30),
-                        cache_creation_cost_per_token=per_million_tokens(3.75),
-                        cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(6.00)},
-                    ),
-                ],
             ),
         ],
     ),

--- a/packages/lmux-anthropic/tests/test_cost.py
+++ b/packages/lmux-anthropic/tests/test_cost.py
@@ -132,41 +132,33 @@ class TestCalculateAnthropicCost:
         assert cost.input_cost == pytest.approx(500_000 * 5.0 / 1_000_000)
         assert cost.output_cost == pytest.approx(1000 * 25.0 / 1_000_000)
 
-    def test_sonnet_5_introductory_pricing_before_sep_2026(self) -> None:
-        """Before 2026-09-01, Claude Sonnet 5 bills at the introductory rate."""
+    def test_sonnet_5_pricing(self) -> None:
+        """Claude Sonnet 5 bills at $2.00/$10.00 with $0.20 cache reads and $2.50 cache writes."""
         usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=200, cache_creation_tokens=100)
-        cost = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 7, 1))
+        cost = calculate_anthropic_cost("claude-sonnet-5", usage)
         assert cost is not None
         assert cost.input_cost == pytest.approx((1000 - 200 - 100) * 2.0 / 1_000_000)
         assert cost.output_cost == pytest.approx(500 * 10.0 / 1_000_000)
         assert cost.cache_read_cost == pytest.approx(200 * 0.20 / 1_000_000)
         assert cost.cache_creation_cost == pytest.approx(100 * 2.50 / 1_000_000)
 
-    def test_sonnet_5_standard_pricing_from_sep_2026(self) -> None:
-        """On/after 2026-09-01, Claude Sonnet 5 bills at the standard rate."""
+    def test_sonnet_5_pricing_does_not_change_on_sep_2026(self) -> None:
+        """The rate increase once scheduled for 2026-09-01 was cancelled, so ``as_of`` is inert."""
         usage = Usage(input_tokens=1000, output_tokens=500)
-        cost = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 9, 1))
-        assert cost is not None
-        assert cost.input_cost == pytest.approx(1000 * 3.0 / 1_000_000)
-        assert cost.output_cost == pytest.approx(500 * 15.0 / 1_000_000)
+        before = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 7, 1))
+        after = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 9, 1))
+        assert before is not None
+        assert after is not None
+        assert before == after
+        assert after.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
+        assert after.output_cost == pytest.approx(500 * 10.0 / 1_000_000)
 
-    def test_sonnet_5_defaults_to_standard_pricing(self) -> None:
-        """With no ``as_of``, Claude Sonnet 5 bills at the latest (standard) schedule."""
-        usage = Usage(input_tokens=1000, output_tokens=500)
+    def test_sonnet_5_per_ttl_cache_write_rate(self) -> None:
+        """The 1h cache-write rate is $4.00/M."""
+        usage = Usage(input_tokens=1000, output_tokens=0, cache_creation_tokens_by_ttl={"1h": 1000})
         cost = calculate_anthropic_cost("claude-sonnet-5", usage)
         assert cost is not None
-        assert cost.input_cost == pytest.approx(1000 * 3.0 / 1_000_000)
-        assert cost.output_cost == pytest.approx(500 * 15.0 / 1_000_000)
-
-    def test_sonnet_5_per_ttl_cache_write_rates_differ_by_schedule(self) -> None:
-        """The 1h cache-write rate is $4.00/M introductory and $6.00/M standard."""
-        usage = Usage(input_tokens=1000, output_tokens=0, cache_creation_tokens_by_ttl={"1h": 1000})
-        intro = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 7, 1))
-        standard = calculate_anthropic_cost("claude-sonnet-5", usage, as_of=date(2026, 9, 1))
-        assert intro is not None
-        assert standard is not None
-        assert intro.cache_creation_cost == pytest.approx(1000 * 4.0 / 1_000_000)
-        assert standard.cache_creation_cost == pytest.approx(1000 * 6.0 / 1_000_000)
+        assert cost.cache_creation_cost == pytest.approx(1000 * 4.0 / 1_000_000)
 
 
 class TestApplyCostMultiplier:

--- a/packages/lmux-anthropic/tests/test_provider.py
+++ b/packages/lmux-anthropic/tests/test_provider.py
@@ -220,18 +220,20 @@ class TestPricingAsOf:
         assert result.cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
         assert result.cost.output_cost == pytest.approx(500 * 10.0 / 1_000_000)
 
-    def test_rate_after_switch(
+    def test_rate_unchanged_after_cancelled_switch(
         self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """No Anthropic model has a dated schedule today, so a later clock bills the same rate."""
         monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 9, 15))
         _ok(respx_mock, _message(model="claude-sonnet-5", input_tokens=1000, output_tokens=500))
         result = sync_provider.chat("claude-sonnet-5", [UserMessage(content="Hi")])
         assert result.cost is not None
-        assert result.cost.input_cost == pytest.approx(1000 * 3.0 / 1_000_000)
+        assert result.cost.input_cost == pytest.approx(1000 * 2.0 / 1_000_000)
 
-    def test_override_wins_over_clock(
+    def test_pricing_as_of_override_is_applied(
         self, sync_provider: AnthropicProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """An explicit ``pricing_as_of`` replaces the clock on the way to the cost calculation."""
         monkeypatch.setattr("lmux_anthropic.provider._today", lambda: date(2026, 9, 15))
         _ok(respx_mock, _message(model="claude-sonnet-5", input_tokens=1000, output_tokens=500))
         result = sync_provider.chat(

--- a/packages/lmux-aws-bedrock/pyproject.toml
+++ b/packages/lmux-aws-bedrock/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-aws-bedrock"
-version = "0.13.0"
+version = "0.13.1"
 description = "AWS Bedrock provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
+++ b/packages/lmux-aws-bedrock/src/lmux_aws_bedrock/cost.py
@@ -5611,18 +5611,18 @@ _BEDROCK_REGIONAL: dict[str, dict[str, ModelPricing]] = {
         "openai.gpt-5.6-luna": ModelPricing(
             tiers=[
                 PricingTier(
-                    input_cost_per_token=per_million_tokens(1.32),
-                    output_cost_per_token=per_million_tokens(7.92),
-                    cache_read_cost_per_token=per_million_tokens(0.132),
+                    input_cost_per_token=per_million_tokens(0.264),
+                    output_cost_per_token=per_million_tokens(1.584),
+                    cache_read_cost_per_token=per_million_tokens(0.0264),
                 ),
             ],
         ),
         "openai.gpt-5.6-terra": ModelPricing(
             tiers=[
                 PricingTier(
-                    input_cost_per_token=per_million_tokens(3.3),
-                    output_cost_per_token=per_million_tokens(19.8),
-                    cache_read_cost_per_token=per_million_tokens(0.33),
+                    input_cost_per_token=per_million_tokens(2.64),
+                    output_cost_per_token=per_million_tokens(15.84),
+                    cache_read_cost_per_token=per_million_tokens(0.264),
                 ),
             ],
         ),

--- a/packages/lmux-azure-foundry/pyproject.toml
+++ b/packages/lmux-azure-foundry/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-azure-foundry"
-version = "0.10.0"
+version = "0.10.1"
 description = "Azure AI Foundry provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
@@ -27,24 +27,20 @@ from lmux.types import Cost, Usage
 DATA_ZONE_MULTIPLIER = 1.1
 """Commercial US/EU Data Zone Standard deployments are 1.1x global pricing.
 
-US and EU Data Zone prices are identical. The ratio holds for input, output and
-cache on nearly every model, but not all: Kimi-K2.6 and Kimi-K2.7-Code output
-is 1.25x global while their input and cache are 1.1x. A handful of xAI and Kimi
-data-zone meters in individual European regions run far higher still.
-
-Non-commercial data zones are not modeled and run higher — the Asia-Pacific
-data zone is ~1.2x and the US Government sovereign cloud is ~1.375x. Use
-``register_pricing()`` for any of these.
+US and EU Data Zone prices are identical, and the ratio holds for input, output
+and cache on nearly every model — Kimi-K2.6 and Kimi-K2.7-Code are the exception,
+billing output at 1.25x global. Non-commercial data zones are not modeled and run
+higher: the Asia-Pacific data zone is ~1.2x and the US Government sovereign cloud
+is ~1.375x. Use ``register_pricing()`` for any of these.
 """
 
 REGIONAL_MULTIPLIER = 1.1
 """Regional deployments are approximately 1.1x global pricing.
 
-Note: actual regional pricing varies by *region*, not by model, and is
-consistent within a region — US regions are 1.1x, most of EU/UK/CH/JP is
-1.21x, North/West Europe and Southeast Asia are 1.32x, and US Gov is 1.375x.
-This constant uses the US multiplier; for exact rates elsewhere, use
-``register_pricing()`` to override individual models.
+The regional rate varies by region rather than by model: US regions are 1.1x,
+most of EU/UK/CH/JP is 1.21x, North/West Europe and Southeast Asia are 1.32x,
+and US Gov is 1.375x. This constant uses the US multiplier; use
+``register_pricing()`` for exact rates elsewhere.
 """
 
 # MARK: Global Standard pricing (base rates)
@@ -845,12 +841,6 @@ _PRICING_BY_PREFIX = build_pricing_index(_PRICING)
 # variants). Returning None is correct — do NOT let them fall through to a broad prefix
 # (e.g. "grok-4") and inherit a fabricated rate. Add real rates once Azure publishes meters.
 _UNPRICED_MODELS = frozenset({"grok-4-20-reasoning", "grok-4-20-non-reasoning"})
-
-# The Fireworks-hosted models (FW-GLM-5/5.1/5.2, FW-MiniMax-M2.5, FW-MiniMax-3) are
-# likewise absent here: Azure meters them on Data Zone only, and every rate in this
-# table is a Global Standard base that DATA_ZONE_MULTIPLIER is applied on top of.
-# Storing a data-zone rate as the base would bill data-zone calls at 1.1x the true
-# price, so they stay unpriced until Azure publishes Global Standard meters.
 
 
 def calculate_azure_foundry_cost(model: str, usage: Usage) -> Cost | None:

--- a/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
+++ b/packages/lmux-azure-foundry/src/lmux_azure_foundry/cost.py
@@ -27,17 +27,23 @@ from lmux.types import Cost, Usage
 DATA_ZONE_MULTIPLIER = 1.1
 """Commercial US/EU Data Zone Standard deployments are 1.1x global pricing.
 
-This holds uniformly across input, output, and cache for every model, and the
-US and EU Data Zone prices are identical. Non-commercial data zones are not
-modeled and run higher — the Asia-Pacific data zone is ~1.2x and the US
-Government sovereign cloud is ~1.375x; use ``register_pricing()`` for those.
+US and EU Data Zone prices are identical. The ratio holds for input, output and
+cache on nearly every model, but not all: Kimi-K2.6 and Kimi-K2.7-Code output
+is 1.25x global while their input and cache are 1.1x. A handful of xAI and Kimi
+data-zone meters in individual European regions run far higher still.
+
+Non-commercial data zones are not modeled and run higher — the Asia-Pacific
+data zone is ~1.2x and the US Government sovereign cloud is ~1.375x. Use
+``register_pricing()`` for any of these.
 """
 
 REGIONAL_MULTIPLIER = 1.1
 """Regional deployments are approximately 1.1x global pricing.
 
-Note: actual regional pricing varies by model (1.1x-1.375x).  This constant
-uses the most common multiplier; for exact per-model regional rates, use
+Note: actual regional pricing varies by *region*, not by model, and is
+consistent within a region — US regions are 1.1x, most of EU/UK/CH/JP is
+1.21x, North/West Europe and Southeast Asia are 1.32x, and US Gov is 1.375x.
+This constant uses the US multiplier; for exact rates elsewhere, use
 ``register_pricing()`` to override individual models.
 """
 
@@ -389,6 +395,16 @@ _PRICING: dict[str, ModelPricing] = {
                 input_cost_per_token=per_million_tokens(2.50),
                 output_cost_per_token=per_million_tokens(10.00),
                 cache_read_cost_per_token=per_million_tokens(1.25),
+            )
+        ],
+    ),
+    # The 2024-05-13 snapshot is priced higher than the current gpt-4o (5/15 vs 2.50/10) and
+    # has no cached-input rate; an explicit key stops it inheriting the cheaper gpt-4o prefix.
+    "gpt-4o-2024-05-13": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(5.00),
+                output_cost_per_token=per_million_tokens(15.00),
             )
         ],
     ),
@@ -829,6 +845,12 @@ _PRICING_BY_PREFIX = build_pricing_index(_PRICING)
 # variants). Returning None is correct — do NOT let them fall through to a broad prefix
 # (e.g. "grok-4") and inherit a fabricated rate. Add real rates once Azure publishes meters.
 _UNPRICED_MODELS = frozenset({"grok-4-20-reasoning", "grok-4-20-non-reasoning"})
+
+# The Fireworks-hosted models (FW-GLM-5/5.1/5.2, FW-MiniMax-M2.5, FW-MiniMax-3) are
+# likewise absent here: Azure meters them on Data Zone only, and every rate in this
+# table is a Global Standard base that DATA_ZONE_MULTIPLIER is applied on top of.
+# Storing a data-zone rate as the base would bill data-zone calls at 1.1x the true
+# price, so they stay unpriced until Azure publishes Global Standard meters.
 
 
 def calculate_azure_foundry_cost(model: str, usage: Usage) -> Cost | None:

--- a/packages/lmux-azure-foundry/tests/test_cost.py
+++ b/packages/lmux-azure-foundry/tests/test_cost.py
@@ -57,6 +57,18 @@ class TestCalculateAzureFoundryCost:
         assert mini_cost is not None
         assert cost.total_cost == pytest.approx(mini_cost.total_cost)
 
+    def test_gpt_4o_2024_05_13_has_dedicated_pricing(self) -> None:
+        """Azure prices the 05-13 snapshot at 5/15 with no cached-input rate, unlike the gpt-4o base."""
+        usage = Usage(input_tokens=1000, output_tokens=500, cache_read_tokens=200)
+        cost = calculate_azure_foundry_cost("gpt-4o-2024-05-13", usage)
+        assert cost is not None
+        assert cost.input_cost == pytest.approx((1000 - 200) * 5.00 / 1_000_000)
+        assert cost.output_cost == pytest.approx(500 * 15.00 / 1_000_000)
+        assert cost.cache_read_cost == pytest.approx(0.0)
+        base = calculate_azure_foundry_cost("gpt-4o", usage)
+        assert base is not None
+        assert cost.total_cost > base.total_cost
+
     def test_gpt5_model(self) -> None:
         usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000)
         cost = calculate_azure_foundry_cost("gpt-5", usage)

--- a/packages/lmux-bedrock-shared/pyproject.toml
+++ b/packages/lmux-bedrock-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-bedrock-shared"
-version = "0.3.0"
+version = "0.3.1"
 description = "Shared AWS Bedrock internals (SigV4 signing, event-stream decoding, Anthropic pricing) for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-bedrock-shared/src/lmux_bedrock_shared/pricing.py
+++ b/packages/lmux-bedrock-shared/src/lmux_bedrock_shared/pricing.py
@@ -1055,6 +1055,17 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
                 ),
             ],
         ),
+        "anthropic.claude-opus-5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(6.0),
+                    output_cost_per_token=per_million_tokens(30.0),
+                    cache_read_cost_per_token=per_million_tokens(0.6),
+                    cache_creation_cost_per_token=per_million_tokens(7.5),
+                    cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(12.0)},
+                ),
+            ],
+        ),
         "anthropic.claude-sonnet-4-5-20250929-v1": ModelPricing(
             tiers=[
                 PricingTier(
@@ -1063,6 +1074,31 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
                     cache_read_cost_per_token=per_million_tokens(0.36),
                     cache_creation_cost_per_token=per_million_tokens(4.5),
                     cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(7.2)},
+                ),
+            ],
+        ),
+        "anthropic.claude-sonnet-5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(2.4),
+                    output_cost_per_token=per_million_tokens(12.0),
+                    cache_read_cost_per_token=per_million_tokens(0.24),
+                    cache_creation_cost_per_token=per_million_tokens(3.0),
+                    cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(4.8)},
+                ),
+            ],
+            schedules=[
+                PricingSchedule(
+                    valid_from=date(2026, 9, 1),
+                    tiers=[
+                        PricingTier(
+                            input_cost_per_token=per_million_tokens(3.6),
+                            output_cost_per_token=per_million_tokens(18.0),
+                            cache_read_cost_per_token=per_million_tokens(0.36),
+                            cache_creation_cost_per_token=per_million_tokens(4.5),
+                            cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(7.2)},
+                        ),
+                    ],
                 ),
             ],
         ),
@@ -1105,6 +1141,17 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
                 ),
             ],
         ),
+        "anthropic.claude-opus-5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(6.0),
+                    output_cost_per_token=per_million_tokens(30.0),
+                    cache_read_cost_per_token=per_million_tokens(0.6),
+                    cache_creation_cost_per_token=per_million_tokens(7.5),
+                    cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(12.0)},
+                ),
+            ],
+        ),
         "anthropic.claude-sonnet-4-5-20250929-v1": ModelPricing(
             tiers=[
                 PricingTier(
@@ -1113,6 +1160,31 @@ ANTHROPIC_REGIONAL_PRICING: dict[str, dict[str, ModelPricing]] = {
                     cache_read_cost_per_token=per_million_tokens(0.36),
                     cache_creation_cost_per_token=per_million_tokens(4.5),
                     cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(7.2)},
+                ),
+            ],
+        ),
+        "anthropic.claude-sonnet-5": ModelPricing(
+            tiers=[
+                PricingTier(
+                    input_cost_per_token=per_million_tokens(2.4),
+                    output_cost_per_token=per_million_tokens(12.0),
+                    cache_read_cost_per_token=per_million_tokens(0.24),
+                    cache_creation_cost_per_token=per_million_tokens(3.0),
+                    cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(4.8)},
+                ),
+            ],
+            schedules=[
+                PricingSchedule(
+                    valid_from=date(2026, 9, 1),
+                    tiers=[
+                        PricingTier(
+                            input_cost_per_token=per_million_tokens(3.6),
+                            output_cost_per_token=per_million_tokens(18.0),
+                            cache_read_cost_per_token=per_million_tokens(0.36),
+                            cache_creation_cost_per_token=per_million_tokens(4.5),
+                            cache_creation_cost_per_token_by_ttl={"1h": per_million_tokens(7.2)},
+                        ),
+                    ],
                 ),
             ],
         ),

--- a/packages/lmux-google/README.md
+++ b/packages/lmux-google/README.md
@@ -112,14 +112,15 @@ response = provider.chat(
 )
 ```
 
-| Parameter           | Type                  | Description                      |
-| ------------------- | --------------------- | -------------------------------- |
-| `safety_settings`   | `list[SafetySetting]` | Content safety thresholds        |
-| `presence_penalty`  | `float`               | Presence penalty                 |
-| `frequency_penalty` | `float`               | Frequency penalty                |
-| `seed`              | `int`                 | Deterministic sampling seed      |
-| `labels`            | `dict[str, str]`      | Request labels                   |
-| `thinking_config`   | `dict`                | Thinking/reasoning configuration |
+| Parameter           | Type                  | Description                                                                                                     |
+| ------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `safety_settings`   | `list[SafetySetting]` | Content safety thresholds                                                                                        |
+| `presence_penalty`  | `float`               | Presence penalty                                                                                                 |
+| `frequency_penalty` | `float`               | Frequency penalty                                                                                                |
+| `seed`              | `int`                 | Deterministic sampling seed                                                                                      |
+| `labels`            | `dict[str, str]`      | Request labels                                                                                                   |
+| `thinking_config`   | `dict`                | Thinking/reasoning configuration                                                                                 |
+| `pricing_as_of`     | `datetime.date`       | Override the date used for dated pricing (e.g. a model's introductory-rate window); defaults to the current date |
 
 ## Constructor Options
 
@@ -139,3 +140,16 @@ GoogleProvider(
 
 `default_headers` is useful for gateway authentication, tracing, and routing. Google-managed authentication,
 quota-project, and content-type headers take precedence over caller values, case-insensitively.
+
+## Pricing
+
+Rates are Vertex global-endpoint list prices. Setting `location` to anything other than `global` puts the
+request on a non-global Vertex endpoint, which bills a 10% premium on the generally available Gemini 3 and
+later families; the provider applies that automatically via `VERTEX_NON_GLOBAL_MULTIPLIER`. Preview models,
+embeddings, and pre-Gemini-3 families are billed uniformly across endpoints, and the Gemini Developer API
+(`vertexai=False`) has no endpoint premium.
+
+Models with time-boxed introductory rates carry dated schedules, so cost reflects the rate in effect on the
+request date. Pass `GoogleParams(pricing_as_of=...)` to price against a different date. The endpoint premium
+is dated too — it starts at `VERTEX_NON_GLOBAL_PREMIUM_START` (2026-07-01), so costs replayed against an
+earlier date take no multiplier.

--- a/packages/lmux-google/README.md
+++ b/packages/lmux-google/README.md
@@ -144,10 +144,10 @@ quota-project, and content-type headers take precedence over caller values, case
 ## Pricing
 
 Rates are Vertex global-endpoint list prices. Setting `location` to anything other than `global` puts the
-request on a non-global Vertex endpoint, which bills a 10% premium on the generally available Gemini 3 and
-later families; the provider applies that automatically via `VERTEX_NON_GLOBAL_MULTIPLIER`. Preview models,
-embeddings, and pre-Gemini-3 families are billed uniformly across endpoints, and the Gemini Developer API
-(`vertexai=False`) has no endpoint premium.
+request on a non-global Vertex endpoint, which bills a 10% premium on the models Vertex publishes a
+non-global rate for; the provider applies that automatically via `VERTEX_NON_GLOBAL_MULTIPLIER`. Every other
+model bills list price on both endpoints, and the Gemini Developer API (`vertexai=False`) has no endpoint
+premium at all.
 
 Models with time-boxed introductory rates carry dated schedules, so cost reflects the rate in effect on the
 request date. Pass `GoogleParams(pricing_as_of=...)` to price against a different date. The endpoint premium

--- a/packages/lmux-google/pyproject.toml
+++ b/packages/lmux-google/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-google"
-version = "0.11.0"
+version = "0.12.0"
 description = "Google (Gemini) provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-google/src/lmux_google/cost.py
+++ b/packages/lmux-google/src/lmux_google/cost.py
@@ -340,7 +340,7 @@ _UNPRICED_IMAGE_PREFIXES = (
 VERTEX_NON_GLOBAL_MULTIPLIER = 1.1
 """Non-global Vertex endpoints bill 1.1x the global rate, from VERTEX_NON_GLOBAL_PREMIUM_START.
 
-Applies to the generally available Gemini 3 and later families only. The Gemini
+Applies only to the models Vertex publishes a Non-global row for; the Gemini
 Developer API has no equivalent premium.
 """
 
@@ -351,17 +351,15 @@ Before this date, global-endpoint pricing applied to every Vertex endpoint, so
 costs replayed against an earlier date take no multiplier.
 """
 
-# GA Gemini 3+ families carry the non-global premium. Add new GA families here as
-# they are priced; preview ids and every pre-Gemini-3 family are billed uniformly
-# across endpoints.
+# Models the Vertex pricing page lists a "Non-global" row for. Membership is read
+# off that page rather than inferred from a model being GA: Gemini 3.6 and 3.7
+# Flash are GA and publish no Non-global rate, so they bill list price everywhere.
 _VERTEX_PREMIUM_PRICING_MODELS = (
-    "gemini-3.7-flash",
-    "gemini-3.6-flash",
     "gemini-3.5-flash",
     "gemini-3.5-flash-lite",
     "gemini-3.1-flash-lite",
 )
-# Preview ids that would otherwise be captured by a GA prefix above.
+# Has no Non-global row of its own, but would inherit one by prefix.
 _VERTEX_UNIFORM_PRICING_MODELS = ("gemini-3.1-flash-lite-preview",)
 # Sorted by prefix length descending so the longest match wins — needed to tell
 # e.g. gemini-3.1-flash-lite-preview (uniform) from gemini-3.1-flash-lite (premium).
@@ -376,9 +374,8 @@ _VERTEX_PREMIUM_BY_PREFIX = sorted(
 def has_vertex_non_global_premium(model: str) -> bool:
     """Whether the model carries the 10% premium on non-global Vertex endpoints.
 
-    Unknown models default to False. The premium is scoped to the GA Gemini 3 and
-    later chat families, while the catalog also carries preview, embedding, and
-    older families that are billed uniformly across endpoints.
+    Unknown models default to False, so a model Vertex has not published a
+    Non-global rate for bills at list price rather than an inferred premium.
     """
     model_lower = model.lower()
     for prefix, premium in _VERTEX_PREMIUM_BY_PREFIX:

--- a/packages/lmux-google/src/lmux_google/cost.py
+++ b/packages/lmux-google/src/lmux_google/cost.py
@@ -28,8 +28,6 @@ from lmux.types import Cost, Usage
 
 _PRICING: dict[str, ModelPricing] = {
     # ── Google Gemini 3 ────────────────────────────────────────
-    # Gemini 3.6 Flash and 3.7 Flash both bill an introductory rate through
-    # 2026-12-31, then double on 2027-01-01.
     "gemini-3.7-flash": ModelPricing(
         tiers=[
             PricingTier(

--- a/packages/lmux-google/src/lmux_google/cost.py
+++ b/packages/lmux-google/src/lmux_google/cost.py
@@ -4,11 +4,20 @@ Prices are for standard on-demand (global endpoint) Vertex AI pricing. The
 Gemini Developer API paid tier matches these rates for Gemini 2.5 and later,
 but diverges on Gemini 2.0: the Developer API bills 2.0 Flash at 0.10/0.40
 against Vertex's 0.15/0.60. The Vertex rates are the ones stored here.
+
+These are global-endpoint rates. Non-global Vertex endpoints carry a 10%
+premium on the GA Gemini 3 and later families, in effect since 2026-07-01;
+GoogleProvider applies it on top of these rates via
+VERTEX_NON_GLOBAL_MULTIPLIER when a location other than "global" is set.
+
 Pricing source: https://cloud.google.com/vertex-ai/generative-ai/pricing
 """
 
+from datetime import date
+
 from lmux.cost import (
     ModelPricing,
+    PricingSchedule,
     PricingTier,
     build_pricing_index,
     calculate_cost,
@@ -19,12 +28,47 @@ from lmux.types import Cost, Usage
 
 _PRICING: dict[str, ModelPricing] = {
     # ── Google Gemini 3 ────────────────────────────────────────
+    # Gemini 3.6 Flash and 3.7 Flash both bill an introductory rate through
+    # 2026-12-31, then double on 2027-01-01.
+    "gemini-3.7-flash": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.75),
+                output_cost_per_token=per_million_tokens(3.75),
+                cache_read_cost_per_token=per_million_tokens(0.075),
+            ),
+        ],
+        schedules=[
+            PricingSchedule(
+                valid_from=date(2027, 1, 1),
+                tiers=[
+                    PricingTier(
+                        input_cost_per_token=per_million_tokens(1.50),
+                        output_cost_per_token=per_million_tokens(7.50),
+                        cache_read_cost_per_token=per_million_tokens(0.15),
+                    ),
+                ],
+            ),
+        ],
+    ),
     "gemini-3.6-flash": ModelPricing(
         tiers=[
             PricingTier(
-                input_cost_per_token=per_million_tokens(1.5),
-                output_cost_per_token=per_million_tokens(7.5),
-                cache_read_cost_per_token=per_million_tokens(0.15),
+                input_cost_per_token=per_million_tokens(0.75),
+                output_cost_per_token=per_million_tokens(3.75),
+                cache_read_cost_per_token=per_million_tokens(0.075),
+            ),
+        ],
+        schedules=[
+            PricingSchedule(
+                valid_from=date(2027, 1, 1),
+                tiers=[
+                    PricingTier(
+                        input_cost_per_token=per_million_tokens(1.50),
+                        output_cost_per_token=per_million_tokens(7.50),
+                        cache_read_cost_per_token=per_million_tokens(0.15),
+                    ),
+                ],
             ),
         ],
     ),
@@ -293,13 +337,80 @@ _UNPRICED_IMAGE_PREFIXES = (
     "gemini-3-pro-image",
 )
 
+# MARK: Vertex endpoint premium
 
-def calculate_google_cost(model: str, usage: Usage) -> Cost | None:
-    """Calculate cost for a Google API call. Returns None if model pricing is unknown."""
+VERTEX_NON_GLOBAL_MULTIPLIER = 1.1
+"""Non-global Vertex endpoints bill 1.1x the global rate, from VERTEX_NON_GLOBAL_PREMIUM_START.
+
+Applies to the generally available Gemini 3 and later families only. The Gemini
+Developer API has no equivalent premium.
+"""
+
+VERTEX_NON_GLOBAL_PREMIUM_START = date(2026, 7, 1)
+"""First day the non-global Vertex premium is billed.
+
+Before this date, global-endpoint pricing applied to every Vertex endpoint, so
+costs replayed against an earlier date take no multiplier.
+"""
+
+# GA Gemini 3+ families carry the non-global premium. Add new GA families here as
+# they are priced; preview ids and every pre-Gemini-3 family are billed uniformly
+# across endpoints.
+_VERTEX_PREMIUM_PRICING_MODELS = (
+    "gemini-3.7-flash",
+    "gemini-3.6-flash",
+    "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.1-flash-lite",
+)
+# Preview ids that would otherwise be captured by a GA prefix above.
+_VERTEX_UNIFORM_PRICING_MODELS = ("gemini-3.1-flash-lite-preview",)
+# Sorted by prefix length descending so the longest match wins — needed to tell
+# e.g. gemini-3.1-flash-lite-preview (uniform) from gemini-3.1-flash-lite (premium).
+_VERTEX_PREMIUM_BY_PREFIX = sorted(
+    [(prefix, True) for prefix in _VERTEX_PREMIUM_PRICING_MODELS]
+    + [(prefix, False) for prefix in _VERTEX_UNIFORM_PRICING_MODELS],
+    key=lambda item: len(item[0]),
+    reverse=True,
+)
+
+
+def has_vertex_non_global_premium(model: str) -> bool:
+    """Whether the model carries the 10% premium on non-global Vertex endpoints.
+
+    Unknown models default to False. The premium is scoped to the GA Gemini 3 and
+    later chat families, while the catalog also carries preview, embedding, and
+    older families that are billed uniformly across endpoints.
+    """
+    model_lower = model.lower()
+    for prefix, premium in _VERTEX_PREMIUM_BY_PREFIX:
+        if model_lower.startswith(prefix):
+            return premium
+    return False
+
+
+def apply_cost_multiplier(cost: Cost, multiplier: float) -> Cost:
+    """Apply a multiplier to all fields in a cost breakdown."""
+    return Cost(
+        input_cost=cost.input_cost * multiplier,
+        output_cost=cost.output_cost * multiplier,
+        total_cost=cost.total_cost * multiplier,
+        cache_read_cost=cost.cache_read_cost * multiplier if cost.cache_read_cost is not None else None,
+        cache_creation_cost=cost.cache_creation_cost * multiplier if cost.cache_creation_cost is not None else None,
+    )
+
+
+def calculate_google_cost(model: str, usage: Usage, as_of: date | None = None) -> Cost | None:
+    """Calculate cost for a Google API call. Returns None if model pricing is unknown.
+
+    ``as_of`` selects dated pricing for models with scheduled rate changes
+    (e.g. the Gemini Flash introductory windows); it defaults to the latest
+    schedule. See ``lmux.cost.calculate_cost``.
+    """
     model_lower = model.lower()
     if any(model_lower.startswith(prefix) for prefix in _UNPRICED_IMAGE_PREFIXES):
         return None
     pricing = resolve_pricing(model, _PRICING_BY_PREFIX)
     if pricing is None:
         return None
-    return calculate_cost(usage, pricing)
+    return calculate_cost(usage, pricing, as_of)

--- a/packages/lmux-google/src/lmux_google/params.py
+++ b/packages/lmux-google/src/lmux_google/params.py
@@ -1,5 +1,6 @@
 """Google provider-specific parameters."""
 
+from datetime import date
 from typing import Any, Literal
 
 from pydantic import BaseModel
@@ -54,3 +55,6 @@ class GoogleParams(BaseProviderParams):
     google_search_retrieval: GoogleSearchRetrievalConfig | None = None
     code_execution: bool | None = None
     task_type: str | None = None
+    # Override the date used to resolve dated pricing (e.g. a model's
+    # introductory-rate window); defaults to the current date when unset.
+    pricing_as_of: date | None = None

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -2,7 +2,8 @@
 
 import asyncio
 import json
-from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
+from datetime import date
 from typing import TYPE_CHECKING, Literal, override
 
 if TYPE_CHECKING:
@@ -61,7 +62,13 @@ from lmux_google._wire import (
     WireVertexPredictResponse,
 )
 from lmux_google.auth import GoogleADCAuthProvider
-from lmux_google.cost import calculate_google_cost
+from lmux_google.cost import (
+    VERTEX_NON_GLOBAL_MULTIPLIER,
+    VERTEX_NON_GLOBAL_PREMIUM_START,
+    apply_cost_multiplier,
+    calculate_google_cost,
+    has_vertex_non_global_premium,
+)
 from lmux_google.params import GoogleParams, GoogleSearchConfig
 
 type GoogleAuth = AuthProvider["Credentials | str", "Credentials | str"]
@@ -70,6 +77,11 @@ PROVIDER_NAME = "google"
 
 _HTTP_ERROR = 400
 _THINKING_BUDGETS: dict[str, int] = {"low": 1024, "medium": 8192, "high": 32768}
+
+
+def _today() -> date:
+    """Return today's date, indirected so tests can pin the pricing clock."""
+    return date.today()
 
 
 class GoogleProvider(
@@ -113,11 +125,50 @@ class GoogleProvider(
     def register_pricing(self, model: str, pricing: ModelPricing) -> None:
         self._custom_pricing[model] = pricing
 
-    def _calculate_cost(self, model: str, usage: Usage) -> Cost | None:
+    @staticmethod
+    def _resolve_pricing_as_of(provider_params: GoogleParams | None) -> date:
+        """Effective pricing date: an explicit ``pricing_as_of`` override, else today."""
+        if provider_params is not None and provider_params.pricing_as_of is not None:
+            return provider_params.pricing_as_of
+        return _today()
+
+    def _vertex_multiplier(self, model: str, as_of: date | None) -> float:
+        """Non-global Vertex endpoints bill a 10% premium on GA Gemini 3+ models.
+
+        The global endpoint (the default when no location is set) bills list
+        prices, and the Gemini Developer API has no endpoint premium at all.
+        The premium only exists from ``VERTEX_NON_GLOBAL_PREMIUM_START``, so a
+        cost replayed against an earlier date takes no multiplier; ``as_of`` of
+        ``None`` means current pricing.
+        """
+        if not self._vertexai or (self._location or "global") == "global":
+            return 1.0
+        if as_of is not None and as_of < VERTEX_NON_GLOBAL_PREMIUM_START:
+            return 1.0
+        if has_vertex_non_global_premium(model):
+            return VERTEX_NON_GLOBAL_MULTIPLIER
+        return 1.0
+
+    def _calculate_cost(self, model: str, usage: Usage, as_of: date | None = None) -> Cost | None:
         pricing = self._custom_pricing.get(model)
         if pricing is not None:
-            return calculate_cost(usage, pricing)
-        return calculate_google_cost(model, usage)
+            cost = calculate_cost(usage, pricing, as_of)
+        else:
+            cost = calculate_google_cost(model, usage, as_of)
+        if cost is None:
+            return None
+        multiplier = self._vertex_multiplier(model, as_of)
+        if multiplier == 1.0:
+            return cost
+        return apply_cost_multiplier(cost, multiplier)
+
+    def _cost_fn_for(self, as_of: date) -> "Callable[[str, Usage], Cost | None]":
+        """A cost callable pinned to a pricing date, for the response mappers."""
+        return lambda model, usage: self._calculate_cost(model, usage, as_of)
+
+    def _cost_fn(self, provider_params: GoogleParams | None) -> "Callable[[str, Usage], Cost | None]":
+        """A cost callable pinned to this request's pricing date, for the response mappers."""
+        return self._cost_fn_for(self._resolve_pricing_as_of(provider_params))
 
     # MARK: Client Management
 
@@ -224,7 +275,7 @@ class GoogleProvider(
             parse_body(response, WireGenerateContentResponse),
             model,
             PROVIDER_NAME,
-            self._calculate_cost,
+            self._cost_fn(provider_params),
             vertexai=self._vertexai,
         )
 
@@ -260,7 +311,7 @@ class GoogleProvider(
             parse_body(response, WireGenerateContentResponse),
             model,
             PROVIDER_NAME,
-            self._calculate_cost,
+            self._cost_fn(provider_params),
             vertexai=self._vertexai,
         )
 
@@ -291,6 +342,7 @@ class GoogleProvider(
             headers = self._request_headers()
         except Exception as e:
             raise map_transport_error(e) from e
+        as_of = self._resolve_pricing_as_of(provider_params)
         try:
             continuation_state = GoogleContinuationState(vertexai=self._vertexai)
             with client.stream("POST", path, json=body, headers=headers) as response:
@@ -303,7 +355,7 @@ class GoogleProvider(
                         raise error_from_stream(chunk)  # noqa: TRY301
                     wire = WireGenerateContentResponse.model_validate(chunk)
                     part_offset = continuation_state.add(wire)
-                    mapped = self._map_stream_chunk(wire, model, part_offset=part_offset)
+                    mapped = self._map_stream_chunk(wire, model, as_of, part_offset=part_offset)
                     if mapped.finish_reason is not None:
                         mapped = mapped.model_copy(update={"continuation": continuation_state.continuation()})
                     yield mapped
@@ -339,6 +391,7 @@ class GoogleProvider(
             headers = await self._arequest_headers()
         except Exception as e:
             raise map_transport_error(e) from e
+        as_of = self._resolve_pricing_as_of(provider_params)
         try:
             continuation_state = GoogleContinuationState(vertexai=self._vertexai)
             async with client.stream("POST", path, json=body, headers=headers) as response:
@@ -351,7 +404,7 @@ class GoogleProvider(
                         raise error_from_stream(chunk)  # noqa: TRY301
                     wire = WireGenerateContentResponse.model_validate(chunk)
                     part_offset = continuation_state.add(wire)
-                    mapped = self._map_stream_chunk(wire, model, part_offset=part_offset)
+                    mapped = self._map_stream_chunk(wire, model, as_of, part_offset=part_offset)
                     if mapped.finish_reason is not None:
                         mapped = mapped.model_copy(update={"continuation": continuation_state.continuation()})
                     yield mapped
@@ -371,8 +424,9 @@ class GoogleProvider(
         dimensions: int | None = None,
         provider_params: GoogleParams | None = None,
     ) -> EmbeddingResponse:
+        as_of = self._resolve_pricing_as_of(provider_params)
         if self._vertexai and _uses_embed_content(model):
-            return self._embed_content(model, input, dimensions)
+            return self._embed_content(model, input, dimensions, as_of)
         texts = input if isinstance(input, list) else [input]
         embeddings: list[list[float]] = []
         input_tokens = 0
@@ -382,14 +436,14 @@ class GoogleProvider(
                 path, body = self._embed_path_and_body(model, chunk, dimensions, provider_params)
                 response = client.post(path, json=body, headers=self._request_headers())
                 raise_for_status(response)
-                result = self._map_embed_response(response, model)
+                result = self._map_embed_response(response, model, as_of)
                 embeddings.extend(result.embeddings)
                 input_tokens += result.usage.input_tokens
         except LmuxError:
             raise
         except Exception as e:
             raise map_transport_error(e) from e
-        return self._embedding_response(model, embeddings, input_tokens)
+        return self._embedding_response(model, embeddings, input_tokens, as_of)
 
     @override
     async def aembed(
@@ -400,8 +454,9 @@ class GoogleProvider(
         dimensions: int | None = None,
         provider_params: GoogleParams | None = None,
     ) -> EmbeddingResponse:
+        as_of = self._resolve_pricing_as_of(provider_params)
         if self._vertexai and _uses_embed_content(model):
-            return await self._aembed_content(model, input, dimensions)
+            return await self._aembed_content(model, input, dimensions, as_of)
         texts = input if isinstance(input, list) else [input]
         embeddings: list[list[float]] = []
         input_tokens = 0
@@ -411,16 +466,22 @@ class GoogleProvider(
                 path, body = self._embed_path_and_body(model, chunk, dimensions, provider_params)
                 response = await client.post(path, json=body, headers=await self._arequest_headers())
                 raise_for_status(response)
-                result = self._map_embed_response(response, model)
+                result = self._map_embed_response(response, model, as_of)
                 embeddings.extend(result.embeddings)
                 input_tokens += result.usage.input_tokens
         except LmuxError:
             raise
         except Exception as e:
             raise map_transport_error(e) from e
-        return self._embedding_response(model, embeddings, input_tokens)
+        return self._embedding_response(model, embeddings, input_tokens, as_of)
 
-    def _embed_content(self, model: str, input: str | list[str], dimensions: int | None) -> EmbeddingResponse:  # noqa: A002
+    def _embed_content(
+        self,
+        model: str,
+        input: str | list[str],  # noqa: A002
+        dimensions: int | None,
+        as_of: date,
+    ) -> EmbeddingResponse:
         # Vertex serves Gemini Embedding 2 models only through :embedContent, which takes a single
         # content per request (no batch) and rejects task_type — so a list is issued one item at a time.
         texts = input if isinstance(input, list) else [input]
@@ -440,9 +501,15 @@ class GoogleProvider(
             raise
         except Exception as e:
             raise map_transport_error(e) from e
-        return self._embedding_response(model, embeddings, input_tokens)
+        return self._embedding_response(model, embeddings, input_tokens, as_of)
 
-    async def _aembed_content(self, model: str, input: str | list[str], dimensions: int | None) -> EmbeddingResponse:  # noqa: A002
+    async def _aembed_content(
+        self,
+        model: str,
+        input: str | list[str],  # noqa: A002
+        dimensions: int | None,
+        as_of: date,
+    ) -> EmbeddingResponse:
         texts = input if isinstance(input, list) else [input]
         path = self._path(model, "embedContent")
         embeddings: list[list[float]] = []
@@ -460,14 +527,16 @@ class GoogleProvider(
             raise
         except Exception as e:
             raise map_transport_error(e) from e
-        return self._embedding_response(model, embeddings, input_tokens)
+        return self._embedding_response(model, embeddings, input_tokens, as_of)
 
-    def _embedding_response(self, model: str, embeddings: list[list[float]], input_tokens: int) -> EmbeddingResponse:
+    def _embedding_response(
+        self, model: str, embeddings: list[list[float]], input_tokens: int, as_of: date
+    ) -> EmbeddingResponse:
         usage = Usage(input_tokens=input_tokens, output_tokens=0)
         return EmbeddingResponse(
             embeddings=embeddings,
             usage=usage,
-            cost=self._calculate_cost(model, usage),
+            cost=self._calculate_cost(model, usage, as_of),
             model=model,
             provider=PROVIDER_NAME,
         )
@@ -487,10 +556,12 @@ class GoogleProvider(
 
     # MARK: Internal Helpers
 
-    def _map_stream_chunk(self, chunk: WireGenerateContentResponse, model: str, *, part_offset: int = 0) -> ChatChunk:
+    def _map_stream_chunk(
+        self, chunk: WireGenerateContentResponse, model: str, as_of: date, *, part_offset: int = 0
+    ) -> ChatChunk:
         mapped = map_generate_content_chunk(chunk, model, PROVIDER_NAME, part_offset=part_offset)
         if mapped.usage is not None:
-            mapped = mapped.model_copy(update={"cost": self._calculate_cost(model, mapped.usage)})
+            mapped = mapped.model_copy(update={"cost": self._calculate_cost(model, mapped.usage, as_of)})
         return mapped
 
     def _embed_path_and_body(
@@ -507,13 +578,14 @@ class GoogleProvider(
         body = self._build_embed_body(model, input, dimensions, provider_params)
         return self._path(model, "batchEmbedContents"), body
 
-    def _map_embed_response(self, response: "httpx.Response", model: str) -> EmbeddingResponse:
+    def _map_embed_response(self, response: "httpx.Response", model: str, as_of: date) -> EmbeddingResponse:
+        cost_fn = self._cost_fn_for(as_of)
         if self._vertexai:
             return map_vertex_embed_response(
-                parse_body(response, WireVertexPredictResponse), model, PROVIDER_NAME, self._calculate_cost
+                parse_body(response, WireVertexPredictResponse), model, PROVIDER_NAME, cost_fn
             )
         return map_batch_embeddings_response(
-            parse_body(response, WireBatchEmbeddingsResponse), model, PROVIDER_NAME, self._calculate_cost
+            parse_body(response, WireBatchEmbeddingsResponse), model, PROVIDER_NAME, cost_fn
         )
 
     @staticmethod

--- a/packages/lmux-google/tests/test_cost.py
+++ b/packages/lmux-google/tests/test_cost.py
@@ -228,17 +228,15 @@ class TestCalculateGoogleCost:
 class TestHasVertexNonGlobalPremium:
     @pytest.mark.parametrize(
         "model",
-        [
-            "gemini-3.7-flash",
-            "gemini-3.6-flash",
-            "gemini-3.5-flash",
-            "gemini-3.5-flash-lite",
-            "gemini-3.1-flash-lite",
-            "gemini-3.5-flash-002",
-        ],
+        ["gemini-3.5-flash", "gemini-3.5-flash-lite", "gemini-3.1-flash-lite", "gemini-3.5-flash-002"],
     )
-    def test_ga_gemini_3_families_carry_the_premium(self, model: str) -> None:
+    def test_models_with_a_published_non_global_rate(self, model: str) -> None:
         assert has_vertex_non_global_premium(model) is True
+
+    @pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.7-flash"])
+    def test_ga_models_without_a_published_non_global_rate(self, model: str) -> None:
+        """Being GA is not the test: Vertex publishes no Non-global row for these two."""
+        assert has_vertex_non_global_premium(model) is False
 
     def test_preview_id_is_exempt_despite_matching_a_ga_prefix(self) -> None:
         """Longest-prefix wins: the -preview id must not inherit its GA sibling's premium."""

--- a/packages/lmux-google/tests/test_cost.py
+++ b/packages/lmux-google/tests/test_cost.py
@@ -1,9 +1,11 @@
 """Tests for Google cost calculation."""
 
+from datetime import date
+
 import pytest
 
-from lmux.types import Usage
-from lmux_google.cost import calculate_google_cost
+from lmux.types import Cost, Usage
+from lmux_google.cost import apply_cost_multiplier, calculate_google_cost, has_vertex_non_global_premium
 
 
 class TestCalculateGoogleCost:
@@ -190,9 +192,21 @@ class TestCalculateGoogleCost:
         assert cost.output_cost == pytest.approx(2.50)
         assert cost.cache_read_cost == pytest.approx(0.03)
 
-    def test_gemini_3_6_flash(self) -> None:
+    @pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.7-flash"])
+    def test_gemini_3_flash_introductory_pricing(self, model: str) -> None:
+        """Through 2026-12-31 both Flash models bill the introductory rate."""
         usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000, cache_read_tokens=100_000)
-        cost = calculate_google_cost("gemini-3.6-flash", usage)
+        cost = calculate_google_cost(model, usage, as_of=date(2026, 8, 16))
+        assert cost is not None
+        assert cost.input_cost == pytest.approx((1_000_000 - 100_000) * 0.75 / 1_000_000)
+        assert cost.output_cost == pytest.approx(3.75)
+        assert cost.cache_read_cost == pytest.approx(100_000 * 0.075 / 1_000_000)
+
+    @pytest.mark.parametrize("model", ["gemini-3.6-flash", "gemini-3.7-flash"])
+    def test_gemini_3_flash_standard_pricing_from_2027(self, model: str) -> None:
+        """From 2027-01-01 the introductory window ends and every rate doubles."""
+        usage = Usage(input_tokens=1_000_000, output_tokens=1_000_000, cache_read_tokens=100_000)
+        cost = calculate_google_cost(model, usage, as_of=date(2027, 1, 1))
         assert cost is not None
         assert cost.input_cost == pytest.approx((1_000_000 - 100_000) * 1.50 / 1_000_000)
         assert cost.output_cost == pytest.approx(7.50)
@@ -209,3 +223,63 @@ class TestCalculateGoogleCost:
         assert cost is not None
         assert cost.cache_read_cost == pytest.approx(100_000 * rate / 1_000_000)
         assert cost.total_cost > 0.0
+
+
+class TestHasVertexNonGlobalPremium:
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini-3.7-flash",
+            "gemini-3.6-flash",
+            "gemini-3.5-flash",
+            "gemini-3.5-flash-lite",
+            "gemini-3.1-flash-lite",
+            "gemini-3.5-flash-002",
+        ],
+    )
+    def test_ga_gemini_3_families_carry_the_premium(self, model: str) -> None:
+        assert has_vertex_non_global_premium(model) is True
+
+    def test_preview_id_is_exempt_despite_matching_a_ga_prefix(self) -> None:
+        """Longest-prefix wins: the -preview id must not inherit its GA sibling's premium."""
+        assert has_vertex_non_global_premium("gemini-3.1-flash-lite-preview") is False
+        assert has_vertex_non_global_premium("gemini-3.1-flash-lite") is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini-2.5-pro",
+            "gemini-2.0-flash",
+            "gemini-1.5-pro",
+            "gemini-3.1-pro-preview",
+            "gemini-3-flash-preview",
+            "text-embedding-005",
+            "gemini-embedding-001",
+            "totally-unknown-model",
+        ],
+    )
+    def test_other_models_are_exempt(self, model: str) -> None:
+        assert has_vertex_non_global_premium(model) is False
+
+
+class TestApplyCostMultiplier:
+    def test_applies_multiplier_to_all_fields(self) -> None:
+        cost = Cost(
+            input_cost=1.0,
+            output_cost=2.0,
+            total_cost=3.0,
+            cache_read_cost=0.5,
+            cache_creation_cost=0.25,
+        )
+        result = apply_cost_multiplier(cost, 1.1)
+        assert result.input_cost == pytest.approx(1.1)
+        assert result.output_cost == pytest.approx(2.2)
+        assert result.total_cost == pytest.approx(3.3)
+        assert result.cache_read_cost == pytest.approx(0.55)
+        assert result.cache_creation_cost == pytest.approx(0.275)
+
+    def test_preserves_none_cache_costs(self) -> None:
+        cost = Cost(input_cost=1.0, output_cost=2.0, total_cost=3.0)
+        result = apply_cost_multiplier(cost, 2.0)
+        assert result.cache_read_cost is None
+        assert result.cache_creation_cost is None

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+from datetime import date
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 
@@ -13,7 +14,7 @@ from pytest_mock import MockerFixture
 if TYPE_CHECKING:
     from google.auth.credentials import Credentials
 
-from lmux.cost import ModelPricing, PricingTier
+from lmux.cost import ModelPricing, PricingSchedule, PricingTier
 from lmux.exceptions import AuthenticationError, InvalidRequestError, NotFoundError, ProviderError
 from lmux.types import (
     FunctionDefinition,
@@ -909,6 +910,233 @@ class TestRegisterPricing:
         _ok(respx_mock, _gen_response(), url=f"{_GEMINI}/{model}:generateContent")
         result = provider.chat(model, [UserMessage(content="Hi")])
         assert result.cost is None
+
+
+# MARK: Dated Pricing
+
+
+_FLASH = "gemini-3.6-flash"
+_FLASH_CHAT_URL = f"{_GEMINI}/{_FLASH}:generateContent"
+_FLASH_STREAM_URL = f"{_GEMINI}/{_FLASH}:streamGenerateContent"
+
+
+class TestPricingAsOf:
+    def test_intro_window_rate(
+        self, provider: GoogleProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("lmux_google.provider._today", lambda: date(2026, 8, 16))
+        _ok(respx_mock, _gen_response(prompt_tokens=1000, output_tokens=500), url=_FLASH_CHAT_URL)
+        result = provider.chat(_FLASH, [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 0.75 / 1_000_000)
+        assert result.cost.output_cost == pytest.approx(500 * 3.75 / 1_000_000)
+
+    def test_rate_after_switch(
+        self, provider: GoogleProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("lmux_google.provider._today", lambda: date(2027, 1, 15))
+        _ok(respx_mock, _gen_response(prompt_tokens=1000, output_tokens=500), url=_FLASH_CHAT_URL)
+        result = provider.chat(_FLASH, [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 1.50 / 1_000_000)
+
+    def test_override_wins_over_clock(
+        self, provider: GoogleProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("lmux_google.provider._today", lambda: date(2027, 1, 15))
+        _ok(respx_mock, _gen_response(prompt_tokens=1000, output_tokens=500), url=_FLASH_CHAT_URL)
+        result = provider.chat(
+            _FLASH,
+            [UserMessage(content="Hi")],
+            provider_params=GoogleParams(pricing_as_of=date(2026, 8, 16)),
+        )
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 0.75 / 1_000_000)
+
+    async def test_achat_applies_dated_pricing(
+        self, provider: GoogleProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("lmux_google.provider._today", lambda: date(2026, 8, 16))
+        _ok(respx_mock, _gen_response(prompt_tokens=1000, output_tokens=500), url=_FLASH_CHAT_URL)
+        result = await provider.achat(_FLASH, [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 0.75 / 1_000_000)
+
+    def test_chat_stream_applies_dated_pricing(
+        self, provider: GoogleProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("lmux_google.provider._today", lambda: date(2026, 8, 16))
+        respx_mock.post(_FLASH_STREAM_URL).mock(return_value=httpx.Response(200, content=_sse_stream()))
+        chunks = list(provider.chat_stream(_FLASH, [UserMessage(content="Hi")]))
+        final = chunks[-1]
+        assert final.cost is not None
+        assert final.cost.input_cost == pytest.approx(10 * 0.75 / 1_000_000)
+
+    async def test_achat_stream_applies_dated_pricing(
+        self, provider: GoogleProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("lmux_google.provider._today", lambda: date(2026, 8, 16))
+        respx_mock.post(_FLASH_STREAM_URL).mock(return_value=httpx.Response(200, content=_sse_stream()))
+        chunks = [chunk async for chunk in provider.achat_stream(_FLASH, [UserMessage(content="Hi")])]
+        final = chunks[-1]
+        assert final.cost is not None
+        assert final.cost.input_cost == pytest.approx(10 * 0.75 / 1_000_000)
+
+    def test_embed_honors_pricing_as_of_for_custom_dated_pricing(
+        self, provider: GoogleProvider, respx_mock: respx.MockRouter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """register_pricing can attach a dated schedule to an embedding model; the override must reach it."""
+        monkeypatch.setattr("lmux_google.provider._today", lambda: date(2027, 6, 1))
+        provider.register_pricing(
+            EMBED_MODEL,
+            ModelPricing(
+                tiers=[PricingTier(input_cost_per_token=1e-6, output_cost_per_token=0.0)],
+                schedules=[
+                    PricingSchedule(
+                        valid_from=date(2027, 1, 1),
+                        tiers=[PricingTier(input_cost_per_token=9e-6, output_cost_per_token=0.0)],
+                    )
+                ],
+            ),
+        )
+        respx_mock.post(_EMBED_URL).mock(
+            return_value=httpx.Response(
+                200, json={"embeddings": [{"values": [0.1]}], "usageMetadata": {"promptTokenCount": 100}}
+            )
+        )
+        later = provider.embed(EMBED_MODEL, "hello")
+        assert later.cost is not None
+        assert later.cost.input_cost == pytest.approx(100 * 9e-6)
+
+        earlier = provider.embed(EMBED_MODEL, "hello", provider_params=GoogleParams(pricing_as_of=date(2026, 8, 16)))
+        assert earlier.cost is not None
+        assert earlier.cost.input_cost == pytest.approx(100 * 1e-6)
+
+
+# MARK: Vertex Endpoint Premium
+
+
+class TestVertexNonGlobalPremium:
+    def test_non_global_location_applies_premium(self, respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"{_VERTEX_MODELS}/gemini-3.5-flash:generateContent"
+        respx_mock.post(url).mock(
+            return_value=httpx.Response(200, json=_gen_response(prompt_tokens=1_000_000, output_tokens=1_000_000))
+        )
+        result = provider.chat("gemini-3.5-flash", [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1.65)
+        assert result.cost.output_cost == pytest.approx(9.90)
+
+    def test_global_location_bills_list_price(self, respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj")
+        url = (
+            "https://aiplatform.googleapis.com/v1/projects/my-proj/locations/global"
+            "/publishers/google/models/gemini-3.5-flash:generateContent"
+        )
+        respx_mock.post(url).mock(
+            return_value=httpx.Response(200, json=_gen_response(prompt_tokens=1_000_000, output_tokens=1_000_000))
+        )
+        result = provider.chat("gemini-3.5-flash", [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1.50)
+        assert result.cost.output_cost == pytest.approx(9.00)
+
+    def test_exempt_model_bills_list_price_on_non_global(self, respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"{_VERTEX_MODELS}/{MODEL}:generateContent"
+        respx_mock.post(url).mock(
+            return_value=httpx.Response(200, json=_gen_response(prompt_tokens=1_000_000, output_tokens=0))
+        )
+        result = provider.chat(MODEL, [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(0.15)
+
+    def test_gemini_developer_api_has_no_premium(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
+        url = f"{_GEMINI}/gemini-3.5-flash:generateContent"
+        respx_mock.post(url).mock(
+            return_value=httpx.Response(200, json=_gen_response(prompt_tokens=1_000_000, output_tokens=1_000_000))
+        )
+        result = provider.chat("gemini-3.5-flash", [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1.50)
+
+    def test_unknown_model_cost_stays_none_on_non_global(self, respx_mock: respx.MockRouter) -> None:
+        """The multiplier must not turn an unknown model's None cost into a number."""
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        model = "totally-unknown-model"
+        respx_mock.post(f"{_VERTEX_MODELS}/{model}:generateContent").mock(
+            return_value=httpx.Response(200, json=_gen_response())
+        )
+        result = provider.chat(model, [UserMessage(content="Hi")])
+        assert result.cost is None
+
+    def test_premium_applies_to_custom_registered_pricing(self, respx_mock: respx.MockRouter) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        provider.register_pricing(
+            "gemini-3.5-flash",
+            ModelPricing(tiers=[PricingTier(input_cost_per_token=10e-6, output_cost_per_token=0.0)]),
+        )
+        url = f"{_VERTEX_MODELS}/gemini-3.5-flash:generateContent"
+        respx_mock.post(url).mock(
+            return_value=httpx.Response(200, json=_gen_response(prompt_tokens=1000, output_tokens=0))
+        )
+        result = provider.chat("gemini-3.5-flash", [UserMessage(content="Hi")])
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 10e-6 * 1.1)
+
+    @pytest.mark.parametrize(
+        ("as_of", "input_cost", "output_cost"),
+        [
+            # Before the premium took effect, global pricing applied to every Vertex endpoint.
+            (date(2026, 6, 30), 1.50, 9.00),
+            # The premium is billed from its first day onward.
+            (date(2026, 7, 1), 1.65, 9.90),
+            (date(2026, 8, 16), 1.65, 9.90),
+        ],
+    )
+    def test_premium_honors_its_effective_date(
+        self, respx_mock: respx.MockRouter, as_of: date, input_cost: float, output_cost: float
+    ) -> None:
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        url = f"{_VERTEX_MODELS}/gemini-3.5-flash:generateContent"
+        respx_mock.post(url).mock(
+            return_value=httpx.Response(200, json=_gen_response(prompt_tokens=1_000_000, output_tokens=1_000_000))
+        )
+        result = provider.chat(
+            "gemini-3.5-flash",
+            [UserMessage(content="Hi")],
+            provider_params=GoogleParams(pricing_as_of=as_of),
+        )
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(input_cost)
+        assert result.cost.output_cost == pytest.approx(output_cost)
+
+    def test_backdated_embedding_takes_no_premium(self, respx_mock: respx.MockRouter) -> None:
+        """The effective-date gate applies on the embedding path too, not just chat."""
+        creds = FakeCredentials()
+        provider = GoogleProvider(auth=FakeCredentialsAuth(creds), project="my-proj", location="us-central1")
+        provider.register_pricing(
+            "gemini-3.5-flash",
+            ModelPricing(tiers=[PricingTier(input_cost_per_token=10e-6, output_cost_per_token=0.0)]),
+        )
+        url = f"{_VERTEX_MODELS}/gemini-3.5-flash:predict"
+        respx_mock.post(url).mock(
+            return_value=httpx.Response(
+                200, json={"predictions": [{"embeddings": {"values": [0.1], "statistics": {"token_count": 1000}}}]}
+            )
+        )
+        result = provider.embed(
+            "gemini-3.5-flash", "hello", provider_params=GoogleParams(pricing_as_of=date(2026, 6, 30))
+        )
+        assert result.cost is not None
+        assert result.cost.input_cost == pytest.approx(1000 * 10e-6)
 
 
 # MARK: Provider Params

--- a/packages/lmux-groq/pyproject.toml
+++ b/packages/lmux-groq/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-groq"
-version = "0.8.0"
+version = "0.8.1"
 description = "Groq provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-groq/src/lmux_groq/cost.py
+++ b/packages/lmux-groq/src/lmux_groq/cost.py
@@ -1,6 +1,10 @@
 """Groq pricing data and cost calculation.
 
-Pricing source: https://groq.com/pricing/
+Cached input bills at 50% of the input rate, and only on the models Groq
+supports prompt caching for; Groq charges nothing for cache writes.
+
+Pricing source: https://console.groq.com/docs/models (per-model cards at
+https://console.groq.com/docs/model/<model-id> carry the cached-input rate)
 """
 
 from lmux.cost import (

--- a/packages/lmux-groq/src/lmux_groq/cost.py
+++ b/packages/lmux-groq/src/lmux_groq/cost.py
@@ -1,8 +1,5 @@
 """Groq pricing data and cost calculation.
 
-Cached input bills at 50% of the input rate, and only on the models Groq
-supports prompt caching for; Groq charges nothing for cache writes.
-
 Pricing source: https://console.groq.com/docs/models (per-model cards at
 https://console.groq.com/docs/model/<model-id> carry the cached-input rate)
 """

--- a/packages/lmux-openai/pyproject.toml
+++ b/packages/lmux-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lmux-openai"
-version = "0.10.0"
+version = "0.10.1"
 description = "OpenAI provider for lmux"
 requires-python = ">=3.13"
 license = "MIT"

--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -87,6 +87,19 @@ _PRICING: dict[str, ModelPricing] = {
             ),
         ],
     ),
+    # "cyber" tier is materially pricier than the rest of the gpt-5.6 family, so it
+    # needs an explicit key (it would otherwise prefix-match gpt-5.6 and be
+    # under-priced at 5.00/30.00). Single tier — OpenAI publishes no >272K rate.
+    "gpt-5.6-cyber": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(12.50),
+                output_cost_per_token=per_million_tokens(75.00),
+                cache_read_cost_per_token=per_million_tokens(1.25),
+                cache_creation_cost_per_token=per_million_tokens(15.625),
+            ),
+        ],
+    ),
     "gpt-5.5-pro": ModelPricing(
         tiers=[
             PricingTier(
@@ -323,6 +336,18 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    # Rates currently mirror gpt-5, which this would also prefix-match; the explicit
+    # key keeps it correct if OpenAI prices the search SKU separately later.
+    # (Per-tool-call search fees are separate and not modeled here.)
+    "gpt-5-search-api": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.25),
+                output_cost_per_token=per_million_tokens(10.00),
+                cache_read_cost_per_token=per_million_tokens(0.125),
+            )
+        ],
+    ),
     # GPT-4.1 family
     "gpt-4.1-mini": ModelPricing(
         tiers=[
@@ -514,6 +539,65 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
+    # Legacy GPT-4 and GPT-3.5 models. None publish a cached-input rate.
+    "gpt-4-turbo-2024-04-09": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(10.00),
+                output_cost_per_token=per_million_tokens(30.00),
+            )
+        ],
+    ),
+    "gpt-4-0613": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(30.00),
+                output_cost_per_token=per_million_tokens(60.00),
+            )
+        ],
+    ),
+    "gpt-3.5-turbo": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.50),
+                output_cost_per_token=per_million_tokens(1.50),
+            )
+        ],
+    ),
+    # The 1106 snapshot and the instruct variant are pricier than the gpt-3.5-turbo
+    # base, so both need explicit keys to avoid inheriting the cheaper prefix.
+    "gpt-3.5-turbo-1106": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.00),
+                output_cost_per_token=per_million_tokens(2.00),
+            )
+        ],
+    ),
+    "gpt-3.5-turbo-instruct": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(1.50),
+                output_cost_per_token=per_million_tokens(2.00),
+            )
+        ],
+    ),
+    "davinci-002": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(2.00),
+                output_cost_per_token=per_million_tokens(2.00),
+            )
+        ],
+    ),
+    "babbage-002": ModelPricing(
+        tiers=[
+            PricingTier(
+                input_cost_per_token=per_million_tokens(0.40),
+                output_cost_per_token=per_million_tokens(0.40),
+            )
+        ],
+    ),
     # Embedding models
     "text-embedding-3-small": ModelPricing(
         tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.02), output_cost_per_token=0.0)]
@@ -539,6 +623,9 @@ _UNPRICED_MODELS = frozenset({"gpt-5.4-cyber"})
 # the gpt-5.5 family (gpt-5.5, gpt-5.5-pro), and the gpt-5.6 family (sol/terra/luna).
 REGIONAL_UPLIFT = 1.1
 _REGIONAL_UPLIFT_PREFIXES = ("gpt-5.4", "gpt-5.5", "gpt-5.6")
+# The "cyber" variants share those family prefixes but are absent from OpenAI's
+# data-residency eligible-model list, so the uplift must not follow the prefix.
+_REGIONAL_UPLIFT_EXCLUDED_SUFFIX = "-cyber"
 
 
 def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:
@@ -554,7 +641,7 @@ def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:
 def regional_uplift_applies(model: str) -> bool:
     """Whether the regional processing (data residency) uplift applies to this model."""
     model_lower = model.lower()
-    if model_lower in _UNPRICED_MODELS:
+    if model_lower in _UNPRICED_MODELS or model_lower.endswith(_REGIONAL_UPLIFT_EXCLUDED_SUFFIX):
         return False
     return any(model_lower.startswith(prefix) for prefix in _REGIONAL_UPLIFT_PREFIXES)
 

--- a/packages/lmux-openai/src/lmux_openai/cost.py
+++ b/packages/lmux-openai/src/lmux_openai/cost.py
@@ -336,18 +336,6 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
-    # Rates currently mirror gpt-5, which this would also prefix-match; the explicit
-    # key keeps it correct if OpenAI prices the search SKU separately later.
-    # (Per-tool-call search fees are separate and not modeled here.)
-    "gpt-5-search-api": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(1.25),
-                output_cost_per_token=per_million_tokens(10.00),
-                cache_read_cost_per_token=per_million_tokens(0.125),
-            )
-        ],
-    ),
     # GPT-4.1 family
     "gpt-4.1-mini": ModelPricing(
         tiers=[
@@ -539,65 +527,6 @@ _PRICING: dict[str, ModelPricing] = {
             )
         ],
     ),
-    # Legacy GPT-4 and GPT-3.5 models. None publish a cached-input rate.
-    "gpt-4-turbo-2024-04-09": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(10.00),
-                output_cost_per_token=per_million_tokens(30.00),
-            )
-        ],
-    ),
-    "gpt-4-0613": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(30.00),
-                output_cost_per_token=per_million_tokens(60.00),
-            )
-        ],
-    ),
-    "gpt-3.5-turbo": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(0.50),
-                output_cost_per_token=per_million_tokens(1.50),
-            )
-        ],
-    ),
-    # The 1106 snapshot and the instruct variant are pricier than the gpt-3.5-turbo
-    # base, so both need explicit keys to avoid inheriting the cheaper prefix.
-    "gpt-3.5-turbo-1106": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(1.00),
-                output_cost_per_token=per_million_tokens(2.00),
-            )
-        ],
-    ),
-    "gpt-3.5-turbo-instruct": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(1.50),
-                output_cost_per_token=per_million_tokens(2.00),
-            )
-        ],
-    ),
-    "davinci-002": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(2.00),
-                output_cost_per_token=per_million_tokens(2.00),
-            )
-        ],
-    ),
-    "babbage-002": ModelPricing(
-        tiers=[
-            PricingTier(
-                input_cost_per_token=per_million_tokens(0.40),
-                output_cost_per_token=per_million_tokens(0.40),
-            )
-        ],
-    ),
     # Embedding models
     "text-embedding-3-small": ModelPricing(
         tiers=[PricingTier(input_cost_per_token=per_million_tokens(0.02), output_cost_per_token=0.0)]
@@ -624,8 +553,9 @@ _UNPRICED_MODELS = frozenset({"gpt-5.4-cyber"})
 REGIONAL_UPLIFT = 1.1
 _REGIONAL_UPLIFT_PREFIXES = ("gpt-5.4", "gpt-5.5", "gpt-5.6")
 # The "cyber" variants share those family prefixes but are absent from OpenAI's
-# data-residency eligible-model list, so the uplift must not follow the prefix.
-_REGIONAL_UPLIFT_EXCLUDED_SUFFIX = "-cyber"
+# data-residency eligible-model list. Matched as prefixes, like the pricing table,
+# so dated snapshots (gpt-5.6-cyber-2026-08-01) are excluded too.
+_REGIONAL_UPLIFT_EXCLUDED_PREFIXES = ("gpt-5.4-cyber", "gpt-5.5-cyber", "gpt-5.6-cyber")
 
 
 def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:
@@ -641,7 +571,7 @@ def calculate_openai_cost(model: str, usage: Usage) -> Cost | None:
 def regional_uplift_applies(model: str) -> bool:
     """Whether the regional processing (data residency) uplift applies to this model."""
     model_lower = model.lower()
-    if model_lower in _UNPRICED_MODELS or model_lower.endswith(_REGIONAL_UPLIFT_EXCLUDED_SUFFIX):
+    if model_lower in _UNPRICED_MODELS or model_lower.startswith(_REGIONAL_UPLIFT_EXCLUDED_PREFIXES):
         return False
     return any(model_lower.startswith(prefix) for prefix in _REGIONAL_UPLIFT_PREFIXES)
 

--- a/packages/lmux-openai/tests/test_cost.py
+++ b/packages/lmux-openai/tests/test_cost.py
@@ -222,6 +222,11 @@ class TestRegionalUpliftApplies:
         # The sibling that does share the prefix must still take the uplift.
         assert regional_uplift_applies(model.removesuffix("-cyber")) is True
 
+    @pytest.mark.parametrize("model", ["gpt-5.6-cyber-2026-08-01", "gpt-5.5-cyber-2026-04-23"])
+    def test_does_not_apply_to_dated_cyber_snapshots(self, model: str) -> None:
+        """Pricing resolves cyber snapshots by prefix, so the uplift check must too."""
+        assert regional_uplift_applies(model) is False
+
 
 class TestApplyCostMultiplier:
     def test_applies_multiplier_to_all_fields(self) -> None:

--- a/packages/lmux-openai/tests/test_cost.py
+++ b/packages/lmux-openai/tests/test_cost.py
@@ -82,6 +82,18 @@ class TestCalculateOpenAICost:
         assert cyber.output_cost == pytest.approx(500 * 75.00 / 1_000_000)
         assert cyber.input_cost > base.input_cost
 
+    def test_gpt_5_6_cyber_has_dedicated_pricing(self) -> None:
+        """gpt-5.6-cyber must use its own (pricier) rate, not prefix-match gpt-5.6."""
+        usage = Usage(input_tokens=1000, output_tokens=500, cache_creation_tokens=100)
+        cyber = calculate_openai_cost("gpt-5.6-cyber", usage)
+        base = calculate_openai_cost("gpt-5.6", usage)
+        assert cyber is not None
+        assert base is not None
+        assert cyber.input_cost == pytest.approx((1000 - 100) * 12.50 / 1_000_000)
+        assert cyber.output_cost == pytest.approx(500 * 75.00 / 1_000_000)
+        assert cyber.cache_creation_cost == pytest.approx(100 * 15.625 / 1_000_000)
+        assert cyber.input_cost > base.input_cost
+
     @pytest.mark.parametrize(
         ("model", "input_rate", "output_rate", "cache_read_rate", "cache_write_rate"),
         [
@@ -202,6 +214,13 @@ class TestRegionalUpliftApplies:
     def test_does_not_apply_to_other_models(self, model: str) -> None:
         # gpt-5.4-cyber starts with "gpt-5.4" but is unpriced, so the uplift must not apply.
         assert regional_uplift_applies(model) is False
+
+    @pytest.mark.parametrize("model", ["gpt-5.5-cyber", "gpt-5.6-cyber"])
+    def test_does_not_apply_to_priced_cyber_variants(self, model: str) -> None:
+        """Cyber models carry a family prefix but are absent from OpenAI's data-residency list."""
+        assert regional_uplift_applies(model) is False
+        # The sibling that does share the prefix must still take the uplift.
+        assert regional_uplift_applies(model.removesuffix("-cyber")) is True
 
 
 class TestApplyCostMultiplier:

--- a/scripts/update_bedrock_pricing.py
+++ b/scripts/update_bedrock_pricing.py
@@ -80,7 +80,7 @@ FM_SERVICENAME_MAP: dict[str, str] = {
     "Claude 3.5 Sonnet": "anthropic.claude-3-5-sonnet-20240620-v1",
     "Claude 3.5 Haiku": "anthropic.claude-3-5-haiku-20241022-v1",
     "Claude 3 Opus": "anthropic.claude-3-opus-20240229-v1",
-    "Claude 3 Sonnet": "anthropic.claude-3-sonnet-v1",
+    "Claude 3 Sonnet": "anthropic.claude-3-sonnet-20240229-v1",
     "Claude 3 Haiku": "anthropic.claude-3-haiku-v1",
     "Claude": "anthropic.claude-v2",
     "Claude Instant": "anthropic.claude-instant-v1",
@@ -325,6 +325,7 @@ KNOWN_UNRESOLVED_IDS: frozenset[str] = frozenset(
         "anthropic.claude-3-5-sonnet-20241022-v2",
         "anthropic.claude-3-7-sonnet-20250219-v1",
         "anthropic.claude-3-opus-20240229-v1",
+        "anthropic.claude-3-sonnet-20240229-v1",
         "anthropic.claude-opus-4-20250514-v1",
         # Not confirmed reachable: the real ID may differ, which would price these as None.
         # These are live models rather than retirements, tracked as a separate known gap.

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ requires-dist = [{ name = "pydantic", specifier = "~=2.10" }]
 
 [[package]]
 name = "lmux-anthropic"
-version = "0.15.0"
+version = "0.15.1"
 source = { editable = "packages/lmux-anthropic" }
 dependencies = [
     { name = "httpx" },
@@ -700,7 +700,7 @@ provides-extras = ["vertex", "bedrock"]
 
 [[package]]
 name = "lmux-aws-bedrock"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "packages/lmux-aws-bedrock" }
 dependencies = [
     { name = "boto3" },
@@ -726,7 +726,7 @@ provides-extras = ["async"]
 
 [[package]]
 name = "lmux-azure-foundry"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "packages/lmux-azure-foundry" }
 dependencies = [
     { name = "httpx" },
@@ -748,7 +748,7 @@ provides-extras = ["identity"]
 
 [[package]]
 name = "lmux-bedrock-shared"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/lmux-bedrock-shared" }
 dependencies = [
     { name = "boto3" },
@@ -774,7 +774,7 @@ requires-dist = [{ name = "lmux-google", editable = "packages/lmux-google" }]
 
 [[package]]
 name = "lmux-google"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/lmux-google" }
 dependencies = [
     { name = "google-auth" },
@@ -791,7 +791,7 @@ requires-dist = [
 
 [[package]]
 name = "lmux-groq"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/lmux-groq" }
 dependencies = [
     { name = "httpx" },
@@ -817,7 +817,7 @@ requires-dist = [{ name = "lmux", editable = "packages/lmux" }]
 
 [[package]]
 name = "lmux-openai"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "packages/lmux-openai" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Provider pricing had drifted from published rates: Sonnet 5 was billing a cancelled increase, Gemini 3.6 Flash was charging double, `gpt-5.6-cyber` was undercharging 2.5x, and the Vertex non-global premium was never applied. This PR audits all six providers and corrects them.

It also unblocks `scripts/update_bedrock_pricing.py`, failing since Claude 3 Sonnet was delisted, and regenerates the Bedrock tables. `lmux-google` gains `pricing_as_of` for dated pricing, hence its minor bump.
