### PR TITLE
fix: Make Google reasoning effort model-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ print(response.usage.reasoning_tokens)  # reasoning token count (or None)
 
 Streaming returns reasoning in `chunk.reasoning_delta`. Each provider maps the effort level to its native API:
 
-| Provider               | Mapping                                                                                                                                  |
-| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| OpenAI / Azure Foundry | `reasoning_effort`                                                                                                                       |
+| Provider               | Mapping                                                                                                                                                                    |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenAI / Azure Foundry | `reasoning_effort`                                                                                                                                                         |
 | Anthropic              | adaptive `thinking` + `output_config.effort` on Claude 4.6+; `thinking` with budget tokens (capped to `max_tokens - 1`) on 4.5 and older; summarized display in both modes |
-| Google                 | `thinking_config` with `thinking_budget` and `include_thoughts`                                                                          |
-| AWS Bedrock            | `additionalModelRequestFields.thinking` — adaptive + `output_config.effort` on Claude 4.6+, capped budget tokens on 4.5 and older, with summarized display in both modes |
-| Groq                   | `reasoning_effort` + `include_reasoning`                                                                                                 |
+| Google                 | model-aware `thinkingBudget` on Gemini 2.5 or `thinkingLevel` on Gemini 3+, with `includeThoughts`                                                                         |
+| AWS Bedrock            | `additionalModelRequestFields.thinking` — adaptive + `output_config.effort` on Claude 4.6+, capped budget tokens on 4.5 and older, with summarized display in both modes   |
+| Groq                   | `reasoning_effort` + `include_reasoning`                                                                                                                                   |
 
 For fine-grained control, use provider-specific params instead (e.g., `AnthropicParams(thinking=...)`). Provider params always take precedence over the top-level `reasoning_effort`.
 

--- a/packages/lmux-google/README.md
+++ b/packages/lmux-google/README.md
@@ -100,6 +100,16 @@ registry.register("google", provider)
 response = registry.chat("google/gemini-2.5-pro", messages)
 ```
 
+## Reasoning
+
+The unified `reasoning_effort` parameter maps `low`, `medium`, and `high` to the native control supported by each
+Gemini generation. Gemini 2.5 uses numeric `thinkingBudget` values: `1_024`, `8_192`, and `24_576` for Flash and
+Flash-Lite, with `32_768` for Pro at high effort. Gemini 3 and later use `thinkingLevel` values `LOW`, `MEDIUM`, and
+`HIGH`. All mappings request thought summaries with `includeThoughts: true`.
+
+Model aliases that do not identify their generation cannot be mapped safely. For those aliases, pass an explicit
+native `thinking_config` as shown below.
+
 ## Provider Params
 
 ```python
