### PR TITLE
fix: Forward embedding task type to Vertex embedContent

### DIFF
--- a/packages/lmux-google/README.md
+++ b/packages/lmux-google/README.md
@@ -120,6 +120,7 @@ response = provider.chat(
 | `seed`              | `int`                 | Deterministic sampling seed                                                                                      |
 | `labels`            | `dict[str, str]`      | Request labels                                                                                                   |
 | `thinking_config`   | `dict`                | Thinking/reasoning configuration                                                                                 |
+| `task_type`         | `str`                 | Embedding task type; not all embedding models make use of this when provided                                     |
 | `pricing_as_of`     | `datetime.date`       | Override the date used for dated pricing (e.g. a model's introductory-rate window); defaults to the current date |
 
 ## Constructor Options

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -426,7 +426,7 @@ class GoogleProvider(
     ) -> EmbeddingResponse:
         as_of = self._resolve_pricing_as_of(provider_params)
         if self._vertexai and _uses_embed_content(model):
-            return self._embed_content(model, input, dimensions, as_of)
+            return self._embed_content(model, input, dimensions, provider_params, as_of)
         texts = input if isinstance(input, list) else [input]
         if self._vertexai and model.startswith("gemini-embedding-001") and not texts:
             return self._embedding_response(model, [], 0, as_of)
@@ -453,7 +453,7 @@ class GoogleProvider(
     ) -> EmbeddingResponse:
         as_of = self._resolve_pricing_as_of(provider_params)
         if self._vertexai and _uses_embed_content(model):
-            return await self._aembed_content(model, input, dimensions, as_of)
+            return await self._aembed_content(model, input, dimensions, provider_params, as_of)
         texts = input if isinstance(input, list) else [input]
         if self._vertexai and model.startswith("gemini-embedding-001") and not texts:
             return self._embedding_response(model, [], 0, as_of)
@@ -474,10 +474,11 @@ class GoogleProvider(
         model: str,
         input: str | list[str],  # noqa: A002
         dimensions: int | None,
+        provider_params: GoogleParams | None,
         as_of: date,
     ) -> EmbeddingResponse:
         # Vertex serves Gemini Embedding 2 models only through :embedContent, which takes a single
-        # content per request (no batch) and rejects task_type — so a list is issued one item at a time.
+        # content per request (no batch), so a list is issued one item at a time.
         texts = input if isinstance(input, list) else [input]
         path = self._path(model, "embedContent")
         embeddings: list[list[float]] = []
@@ -486,7 +487,9 @@ class GoogleProvider(
             client = self._get_sync_client()
             for text in texts:
                 headers = self._request_headers()
-                response = client.post(path, json=_embed_content_body(text, dimensions), headers=headers)
+                response = client.post(
+                    path, json=_embed_content_body(text, dimensions, provider_params), headers=headers
+                )
                 raise_for_status(response)
                 values, tokens = map_embed_content_response(parse_body(response, WireEmbedContentResponse))
                 embeddings.append(values)
@@ -502,6 +505,7 @@ class GoogleProvider(
         model: str,
         input: str | list[str],  # noqa: A002
         dimensions: int | None,
+        provider_params: GoogleParams | None,
         as_of: date,
     ) -> EmbeddingResponse:
         texts = input if isinstance(input, list) else [input]
@@ -512,7 +516,9 @@ class GoogleProvider(
             client = await self._get_async_client()
             for text in texts:
                 headers = await self._arequest_headers()
-                response = await client.post(path, json=_embed_content_body(text, dimensions), headers=headers)
+                response = await client.post(
+                    path, json=_embed_content_body(text, dimensions, provider_params), headers=headers
+                )
                 raise_for_status(response)
                 values, tokens = map_embed_content_response(parse_body(response, WireEmbedContentResponse))
                 embeddings.append(values)
@@ -721,8 +727,10 @@ def _uses_embed_content(model: str) -> bool:
     return model.startswith("gemini-embedding-2")
 
 
-def _embed_content_body(text: str, dimensions: int | None) -> Json:
+def _embed_content_body(text: str, dimensions: int | None, provider_params: GoogleParams | None) -> Json:
     body: Json = {"content": {"parts": [{"text": text}]}}
     if dimensions is not None:
         body["outputDimensionality"] = dimensions
+    if provider_params is not None and provider_params.task_type is not None:
+        body["embedContentConfig"] = {"taskType": provider_params.task_type}
     return body

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -757,20 +757,31 @@ class TestVertexEmbedContent:
         assert result.embeddings == [[0.1, 0.2]]
         assert result.usage.input_tokens == 4
         assert route.calls.last.request.headers["authorization"] == "Bearer vertex-token"
-        # embedContent is single-content and rejects task_type — the body carries neither instances nor task_type.
+        # embedContent is single-content, so the body carries content rather than instances.
         assert json.loads(route.calls.last.request.content) == {"content": {"parts": [{"text": "hello"}]}}
 
-    def test_list_issues_one_request_per_item(self, respx_mock: respx.MockRouter) -> None:
+    def test_list_issues_one_request_per_item_with_task_type(self, respx_mock: respx.MockRouter) -> None:
         responses = [
             httpx.Response(200, json={"embedding": {"values": [0.1]}, "usageMetadata": {"promptTokenCount": 2}}),
             httpx.Response(200, json={"embedding": {"values": [0.2]}, "usageMetadata": {"promptTokenCount": 3}}),
         ]
         route = respx_mock.post(_embed_content_url()).mock(side_effect=responses)
-        result = _vertex_embed2_provider().embed(_EMBED2_MODEL, ["a", "b"])
+        result = _vertex_embed2_provider().embed(
+            _EMBED2_MODEL, ["a", "b"], provider_params=GoogleParams(task_type="RETRIEVAL_DOCUMENT")
+        )
         assert result.embeddings == [[0.1], [0.2]]
         assert result.usage.input_tokens == 5
         assert len(route.calls) == 2
-        assert json.loads(route.calls[0].request.content) == {"content": {"parts": [{"text": "a"}]}}
+        assert [json.loads(call.request.content) for call in route.calls] == [
+            {
+                "content": {"parts": [{"text": "a"}]},
+                "embedContentConfig": {"taskType": "RETRIEVAL_DOCUMENT"},
+            },
+            {
+                "content": {"parts": [{"text": "b"}]},
+                "embedContentConfig": {"taskType": "RETRIEVAL_DOCUMENT"},
+            },
+        ]
 
     def test_dimensions_forwarded(self, respx_mock: respx.MockRouter) -> None:
         body = {"embedding": {"values": [0.1]}}
@@ -809,16 +820,28 @@ class TestVertexEmbedContent:
         with pytest.raises(NotFoundError):
             await _vertex_embed2_provider().aembed(_EMBED2_MODEL, "hi")
 
-    async def test_aembed_list_issues_one_request_per_item(self, respx_mock: respx.MockRouter) -> None:
+    async def test_aembed_list_issues_one_request_per_item_with_task_type(self, respx_mock: respx.MockRouter) -> None:
         responses = [
             httpx.Response(200, json={"embedding": {"values": [0.1]}, "usageMetadata": {"promptTokenCount": 2}}),
             httpx.Response(200, json={"embedding": {"values": [0.2]}, "usageMetadata": {"promptTokenCount": 3}}),
         ]
         route = respx_mock.post(_embed_content_url()).mock(side_effect=responses)
-        result = await _vertex_embed2_provider().aembed(_EMBED2_MODEL, ["a", "b"])
+        result = await _vertex_embed2_provider().aembed(
+            _EMBED2_MODEL, ["a", "b"], provider_params=GoogleParams(task_type="RETRIEVAL_DOCUMENT")
+        )
         assert result.embeddings == [[0.1], [0.2]]
         assert result.usage.input_tokens == 5
         assert len(route.calls) == 2
+        assert [json.loads(call.request.content) for call in route.calls] == [
+            {
+                "content": {"parts": [{"text": "a"}]},
+                "embedContentConfig": {"taskType": "RETRIEVAL_DOCUMENT"},
+            },
+            {
+                "content": {"parts": [{"text": "b"}]},
+                "embedContentConfig": {"taskType": "RETRIEVAL_DOCUMENT"},
+            },
+        ]
 
 
 # MARK: Client Management

--- a/tests/integration/cassettes/google/vertex_embed_content.json
+++ b/tests/integration/cassettes/google/vertex_embed_content.json
@@ -8,7 +8,10 @@
         }
       ]
     },
-    "outputDimensionality": 256
+    "outputDimensionality": 256,
+    "embedContentConfig": {
+      "taskType": "RETRIEVAL_DOCUMENT"
+    }
   },
   "response": {
     "embedding": {

--- a/tests/integration/google/test_embed_content.py
+++ b/tests/integration/google/test_embed_content.py
@@ -11,10 +11,12 @@ from typing import Any
 import pytest
 
 from lmux.types import EmbeddingResponse
+from lmux_google import GoogleParams
 
 _MODEL = "gemini-embedding-2-preview"
 _LOCATION = "us-central1"
 _DIMENSIONS = 256
+_TASK_TYPE = "RETRIEVAL_DOCUMENT"
 _CASSETTE = Path(__file__).parent.parent / "cassettes" / "google" / "vertex_embed_content.json"
 
 _RATES = {"input_rate": 0.20 / 1_000_000, "output_rate": 0.0}
@@ -31,7 +33,10 @@ def test_embeddings_embed_content(
     # per request, so the count (2) and summed usage — not vector identity — are what this proves.
     def _embed(auth: Any, transport: Any) -> EmbeddingResponse:  # noqa: ANN401 — harness-supplied per mode
         return vertex_adc_provider(auth, transport, location=_LOCATION).embed(
-            _MODEL, ["alpha", "beta"], dimensions=_DIMENSIONS
+            _MODEL,
+            ["alpha", "beta"],
+            dimensions=_DIMENSIONS,
+            provider_params=GoogleParams(task_type=_TASK_TYPE),
         )
 
     resp = scenario(_CASSETTE, _embed, requires="GOOGLE_CLOUD_PROJECT")


### PR DESCRIPTION
`GoogleParams.task_type` is already forwarded by the Developer API and Vertex `:predict` embedding paths, but the Vertex `:embedContent` path silently drops it. This makes behavior depend on which Google endpoint serves the model and prevents callers from passing through the native embedding configuration.

This PR forwards `task_type` as `embedContentConfig.taskType` for both sync and async `:embedContent` requests without locally validating model support. It adds unit and live integration coverage and documents that not every embedding model necessarily uses the field.

Closes #139
