### PR TITLE
fix: Resolve file-based Vertex ADC without Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,17 +139,17 @@ provider.register_pricing("my-fine-tune", ModelPricing(tiers=[
 
 ## Providers
 
-| Package                                              | Protocols                        | Auth                                                 |
-| ---------------------------------------------------- | -------------------------------- | ---------------------------------------------------- |
-| [lmux-openai](packages/lmux-openai)                  | Completion, Embedding, Responses | `OPENAI_API_KEY`                                     |
-| [lmux-anthropic](packages/lmux-anthropic)            | Completion                       | `ANTHROPIC_API_KEY`                                  |
-| [lmux-anthropic\[vertex\]](packages/lmux-anthropic)  | Completion                       | ADC, service account                                 |
-| [lmux-anthropic](packages/lmux-anthropic) (Foundry)  | Completion                       | `ANTHROPIC_FOUNDRY_API_KEY`, Entra ID token provider |
-| [lmux-anthropic\[bedrock\]](packages/lmux-anthropic) | Completion                       | boto3 credential chain, `AWS_BEARER_TOKEN_BEDROCK`   |
-| [lmux-azure-foundry](packages/lmux-azure-foundry)    | Completion, Embedding, Responses | `AZURE_FOUNDRY_API_KEY`, Azure AD, token provider    |
-| [lmux-aws-bedrock](packages/lmux-aws-bedrock)        | Completion, Embedding            | boto3 credential chain                               |
-| [lmux-google](packages/lmux-google)                  | Completion, Embedding            | ADC, service account, `GOOGLE_API_KEY`               |
-| [lmux-groq](packages/lmux-groq)                      | Completion                       | `GROQ_API_KEY`                                       |
+| Package                                              | Protocols                        | Auth                                                                        |
+| ---------------------------------------------------- | -------------------------------- | --------------------------------------------------------------------------- |
+| [lmux-openai](packages/lmux-openai)                  | Completion, Embedding, Responses | `OPENAI_API_KEY`                                                            |
+| [lmux-anthropic](packages/lmux-anthropic)            | Completion                       | `ANTHROPIC_API_KEY`                                                         |
+| [lmux-anthropic\[vertex\]](packages/lmux-anthropic)  | Completion                       | File ADC, metadata ADC with `[requests]`, service account                   |
+| [lmux-anthropic](packages/lmux-anthropic) (Foundry)  | Completion                       | `ANTHROPIC_FOUNDRY_API_KEY`, Entra ID token provider                        |
+| [lmux-anthropic\[bedrock\]](packages/lmux-anthropic) | Completion                       | boto3 credential chain, `AWS_BEARER_TOKEN_BEDROCK`                          |
+| [lmux-azure-foundry](packages/lmux-azure-foundry)    | Completion, Embedding, Responses | `AZURE_FOUNDRY_API_KEY`, Azure AD, token provider                           |
+| [lmux-aws-bedrock](packages/lmux-aws-bedrock)        | Completion, Embedding            | boto3 credential chain                                                      |
+| [lmux-google](packages/lmux-google)                  | Completion, Embedding            | File ADC, metadata ADC with `[requests]`, service account, `GOOGLE_API_KEY` |
+| [lmux-groq](packages/lmux-groq)                      | Completion                       | `GROQ_API_KEY`                                                              |
 
 ## Load balancing
 

--- a/packages/lmux-anthropic/README.md
+++ b/packages/lmux-anthropic/README.md
@@ -116,6 +116,10 @@ Requires the `vertex` extra, which pulls in `google-auth`:
 uv add "lmux-anthropic[vertex]"
 ```
 
+File-based ADC from `GOOGLE_APPLICATION_CREDENTIALS` or the `gcloud` CLI works with this extra. For ADC from an
+attached service account's instance metadata, install the requests transport with
+`uv add "lmux-anthropic[vertex,requests]"`.
+
 `AnthropicVertexProvider` serves Claude through GCP Vertex AI with the same chat/streaming interface:
 
 ```python

--- a/packages/lmux-anthropic/pyproject.toml
+++ b/packages/lmux-anthropic/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 
 [project.optional-dependencies]
 vertex = ["google-auth~=2.0"]
+requests = ["google-auth[requests]~=2.0"]
 bedrock = ["boto3>=1.42.31,<2", "lmux-bedrock-shared~=0.3"]
 
 [project.urls]

--- a/packages/lmux-anthropic/src/lmux_anthropic/auth.py
+++ b/packages/lmux-anthropic/src/lmux_anthropic/auth.py
@@ -1,6 +1,7 @@
 """Auth providers for the Anthropic API, Claude on Vertex AI, and Claude in Microsoft Foundry."""
 
 import os
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 
@@ -9,6 +10,45 @@ from lmux.exceptions import AuthenticationError
 if TYPE_CHECKING:
     import boto3
     from google.auth.credentials import Credentials
+
+
+def _load_vertex_adc_credentials(scopes: list[str]) -> "tuple[Credentials, str | None]":
+    try:
+        import google.auth  # noqa: PLC0415
+    except ImportError as e:
+        raise ImportError("[vertex] extra group is required for Vertex AI support") from e  # noqa: TRY003
+
+    from google.auth import _cloud_sdk, environment_vars  # noqa: PLC0415
+    from google.auth.credentials import with_scopes_if_required  # noqa: PLC0415
+
+    cloud_sdk_file = _cloud_sdk.get_application_default_credentials_path()
+    explicit_file = os.environ.get(environment_vars.CREDENTIALS)
+    credentials_file = explicit_file or cloud_sdk_file
+    if not os.path.isfile(credentials_file):
+        credentials, project_id = google.auth.default(scopes=scopes)
+        return cast("Credentials", credentials), project_id
+
+    from lmux_anthropic._lazy import HttpxTransportRequest  # noqa: PLC0415
+
+    request = HttpxTransportRequest()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        credentials, project_id = google.auth.load_credentials_from_file(credentials_file, request=request)
+    credentials = with_scopes_if_required(credentials, scopes)
+
+    if credentials_file == cloud_sdk_file and not project_id:
+        project_id = _cloud_sdk.get_project_id()
+
+    explicit_project_id = os.environ.get(
+        environment_vars.PROJECT,
+        os.environ.get(environment_vars.LEGACY_PROJECT),
+    )
+    effective_project_id = explicit_project_id or project_id
+    get_project_id = getattr(credentials, "get_project_id", None)
+    if not effective_project_id and callable(get_project_id):
+        effective_project_id = get_project_id(request=request)
+
+    return cast("Credentials", credentials), cast("str | None", effective_project_id)
 
 
 class AnthropicEnvAuthProvider:
@@ -28,8 +68,8 @@ class AnthropicEnvAuthProvider:
 class AnthropicVertexADCAuthProvider:
     """Default Vertex auth provider — uses Application Default Credentials.
 
-    Credentials are resolved by ``google.auth.default()`` which searches
-    environment variables, ``gcloud`` CLI defaults, and instance metadata.
+    File-based credentials use lmux's httpx auth transport. If no file exists,
+    ``google.auth.default()`` handles instance metadata and other environments.
     Returns the credentials together with the project ID that ADC resolved
     (which may be None). Requires the ``[vertex]`` extra.
     """
@@ -38,14 +78,7 @@ class AnthropicVertexADCAuthProvider:
         self._scopes: list[str] = scopes or ["https://www.googleapis.com/auth/cloud-platform"]
 
     def get_credentials(self) -> "tuple[Credentials, str | None]":
-        try:
-            import google.auth  # noqa: PLC0415
-        except ImportError as e:
-            raise ImportError("[vertex] extra group is required for Vertex AI support") from e  # noqa: TRY003
-
-        credentials, project_id = google.auth.default(scopes=self._scopes)
-        # google.auth has unresolvable string forward-ref annotations; cast is required
-        return cast("Credentials", credentials), project_id
+        return _load_vertex_adc_credentials(self._scopes)
 
     async def aget_credentials(self) -> "tuple[Credentials, str | None]":
         return self.get_credentials()

--- a/packages/lmux-anthropic/tests/test_auth.py
+++ b/packages/lmux-anthropic/tests/test_auth.py
@@ -1,6 +1,7 @@
 """Tests for Anthropic auth providers."""
 
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, sentinel
 
 import boto3
 import pytest
@@ -31,6 +32,37 @@ def mock_google_auth_default(mock_credentials: MagicMock, mocker: MockerFixture)
 
 
 @pytest.fixture
+def mock_load_credentials(mock_credentials: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch(
+        "google.auth.load_credentials_from_file",
+        return_value=(mock_credentials, "file-project"),
+    )
+
+
+@pytest.fixture
+def mock_with_scopes(mock_credentials: MagicMock, mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("google.auth.credentials.with_scopes_if_required", return_value=mock_credentials)
+
+
+@pytest.fixture
+def mock_cloud_sdk_path(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch(
+        "google.auth._cloud_sdk.get_application_default_credentials_path",
+        return_value="/missing/gcloud/application_default_credentials.json",
+    )
+
+
+@pytest.fixture
+def mock_cloud_sdk_project(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("google.auth._cloud_sdk.get_project_id", return_value="gcloud-project")
+
+
+@pytest.fixture
+def mock_transport_request(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("lmux_anthropic._lazy.HttpxTransportRequest", return_value=sentinel.request)
+
+
+@pytest.fixture
 def mock_from_service_account_file(mock_credentials: MagicMock, mocker: MockerFixture) -> MagicMock:
     mock_credentials.project_id = "sa-project"
     return mocker.patch(
@@ -47,6 +79,13 @@ def mock_missing_google_auth(mocker: MockerFixture) -> None:
 @pytest.fixture
 def mock_missing_google_oauth2(mocker: MockerFixture) -> None:
     mocker.patch.dict("sys.modules", {"google.oauth2": None})
+
+
+@pytest.fixture(autouse=True)
+def clear_adc_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.delenv("GCLOUD_PROJECT", raising=False)
 
 
 class TestAnthropicEnvAuthProvider:
@@ -69,20 +108,219 @@ class TestAnthropicEnvAuthProvider:
 
 
 class TestAnthropicVertexADCAuthProvider:
-    def test_get_credentials(self, mock_google_auth_default: MagicMock, mock_credentials: MagicMock) -> None:
+    def test_get_credentials_falls_back_to_default(
+        self,
+        mock_google_auth_default: MagicMock,
+        mock_credentials: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+    ) -> None:
         provider = AnthropicVertexADCAuthProvider()
         assert provider.get_credentials() == (mock_credentials, "test-project")
         mock_google_auth_default.assert_called_once_with(scopes=[CLOUD_PLATFORM_SCOPE])
+        mock_load_credentials.assert_not_called()
+        mock_cloud_sdk_path.assert_called_once_with()
 
-    def test_custom_scopes(self, mock_google_auth_default: MagicMock, mock_credentials: MagicMock) -> None:
+    def test_custom_scopes_for_default(
+        self,
+        mock_google_auth_default: MagicMock,
+        mock_credentials: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+    ) -> None:
         provider = AnthropicVertexADCAuthProvider(scopes=["https://www.googleapis.com/auth/custom"])
         assert provider.get_credentials() == (mock_credentials, "test-project")
         mock_google_auth_default.assert_called_once_with(scopes=["https://www.googleapis.com/auth/custom"])
+        mock_cloud_sdk_path.assert_called_once_with()
 
-    async def test_aget_credentials(self, mock_google_auth_default: MagicMock, mock_credentials: MagicMock) -> None:
+    async def test_aget_credentials_falls_back_to_default(
+        self,
+        mock_google_auth_default: MagicMock,
+        mock_credentials: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+    ) -> None:
         provider = AnthropicVertexADCAuthProvider()
         assert await provider.aget_credentials() == (mock_credentials, "test-project")
         mock_google_auth_default.assert_called_once_with(scopes=[CLOUD_PLATFORM_SCOPE])
+        mock_cloud_sdk_path.assert_called_once_with()
+
+    def test_explicit_adc_file_uses_httpx_request(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_credentials: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_cloud_sdk_project: MagicMock,
+        mock_transport_request: MagicMock,
+    ) -> None:
+        credentials_file = tmp_path / "adc.json"
+        credentials_file.touch()
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_file))
+
+        result = AnthropicVertexADCAuthProvider().get_credentials()
+
+        assert result == (mock_credentials, "file-project")
+        mock_load_credentials.assert_called_once_with(str(credentials_file), request=sentinel.request)
+        mock_with_scopes.assert_called_once_with(mock_credentials, [CLOUD_PLATFORM_SCOPE])
+        mock_transport_request.assert_called_once_with()
+        mock_google_auth_default.assert_not_called()
+        mock_cloud_sdk_path.assert_called_once_with()
+        mock_cloud_sdk_project.assert_not_called()
+
+    def test_gcloud_adc_file_preserves_project_resolution(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        mock_credentials: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_cloud_sdk_project: MagicMock,
+        mock_transport_request: MagicMock,
+    ) -> None:
+        credentials_file = tmp_path / "application_default_credentials.json"
+        credentials_file.touch()
+        mock_cloud_sdk_path.return_value = str(credentials_file)
+        mock_load_credentials.return_value = (mock_credentials, None)
+
+        result = AnthropicVertexADCAuthProvider().get_credentials()
+
+        assert result == (mock_credentials, "gcloud-project")
+        mock_load_credentials.assert_called_once_with(str(credentials_file), request=sentinel.request)
+        mock_with_scopes.assert_called_once_with(mock_credentials, [CLOUD_PLATFORM_SCOPE])
+        mock_cloud_sdk_project.assert_called_once_with()
+        mock_google_auth_default.assert_not_called()
+        mock_transport_request.assert_called_once_with()
+
+    def test_external_account_project_uses_httpx_request(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_credentials: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_cloud_sdk_project: MagicMock,
+        mock_transport_request: MagicMock,
+    ) -> None:
+        credentials_file = tmp_path / "external.json"
+        credentials_file.touch()
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_file))
+        scoped_credentials = MagicMock()
+        scoped_credentials.get_project_id.return_value = "workload-project"
+        mock_load_credentials.return_value = (mock_credentials, None)
+        mock_with_scopes.return_value = scoped_credentials
+
+        result = AnthropicVertexADCAuthProvider().get_credentials()
+
+        assert result == (scoped_credentials, "workload-project")
+        scoped_credentials.get_project_id.assert_called_once_with(request=sentinel.request)
+        mock_google_auth_default.assert_not_called()
+        mock_cloud_sdk_path.assert_called_once_with()
+        mock_cloud_sdk_project.assert_not_called()
+        mock_transport_request.assert_called_once_with()
+
+    def test_explicit_project_overrides_file_project(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_credentials: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_cloud_sdk_project: MagicMock,
+        mock_transport_request: MagicMock,
+    ) -> None:
+        credentials_file = tmp_path / "adc.json"
+        credentials_file.touch()
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_file))
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "explicit-project")
+
+        result = AnthropicVertexADCAuthProvider().get_credentials()
+
+        assert result == (mock_credentials, "explicit-project")
+        mock_load_credentials.assert_called_once_with(str(credentials_file), request=sentinel.request)
+        mock_with_scopes.assert_called_once_with(mock_credentials, [CLOUD_PLATFORM_SCOPE])
+        mock_credentials.get_project_id.assert_not_called()
+        mock_google_auth_default.assert_not_called()
+        mock_cloud_sdk_path.assert_called_once_with()
+        mock_cloud_sdk_project.assert_not_called()
+        mock_transport_request.assert_called_once_with()
+
+    def test_file_without_project_lookup_returns_none(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_cloud_sdk_project: MagicMock,
+        mock_transport_request: MagicMock,
+    ) -> None:
+        credentials_file = tmp_path / "adc.json"
+        credentials_file.touch()
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_file))
+        credentials = object()
+        mock_load_credentials.return_value = (credentials, None)
+        mock_with_scopes.return_value = credentials
+
+        result = AnthropicVertexADCAuthProvider().get_credentials()
+
+        assert result == (credentials, None)
+        mock_google_auth_default.assert_not_called()
+        mock_cloud_sdk_path.assert_called_once_with()
+        mock_cloud_sdk_project.assert_not_called()
+        mock_transport_request.assert_called_once_with()
+
+    def test_missing_explicit_file_preserves_default_fallback(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_credentials: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+    ) -> None:
+        gcloud_file = tmp_path / "application_default_credentials.json"
+        gcloud_file.touch()
+        mock_cloud_sdk_path.return_value = str(gcloud_file)
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(tmp_path / "missing.json"))
+
+        result = AnthropicVertexADCAuthProvider().get_credentials()
+
+        assert result == (mock_credentials, "test-project")
+        mock_google_auth_default.assert_called_once_with(scopes=[CLOUD_PLATFORM_SCOPE])
+        mock_load_credentials.assert_not_called()
+
+    def test_custom_scopes_for_file_credentials(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_credentials: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_transport_request: MagicMock,
+    ) -> None:
+        custom_scopes = ["https://www.googleapis.com/auth/custom"]
+        credentials_file = tmp_path / "adc.json"
+        credentials_file.touch()
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_file))
+
+        result = AnthropicVertexADCAuthProvider(scopes=custom_scopes).get_credentials()
+
+        assert result == (mock_credentials, "file-project")
+        mock_with_scopes.assert_called_once_with(mock_credentials, custom_scopes)
+        mock_google_auth_default.assert_not_called()
+        mock_load_credentials.assert_called_once_with(str(credentials_file), request=sentinel.request)
+        mock_cloud_sdk_path.assert_called_once_with()
+        mock_transport_request.assert_called_once_with()
 
     def test_get_raises_import_error_without_extra(self, mock_missing_google_auth: None) -> None:
         assert mock_missing_google_auth is None  # side-effect fixture: patches sys.modules