@@ -108,9 +118,12 @@ from lmux_google import GoogleParams
 response = provider.chat(
     "gemini-2.5-pro",
     messages,
-    provider_params=GoogleParams(thinking_config={"thinking_budget": 1024}),
+    provider_params=GoogleParams(thinking_config={"thinkingBudget": 1024, "includeThoughts": True}),
 )
 ```
+
+`thinking_config` is passed through verbatim using the native REST field names and takes precedence over the
+top-level `reasoning_effort` parameter.
 
 | Parameter           | Type                  | Description                                                                                                      |
 | ------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------- |

--- a/packages/lmux-google/src/lmux_google/provider.py
+++ b/packages/lmux-google/src/lmux_google/provider.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import re
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from datetime import date
 from typing import TYPE_CHECKING, Literal, override
@@ -12,7 +13,7 @@ if TYPE_CHECKING:
 
 from lmux._http import aiter_sse, iter_sse
 from lmux.cost import ModelPricing, calculate_cost
-from lmux.exceptions import LmuxError, ProviderError
+from lmux.exceptions import InvalidRequestError, LmuxError, ProviderError
 from lmux.protocols import AuthProvider, CompletionProvider, EmbeddingProvider, PricingProvider
 from lmux.types import (
     ChatChunk,
@@ -77,6 +78,29 @@ PROVIDER_NAME = "google"
 
 _HTTP_ERROR = 400
 _THINKING_BUDGETS: dict[str, int] = {"low": 1024, "medium": 8192, "high": 32768}
+_FLASH_THINKING_BUDGETS: dict[str, int] = {**_THINKING_BUDGETS, "high": 24576}
+_GEMINI_GENERATION_RE = re.compile(r"^gemini-(\d+)(?:\.\d+)?(?=-|$)", re.IGNORECASE)
+_THINKING_LEVEL_MIN_GENERATION = 3
+
+
+def _matches_model_family(model: str, family: str) -> bool:
+    return model == family or model.startswith(f"{family}-")
+
+
+def _thinking_config(model: str, effort: Literal["low", "medium", "high"]) -> Json:
+    normalized = model.casefold()
+    generation = _GEMINI_GENERATION_RE.match(normalized)
+    if generation is not None and int(generation.group(1)) >= _THINKING_LEVEL_MIN_GENERATION:
+        return {"thinkingLevel": effort.upper(), "includeThoughts": True}
+    if _matches_model_family(normalized, "gemini-2.5-flash"):
+        return {"thinkingBudget": _FLASH_THINKING_BUDGETS[effort], "includeThoughts": True}
+    if _matches_model_family(normalized, "gemini-2.5-pro"):
+        return {"thinkingBudget": _THINKING_BUDGETS[effort], "includeThoughts": True}
+    msg = (
+        f"Cannot map reasoning_effort for unrecognized Gemini model {model!r}; "
+        "set provider_params.thinking_config explicitly"
+    )
+    raise InvalidRequestError(msg, provider=PROVIDER_NAME)
 
 
 def _today() -> date:
@@ -260,7 +284,7 @@ class GoogleProvider(
         provider_params: GoogleParams | None = None,
     ) -> ChatResponse:
         body = self._build_body(
-            messages, temperature, max_tokens, top_p, stop,
+            model, messages, temperature, max_tokens, top_p, stop,
             tools, tool_choice, response_format, reasoning_effort, provider_params,
             vertexai=self._vertexai,
         )  # fmt: skip
@@ -296,7 +320,7 @@ class GoogleProvider(
         provider_params: GoogleParams | None = None,
     ) -> ChatResponse:
         body = self._build_body(
-            messages, temperature, max_tokens, top_p, stop,
+            model, messages, temperature, max_tokens, top_p, stop,
             tools, tool_choice, response_format, reasoning_effort, provider_params,
             vertexai=self._vertexai,
         )  # fmt: skip
@@ -332,7 +356,7 @@ class GoogleProvider(
         provider_params: GoogleParams | None = None,
     ) -> Iterator[ChatChunk]:
         body = self._build_body(
-            messages, temperature, max_tokens, top_p, stop,
+            model, messages, temperature, max_tokens, top_p, stop,
             tools, tool_choice, response_format, reasoning_effort, provider_params,
             vertexai=self._vertexai,
         )  # fmt: skip
@@ -381,7 +405,7 @@ class GoogleProvider(
         provider_params: GoogleParams | None = None,
     ) -> AsyncIterator[ChatChunk]:
         body = self._build_body(
-            messages, temperature, max_tokens, top_p, stop,
+            model, messages, temperature, max_tokens, top_p, stop,
             tools, tool_choice, response_format, reasoning_effort, provider_params,
             vertexai=self._vertexai,
         )  # fmt: skip
@@ -613,6 +637,7 @@ class GoogleProvider(
 
     @staticmethod
     def _build_body(  # noqa: PLR0913, PLR0912
+        model: str,
         messages: Sequence[Message],
         temperature: float | None,
         max_tokens: int | None,
@@ -627,6 +652,7 @@ class GoogleProvider(
         vertexai: bool,
     ) -> Json:
         system, contents = map_messages(messages, include_tool_call_ids=not vertexai)
+        provider_thinking = provider_params.thinking_config if provider_params is not None else None
         body: Json = {"contents": contents}
         if system is not None:
             body["systemInstruction"] = {"parts": [{"text": system}]}
@@ -647,8 +673,8 @@ class GoogleProvider(
                 # responseJsonSchema accepts full JSON Schema (incl. $defs/$ref); responseSchema
                 # is the narrower OpenAPI-style shape that rejects those constructs.
                 gen["responseJsonSchema"] = schema
-        if reasoning_effort is not None:
-            gen["thinkingConfig"] = {"thinkingBudget": _THINKING_BUDGETS[reasoning_effort], "includeThoughts": True}
+        if reasoning_effort is not None and provider_thinking is None:
+            gen["thinkingConfig"] = _thinking_config(model, reasoning_effort)
         if tools is not None:
             body["tools"] = map_tools(tools)
         if tool_choice is not None:

--- a/packages/lmux-google/tests/test_provider.py
+++ b/packages/lmux-google/tests/test_provider.py
@@ -3,7 +3,7 @@
 import asyncio
 import json
 from datetime import date
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from unittest.mock import MagicMock
 
 import httpx
@@ -265,13 +265,50 @@ class TestChat:
         assert body["generationConfig"]["responseMimeType"] == "application/json"
         assert body["generationConfig"]["responseJsonSchema"] == {"type": "object"}
 
+    @pytest.mark.parametrize(
+        "case",
+        [
+            ("gemini-2.5-flash", "low", {"thinkingBudget": 1024, "includeThoughts": True}),
+            ("gemini-2.5-flash-preview-09-2025", "medium", {"thinkingBudget": 8192, "includeThoughts": True}),
+            ("gemini-2.5-flash-001", "high", {"thinkingBudget": 24576, "includeThoughts": True}),
+            ("gemini-2.5-flash-lite", "high", {"thinkingBudget": 24576, "includeThoughts": True}),
+            (
+                "gemini-2.5-flash-lite-preview-09-2025",
+                "medium",
+                {"thinkingBudget": 8192, "includeThoughts": True},
+            ),
+            ("gemini-2.5-pro", "high", {"thinkingBudget": 32768, "includeThoughts": True}),
+            ("gemini-2.5-pro-preview-06-05", "low", {"thinkingBudget": 1024, "includeThoughts": True}),
+            ("gemini-3-flash-preview", "low", {"thinkingLevel": "LOW", "includeThoughts": True}),
+            ("gemini-3.1-pro-preview", "medium", {"thinkingLevel": "MEDIUM", "includeThoughts": True}),
+            ("gemini-3.5-flash", "high", {"thinkingLevel": "HIGH", "includeThoughts": True}),
+            ("gemini-3.5-flash-lite", "low", {"thinkingLevel": "LOW", "includeThoughts": True}),
+            ("gemini-3.7-flash", "medium", {"thinkingLevel": "MEDIUM", "includeThoughts": True}),
+        ],
+    )
     def test_reasoning_effort(
+        self,
+        provider: GoogleProvider,
+        gen_response: dict[str, Any],
+        respx_mock: respx.MockRouter,
+        case: tuple[str, Literal["low", "medium", "high"], dict[str, object]],
+    ) -> None:
+        model, effort, expected = case
+        route = _ok(respx_mock, gen_response, url=f"{_GEMINI}/{model}:generateContent")
+        provider.chat(model, [UserMessage(content="Hi")], reasoning_effort=effort)
+        body = json.loads(route.calls.last.request.content)
+        assert body["generationConfig"]["thinkingConfig"] == expected
+
+    def test_reasoning_effort_rejects_opaque_model(
         self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
     ) -> None:
-        route = _ok(respx_mock, gen_response)
-        provider.chat(MODEL, [UserMessage(content="Hi")], reasoning_effort="medium")
-        body = json.loads(route.calls.last.request.content)
-        assert body["generationConfig"]["thinkingConfig"] == {"thinkingBudget": 8192, "includeThoughts": True}
+        model = "gemini-flash-latest"
+        route = _ok(respx_mock, gen_response, url=f"{_GEMINI}/{model}:generateContent")
+
+        with pytest.raises(InvalidRequestError, match=r"Cannot map reasoning_effort.*gemini-flash-latest"):
+            provider.chat(model, [UserMessage(content="Hi")], reasoning_effort="high")
+
+        assert not route.called
 
     def test_status_error_mapped(self, provider: GoogleProvider, respx_mock: respx.MockRouter) -> None:
         respx_mock.post(_CHAT_URL).mock(return_value=httpx.Response(400, json={"error": {"message": "bad"}}))
@@ -1230,6 +1267,27 @@ class TestProviderParams:
             "seed": 42,
             "thinkingConfig": {"thinkingBudget": 1024},
         }
+
+    def test_thinking_config_verbatim_override(
+        self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter
+    ) -> None:
+        model = "gemini-flash-latest"
+        thinking_config = {
+            "thinkingLevel": "MINIMAL",
+            "includeThoughts": False,
+            "futureOption": {"enabled": True},
+        }
+        route = _ok(respx_mock, gen_response, url=f"{_GEMINI}/{model}:generateContent")
+
+        provider.chat(
+            model,
+            [UserMessage(content="Hi")],
+            reasoning_effort="high",
+            provider_params=GoogleParams(thinking_config=thinking_config),
+        )
+
+        body = json.loads(route.calls.last.request.content)
+        assert body["generationConfig"]["thinkingConfig"] == thinking_config
 
     def test_google_search_bool(
         self, provider: GoogleProvider, gen_response: dict[str, Any], respx_mock: respx.MockRouter

--- a/tests/integration/cassettes/google/vertex_reasoning_2_5_flash_high.json
+++ b/tests/integration/cassettes/google/vertex_reasoning_2_5_flash_high.json
@@ -1,0 +1,63 @@
+{
+  "endpoint": "https://aiplatform.googleapis.com/v1/projects/lmux-integration/locations/global/publishers/google/models/gemini-2.5-flash:generateContent",
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "What is 17 times 23? Reply with just the number."
+          }
+        ]
+      }
+    ],
+    "generationConfig": {
+      "thinkingConfig": {
+        "thinkingBudget": 24576,
+        "includeThoughts": true
+      }
+    }
+  },
+  "response": {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Okay, so the user needs the product of 17 and 23. My task here is straightforward: I need to calculate that product and then provide *only* the numerical result. No preamble, no explanation of the calculation, just the final answer.\n\nTo get that answer, I'll break down the multiplication:\nFirst, I'll calculate 17 times 20, which is 340.\nThen, I'll calculate 17 times 3, which gives me 51.\nFinally, I'll add those two results together: 340 plus 51 equals 391.\n\nSo, the product of 17 and 23 is 391. That's the single piece of information I'll be returning.",
+              "thought": true
+            },
+            {
+              "text": "391"
+            }
+          ]
+        },
+        "finishReason": "STOP",
+        "avgLogprobs": -5.557614644368489
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 16,
+      "candidatesTokenCount": 3,
+      "totalTokenCount": 96,
+      "trafficType": "ON_DEMAND",
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 16
+        }
+      ],
+      "candidatesTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 3
+        }
+      ],
+      "thoughtsTokenCount": 77
+    },
+    "modelVersion": "gemini-2.5-flash",
+    "createTime": "2026-08-22T12:53:01.302586Z",
+    "responseId": "rZuJavq7Esnij8MPp_6A6QI"
+  }
+}

--- a/tests/integration/cassettes/google/vertex_reasoning_2_5_flash_lite_high.json
+++ b/tests/integration/cassettes/google/vertex_reasoning_2_5_flash_lite_high.json
@@ -1,0 +1,63 @@
+{
+  "endpoint": "https://aiplatform.googleapis.com/v1/projects/lmux-integration/locations/global/publishers/google/models/gemini-2.5-flash-lite:generateContent",
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "What is 17 times 23? Reply with just the number."
+          }
+        ]
+      }
+    ],
+    "generationConfig": {
+      "thinkingConfig": {
+        "thinkingBudget": 24576,
+        "includeThoughts": true
+      }
+    }
+  },
+  "response": {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Alright, the user's request is straightforward: calculate the product of 17 and 23, and then respond solely with that numerical result. My immediate task is to execute that multiplication.\n\nI can approach this calculation in several ways, all of which should yield the same answer. The most conventional method, of course, is the standard multiplication algorithm. I'd set it up vertically: 17 multiplied by 23.\n\nFirst, I'd take the 3 from 23 and multiply it by 17. That's 3 times 10 is 30, and 3 times 7 is 21. So, 30 plus 21 gives me 51.\n\nNext, I'd take the 2 from 23, which actually represents 20, and multiply it by 17. 20 times 17. I know 2 times 17 is 34, so 20 times 17 is 340.\n\nNow, I add those two intermediate results: 51 plus 340. This sums to 391.\n\nAlternatively, I could employ the distributive property. I could break down 23 into 20 and 3. So, 17 multiplied by (20 + 3). This means (17 * 20) + (17 * 3). I've already done these: 17 * 20 is 340, and 17 * 3 is 51. Adding them, 340 + 51, again gives 391.\n\nI could also distribute 17. Let's say I break 17 into 10 and 7. So, (10 + 7) multiplied by 23. This translates to (10 * 23) + (7 * 23). Ten times 23 is obviously 230. For 7 times 23, I can break 23 into 20 and 3 again: (7 * 20) + (7 * 3). That's 140 plus 21, which equals 161. Then I add the initial 230 to this 161: 230 + 161. This, too, results in 391.\n\nAll methods confirm the product is 391.\n\nThe user explicitly stated to reply with *just* the number. Therefore, my final output will be that singular numerical value.",
+              "thought": true
+            },
+            {
+              "text": "391"
+            }
+          ]
+        },
+        "finishReason": "STOP",
+        "avgLogprobs": -7.953607559204102
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 16,
+      "candidatesTokenCount": 3,
+      "totalTokenCount": 349,
+      "trafficType": "ON_DEMAND",
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 16
+        }
+      ],
+      "candidatesTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 3
+        }
+      ],
+      "thoughtsTokenCount": 330
+    },
+    "modelVersion": "gemini-2.5-flash-lite",
+    "createTime": "2026-08-22T12:53:03.219103Z",
+    "responseId": "r5uJat-vDY2mj8MPwuOUqQw"
+  }
+}

--- a/tests/integration/cassettes/google/vertex_reasoning_2_5_pro_high.json
+++ b/tests/integration/cassettes/google/vertex_reasoning_2_5_pro_high.json
@@ -1,0 +1,63 @@
+{
+  "endpoint": "https://aiplatform.googleapis.com/v1/projects/lmux-integration/locations/global/publishers/google/models/gemini-2.5-pro:generateContent",
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "What is 17 times 23? Reply with just the number."
+          }
+        ]
+      }
+    ],
+    "generationConfig": {
+      "thinkingConfig": {
+        "thinkingBudget": 32768,
+        "includeThoughts": true
+      }
+    }
+  },
+  "response": {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "text": "Ah, so the core of this request is a straightforward calculation: find the product of 17 and 23. The user has also laid down a very specific constraint \u2013 they want *only* the numerical result, no preamble, no explanation, just the number itself.\n\nMy first thought is to execute the multiplication. I can approach this in a few ways, all leading to the same outcome. The standard algorithmic approach is one: multiplying 17 by 3 gives me 51, and then multiplying 17 by 20 (or 2 by 17 and then multiplying by 10) yields 340. Summing those, 51 and 340, brings me to 391.\n\nAlternatively, I might think of it using the distributive property mentally. I could break down 23 into 20 and 3. So, 17 times 20 is 340. Then, 17 times 3 is 51. Adding those together: 340 plus 51 equals 391. Or, I could distribute on the other number: 23 times 10 is 230. And 23 times 7... that's 20 times 7 (140) plus 3 times 7 (21), which equals 161. Then, 230 plus 161 also equals 391.\n\nRegardless of the method, the result is consistently 391.\n\nNow, I need to adhere strictly to the output format. The user explicitly asked for \"just the number.\" This means no conversational filler, no confirmation of the calculation, no mention of the methods used. The final output must be *only* the numerical answer.\n\nTherefore, after confirming the calculation through multiple mental or procedural checks, the definitive answer, presented precisely as requested, is 391.",
+              "thought": true
+            },
+            {
+              "text": "391"
+            }
+          ]
+        },
+        "finishReason": "STOP",
+        "avgLogprobs": -6.162923177083333
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 16,
+      "candidatesTokenCount": 3,
+      "totalTokenCount": 354,
+      "trafficType": "ON_DEMAND",
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 16
+        }
+      ],
+      "candidatesTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 3
+        }
+      ],
+      "thoughtsTokenCount": 335
+    },
+    "modelVersion": "gemini-2.5-pro",
+    "createTime": "2026-08-22T12:53:07.816376Z",
+    "responseId": "s5uJavjpMbr1j8MP7pjT2AE"
+  }
+}

--- a/tests/integration/cassettes/google/vertex_reasoning_3_5_flash_high.json
+++ b/tests/integration/cassettes/google/vertex_reasoning_3_5_flash_high.json
@@ -1,0 +1,63 @@
+{
+  "endpoint": "https://aiplatform.googleapis.com/v1/projects/lmux-integration/locations/global/publishers/google/models/gemini-3.5-flash:generateContent",
+  "request": {
+    "contents": [
+      {
+        "role": "user",
+        "parts": [
+          {
+            "text": "What is 17 times 23? Reply with just the number."
+          }
+        ]
+      }
+    ],
+    "generationConfig": {
+      "thinkingConfig": {
+        "thinkingLevel": "HIGH",
+        "includeThoughts": true
+      }
+    }
+  },
+  "response": {
+    "candidates": [
+      {
+        "content": {
+          "role": "model",
+          "parts": [
+            {
+              "text": "**My Thought Process on the Calculation of 17 x 23**\n\nWhen presented with the straightforward arithmetic problem of determining the product of 17 and 23, my initial approach is to break down the operation into manageable steps, leveraging distributive properties for efficiency and accuracy. I recognize this as a fundamental multiplication task, and my expertise in numerical manipulation allows me to quickly engage with it.\n\nMy first step is to mentally decompose the larger factor, 23, into its constituent tens and units. This allows me to apply the distributive property of multiplication over addition: $17 \\times 23 = 17 \\times (20 + 3)$. This rephrasing is crucial, as multiplying by multiples of ten is significantly simpler than direct multiplication with a two-digit number.\n\nFollowing this decomposition, I then distribute the 17 to each component of the sum: $(17 \\times 20) + (17 \\times 3)$. The first part, $17 \\times 20$, is easily calculated by recognizing that multiplying by 20 is equivalent to multiplying by 2 and then by 10. Thus, $17 \\times 2 = 34$, and appending the zero for the factor of 10 yields 340.\n\nThe second part of the expression, $17 \\times 3$, requires a direct multiplication of a two-digit number by a single digit. I mentally perform this as $(10 \\times 3) + (7 \\times 3)$, which equates to $30 + 21$, resulting in 51.\n\nFinally, I sum the results of these two sub-calculations: $340 + 51$. This addition is straightforward, yielding the final product of 391.\n\nCrucially, I recall the specific instruction to \"Reply with just the number.\" This constraint guides my final output, ensuring that only the numerical result is provided, devoid of any explanatory text or context that might accompany a more verbose response. Therefore, my final internal output, ready for rendering, is simply the number itself.\n\n",
+              "thought": true
+            },
+            {
+              "text": "391",
+              "thoughtSignature": "AY89a187wOFOb0hwERtO36u5JcZNAmVHCxmREfEQDFL7LZS8ncA8hV8C7z+pw9OezfYV1TqmgUjZM06urGkMmu3j0xVpYbtAtkIvDbmyubOBQHqQGl3QEho23RdrH1CROLjq4ZBNeWdlEPr/OBYxT1SrAsHHDVl3kCPM+zrRn7Ucg8M8FT1NuoZC5/JlmelXJLuB5VxcLOnGjdkbIhAr7XqjmicIPB8U8TQrbAatMAECYIZkq6b1wKK1rphS/uoyqsD+jvzY2mxiM6qcp1G1tQ+EcVXUbf81JiE96JEVQKVFAyUAB8rQtLkwge08X0xU1/AwMxaAqE8TAim6tNl1zqaTWoxvdJ4RhuiTCi3iYmOsZvz8Lug165VFJhzpWIO7mzaUTl7iewqlROG8DipSFUFD0JRP8T2qE6os+BYKD3ampFim2/HSEiHO8FwY9r1ya3eQbRYYDcDxoHau4ARFod6NmHvcncBVmV5+de1XN7/bIw8Fe4k3kXxJiXx/vcRyzpitkKwNA/uVGAm4JtGQ+D6iDyUK1hsRwkGwb5RjmZA/XqJCOlmctrPV4jWAQpSzrg=="
+            }
+          ]
+        },
+        "finishReason": "STOP"
+      }
+    ],
+    "usageMetadata": {
+      "promptTokenCount": 16,
+      "candidatesTokenCount": 3,
+      "totalTokenCount": 162,
+      "trafficType": "ON_DEMAND",
+      "promptTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 16
+        }
+      ],
+      "candidatesTokensDetails": [
+        {
+          "modality": "TEXT",
+          "tokenCount": 3
+        }
+      ],
+      "thoughtsTokenCount": 143
+    },
+    "modelVersion": "gemini-3.5-flash",
+    "createTime": "2026-08-22T12:53:13.235360Z",
+    "responseId": "uZuJauCuDqTLj8MPgpe7sQo"
+  }
+}

--- a/tests/integration/google/test_reasoning.py
+++ b/tests/integration/google/test_reasoning.py
@@ -14,6 +14,13 @@ _MODEL = "gemini-2.5-flash"
 _MAX_TOKENS = 2048  # leave room for the thinking budget (effort=low -> 1024) plus the answer
 _PROMPT = "What is 17 times 23? Reply with just the number."
 _CASSETTE = Path(__file__).parent.parent / "cassettes" / "google" / "vertex_reasoning.json"
+_CASSETTE_DIR = _CASSETTE.parent
+_MODEL_CASES = [
+    ("gemini-2.5-flash", _CASSETTE_DIR / "vertex_reasoning_2_5_flash_high.json"),
+    ("gemini-2.5-flash-lite", _CASSETTE_DIR / "vertex_reasoning_2_5_flash_lite_high.json"),
+    ("gemini-2.5-pro", _CASSETTE_DIR / "vertex_reasoning_2_5_pro_high.json"),
+    ("gemini-3.5-flash", _CASSETTE_DIR / "vertex_reasoning_3_5_flash_high.json"),
+]
 
 _RATES = {"input_rate": 0.30 / 1_000_000, "output_rate": 2.50 / 1_000_000}
 
@@ -41,3 +48,29 @@ def test_reasoning(
     # assert_cost bill the thinking tokens. (Live-safe: pins the invariant, not the exact thought count.)
     assert resp.usage.output_tokens > resp.usage.reasoning_tokens
     assert_cost(resp, **_RATES)
+
+
+@pytest.mark.verified
+@pytest.mark.parametrize(("model", "cassette"), _MODEL_CASES)
+def test_reasoning_effort_model_matrix(
+    model: str,
+    cassette: Path,
+    scenario: Callable[..., Any],
+    vertex_adc_provider: Callable[..., Any],
+    assert_chat: Callable[..., None],
+) -> None:
+    def _chat(auth: Any, transport: Any) -> ChatResponse:  # noqa: ANN401 — harness-supplied per mode
+        return vertex_adc_provider(auth, transport).chat(
+            model,
+            [UserMessage(content=_PROMPT)],
+            reasoning_effort="high",
+        )
+
+    resp = scenario(cassette, _chat, requires="GOOGLE_CLOUD_PROJECT")
+    assert_chat(resp, provider="google")
+    assert "391" in (resp.content or "")
+    assert resp.reasoning
+    assert resp.usage is not None
+    assert resp.usage.reasoning_tokens is not None
+    assert resp.usage.reasoning_tokens > 0
+    assert resp.usage.output_tokens > resp.usage.reasoning_tokens


### PR DESCRIPTION
`reasoning_effort` currently maps every Gemini model to the same numeric thinking budgets because the Google request builder does not receive the model ID. This sends an unsupported high budget to Gemini 2.5 Flash and Flash-Lite and does not use the generation-native `thinkingLevel` control for Gemini 3 and later.

This PR makes the mapping model-aware, using family-specific budgets for Gemini 2.5 and thinking levels for Gemini 3 and later. It continues requesting thought summaries, preserves explicit `thinking_config` values as verbatim overrides, rejects aliases that cannot be mapped safely, and adds unit and live integration coverage across both generations.

Closes #140