--- a/packages/lmux-google/README.md
+++ b/packages/lmux-google/README.md
@@ -15,7 +15,8 @@ Three authentication methods:
 
 ### Application Default Credentials (default)
 
-Uses `google.auth.default()`, which works with `GOOGLE_APPLICATION_CREDENTIALS`, `gcloud` CLI, or instance metadata.
+File-based ADC from `GOOGLE_APPLICATION_CREDENTIALS` or the `gcloud` CLI works with the base package. For ADC from
+an attached service account's instance metadata, install the requests transport with `uv add "lmux-google[requests]"`.
 
 ```python
 from lmux_google import GoogleProvider

--- a/packages/lmux-google/pyproject.toml
+++ b/packages/lmux-google/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
   "google-auth~=2.0",
 ]
 
+[project.optional-dependencies]
+requests = ["google-auth[requests]~=2.0"]
+
 [project.urls]
 Homepage = "https://github.com/cluebbehusen/lmux"
 Source = "https://github.com/cluebbehusen/lmux/tree/main/packages/lmux-google"

--- a/packages/lmux-google/src/lmux_google/auth.py
+++ b/packages/lmux-google/src/lmux_google/auth.py
@@ -3,8 +3,8 @@
 The simplest way to authenticate is to use Application Default Credentials (ADC)
 via ``GoogleADCAuthProvider`` (the default).  ADC searches for credentials in:
 
-1. ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable (path to a service
-   account JSON key file)
+1. ``GOOGLE_APPLICATION_CREDENTIALS`` environment variable (path to a Google
+   credential configuration file)
 2. ``gcloud auth application-default login`` cached credentials
 3. Compute Engine / Cloud Run / GKE metadata server
 
@@ -16,6 +16,7 @@ See: https://cloud.google.com/vertex-ai/generative-ai/docs/start/api-keys
 """
 
 import os
+import warnings
 from typing import TYPE_CHECKING, cast
 
 from lmux.exceptions import AuthenticationError
@@ -26,11 +27,33 @@ if TYPE_CHECKING:
 PROVIDER_NAME = "google"
 
 
+def _load_adc_credentials(scopes: list[str]) -> "Credentials":
+    import google.auth  # noqa: PLC0415
+    from google.auth import _cloud_sdk, environment_vars  # noqa: PLC0415
+    from google.auth.credentials import with_scopes_if_required  # noqa: PLC0415
+
+    cloud_sdk_file = _cloud_sdk.get_application_default_credentials_path()
+    explicit_file = os.environ.get(environment_vars.CREDENTIALS)
+    credentials_file = explicit_file or cloud_sdk_file
+    if not os.path.isfile(credentials_file):
+        credentials, _ = google.auth.default(scopes=scopes)
+        return cast("Credentials", credentials)
+
+    from lmux_google._lazy import HttpxAuthRequest  # noqa: PLC0415
+
+    request = HttpxAuthRequest()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        credentials, _ = google.auth.load_credentials_from_file(credentials_file, request=request)
+    credentials = with_scopes_if_required(credentials, scopes)
+    return cast("Credentials", credentials)
+
+
 class GoogleADCAuthProvider:
     """Default auth provider — uses Application Default Credentials.
 
-    Credentials are resolved by ``google.auth.default()`` which searches
-    environment variables, ``gcloud`` CLI defaults, and instance metadata.
+    File-based credentials use lmux's httpx auth transport. If no file exists,
+    ``google.auth.default()`` handles instance metadata and other environments.
 
     Scopes default to ``cloud-platform`` which is required for Vertex AI
     and for Workload Identity Federation impersonation flows.
@@ -40,15 +63,10 @@ class GoogleADCAuthProvider:
         self._scopes: list[str] = scopes or ["https://www.googleapis.com/auth/cloud-platform"]
 
     def get_credentials(self) -> "Credentials":
-        import google.auth  # noqa: PLC0415
-
-        # google.auth has unresolvable string forward-ref annotations; cast is required
-        return cast("Credentials", google.auth.default(scopes=self._scopes)[0])
+        return _load_adc_credentials(self._scopes)
 
     async def aget_credentials(self) -> "Credentials":
-        import google.auth  # noqa: PLC0415
-
-        return cast("Credentials", google.auth.default(scopes=self._scopes)[0])
+        return self.get_credentials()
 
 
 class GoogleServiceAccountAuthProvider:

--- a/packages/lmux-google/tests/test_auth.py
+++ b/packages/lmux-google/tests/test_auth.py
@@ -1,6 +1,7 @@
 """Tests for Google auth providers."""
 
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, sentinel
 
 import pytest
 from pytest_mock import MockerFixture
@@ -12,8 +13,16 @@ from lmux_google.auth import (
     GoogleServiceAccountAuthProvider,
 )
 
+CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+
 
 class TestGoogleADCAuthProvider:
+    @pytest.fixture(autouse=True)
+    def clear_adc_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("GCLOUD_PROJECT", raising=False)
+
     @pytest.fixture
     def mock_creds(self) -> MagicMock:
         return MagicMock()
@@ -22,26 +31,171 @@ class TestGoogleADCAuthProvider:
     def mock_google_auth_default(self, mock_creds: MagicMock, mocker: MockerFixture) -> MagicMock:
         return mocker.patch("google.auth.default", return_value=(mock_creds, "my-project"))
 
-    def test_get_credentials(self, mock_creds: MagicMock, mock_google_auth_default: MagicMock) -> None:
+    @pytest.fixture
+    def mock_load_credentials(self, mock_creds: MagicMock, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch("google.auth.load_credentials_from_file", return_value=(mock_creds, "file-project"))
+
+    @pytest.fixture
+    def mock_with_scopes(self, mock_creds: MagicMock, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch("google.auth.credentials.with_scopes_if_required", return_value=mock_creds)
+
+    @pytest.fixture
+    def mock_cloud_sdk_path(self, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch(
+            "google.auth._cloud_sdk.get_application_default_credentials_path",
+            return_value="/missing/gcloud/application_default_credentials.json",
+        )
+
+    @pytest.fixture
+    def mock_auth_request(self, mocker: MockerFixture) -> MagicMock:
+        return mocker.patch("lmux_google._lazy.HttpxAuthRequest", return_value=sentinel.request)
+
+    def test_get_credentials_falls_back_to_default(
+        self,
+        mock_creds: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+    ) -> None:
         provider = GoogleADCAuthProvider()
         result = provider.get_credentials()
 
         assert result is mock_creds
-        mock_google_auth_default.assert_called_once_with(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+        mock_google_auth_default.assert_called_once_with(scopes=[CLOUD_PLATFORM_SCOPE])
+        mock_load_credentials.assert_not_called()
+        mock_cloud_sdk_path.assert_called_once_with()
 
-    async def test_aget_credentials(self, mock_creds: MagicMock, mock_google_auth_default: MagicMock) -> None:
+    async def test_aget_credentials_falls_back_to_default(
+        self,
+        mock_creds: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+    ) -> None:
         provider = GoogleADCAuthProvider()
         result = await provider.aget_credentials()
 
         assert result is mock_creds
-        mock_google_auth_default.assert_called_once_with(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+        mock_google_auth_default.assert_called_once_with(scopes=[CLOUD_PLATFORM_SCOPE])
+        mock_cloud_sdk_path.assert_called_once_with()
 
-    def test_custom_scopes(self, mock_google_auth_default: MagicMock) -> None:
+    def test_explicit_adc_file_uses_httpx_request(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_creds: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_auth_request: MagicMock,
+    ) -> None:
+        credentials_file = tmp_path / "adc.json"
+        credentials_file.touch()
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_file))
+
+        result = GoogleADCAuthProvider().get_credentials()
+
+        assert result is mock_creds
+        mock_load_credentials.assert_called_once_with(str(credentials_file), request=sentinel.request)
+        mock_with_scopes.assert_called_once_with(mock_creds, [CLOUD_PLATFORM_SCOPE])
+        mock_auth_request.assert_called_once_with()
+        mock_google_auth_default.assert_not_called()
+        mock_cloud_sdk_path.assert_called_once_with()
+
+    def test_gcloud_adc_file_uses_httpx_request(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        mock_creds: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_auth_request: MagicMock,
+    ) -> None:
+        credentials_file = tmp_path / "application_default_credentials.json"
+        credentials_file.touch()
+        mock_cloud_sdk_path.return_value = str(credentials_file)
+        mock_load_credentials.return_value = (mock_creds, None)
+
+        result = GoogleADCAuthProvider().get_credentials()
+
+        assert result is mock_creds
+        mock_load_credentials.assert_called_once_with(str(credentials_file), request=sentinel.request)
+        mock_with_scopes.assert_called_once_with(mock_creds, [CLOUD_PLATFORM_SCOPE])
+        mock_google_auth_default.assert_not_called()
+        mock_auth_request.assert_called_once_with()
+
+    def test_external_account_does_not_resolve_unused_project(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_creds: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_auth_request: MagicMock,
+    ) -> None:
+        credentials_file = tmp_path / "external.json"
+        credentials_file.touch()
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_file))
+        scoped_credentials = MagicMock()
+        scoped_credentials.get_project_id.return_value = "workload-project"
+        mock_load_credentials.return_value = (mock_creds, None)
+        mock_with_scopes.return_value = scoped_credentials
+
+        result = GoogleADCAuthProvider().get_credentials()
+
+        assert result is scoped_credentials
+        scoped_credentials.get_project_id.assert_not_called()
+        mock_google_auth_default.assert_not_called()
+        mock_cloud_sdk_path.assert_called_once_with()
+        mock_auth_request.assert_called_once_with()
+
+    def test_missing_explicit_file_preserves_default_fallback(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_creds: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+    ) -> None:
+        gcloud_file = tmp_path / "application_default_credentials.json"
+        gcloud_file.touch()
+        mock_cloud_sdk_path.return_value = str(gcloud_file)
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(tmp_path / "missing.json"))
+
+        result = GoogleADCAuthProvider().get_credentials()
+
+        assert result is mock_creds
+        mock_google_auth_default.assert_called_once_with(scopes=[CLOUD_PLATFORM_SCOPE])
+        mock_load_credentials.assert_not_called()
+
+    def test_custom_scopes_for_file_credentials(  # noqa: PLR0913
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_creds: MagicMock,
+        mock_google_auth_default: MagicMock,
+        mock_load_credentials: MagicMock,
+        mock_with_scopes: MagicMock,
+        mock_cloud_sdk_path: MagicMock,
+        mock_auth_request: MagicMock,
+    ) -> None:
         custom_scopes = ["https://www.googleapis.com/auth/bigquery"]
-        provider = GoogleADCAuthProvider(scopes=custom_scopes)
-        _ = provider.get_credentials()
+        credentials_file = tmp_path / "adc.json"
+        credentials_file.touch()
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials_file))
 
-        mock_google_auth_default.assert_called_once_with(scopes=custom_scopes)
+        result = GoogleADCAuthProvider(scopes=custom_scopes).get_credentials()
+
+        assert result is mock_creds
+        mock_with_scopes.assert_called_once_with(mock_creds, custom_scopes)
+        mock_google_auth_default.assert_not_called()
+        mock_load_credentials.assert_called_once_with(str(credentials_file), request=sentinel.request)
+        mock_cloud_sdk_path.assert_called_once_with()
+        mock_auth_request.assert_called_once_with()
 
 
 class TestGoogleServiceAccountAuthProvider:

--- a/uv.lock
+++ b/uv.lock
@@ -595,6 +595,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
 ]
 
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
 [[package]]
 name = "h11"
 version = "0.16.0"
@@ -684,6 +689,9 @@ bedrock = [
     { name = "boto3" },
     { name = "lmux-bedrock-shared" },
 ]
+requests = [
+    { name = "google-auth", extra = ["requests"] },
+]
 vertex = [
     { name = "google-auth" },
 ]
@@ -692,11 +700,12 @@ vertex = [
 requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.42.31,<2" },
     { name = "google-auth", marker = "extra == 'vertex'", specifier = "~=2.0" },
+    { name = "google-auth", extras = ["requests"], marker = "extra == 'requests'", specifier = "~=2.0" },
     { name = "httpx", specifier = "~=0.28" },
     { name = "lmux", editable = "packages/lmux" },
     { name = "lmux-bedrock-shared", marker = "extra == 'bedrock'", editable = "packages/lmux-bedrock-shared" },
 ]
-provides-extras = ["vertex", "bedrock"]
+provides-extras = ["vertex", "requests", "bedrock"]
 
 [[package]]
 name = "lmux-aws-bedrock"
@@ -782,12 +791,19 @@ dependencies = [
     { name = "lmux" },
 ]
 
+[package.optional-dependencies]
+requests = [
+    { name = "google-auth", extra = ["requests"] },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "google-auth", specifier = "~=2.0" },
+    { name = "google-auth", extras = ["requests"], marker = "extra == 'requests'", specifier = "~=2.0" },
     { name = "httpx", specifier = "~=0.28" },
     { name = "lmux", editable = "packages/lmux" },
 ]
+provides-extras = ["requests"]
 
 [[package]]
 name = "lmux-groq"


### PR DESCRIPTION
`lmux-google` and `lmux-anthropic[vertex]` currently delegate all ADC discovery to `google.auth.default()`. Parts of that discovery path import the Requests transport, so file-based ADC can fail when `requests` is not otherwise present in the dependency closure, even though both providers already use HTTPX to refresh credentials.

This PR resolves explicit and gcloud well-known credential files directly with `load_credentials_from_file()` and `HttpxAuthRequest`, keeping file-based ADC independent of Requests for both sync and async paths. It retains `google.auth.default()` for metadata-based discovery and adds optional `requests` extras for consumers that need that fallback. It also updates authentication documentation and coverage across both provider packages.

Closes #141
